### PR TITLE
Replace deprecated __has_trivial_* with std::is_trivally_*

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -31,11 +31,12 @@
 #ifndef COWDATA_H_
 #define COWDATA_H_
 
-#include <string.h>
-
 #include "core/error_macros.h"
 #include "core/os/memory.h"
 #include "core/safe_refcount.h"
+
+#include <string.h>
+#include <type_traits>
 
 template <class T>
 class Vector;
@@ -202,7 +203,7 @@ void CowData<T>::_unref(void *p_data) {
 	}
 	// clean up
 
-	if (!__has_trivial_destructor(T)) {
+	if (!std::is_trivially_destructible<T>::value) {
 		uint32_t *count = _get_size();
 		T *data = (T *)(count + 1);
 
@@ -237,7 +238,7 @@ uint32_t CowData<T>::_copy_on_write() {
 		T *_data = (T *)(mem_new);
 
 		// initialize new elements
-		if (__has_trivial_copy(T)) {
+		if (std::is_trivially_copyable<T>::value) {
 			memcpy(mem_new, _ptr, current_size * sizeof(T));
 
 		} else {
@@ -300,7 +301,7 @@ Error CowData<T>::resize(int p_size) {
 
 		// construct the newly created elements
 
-		if (!__has_trivial_constructor(T)) {
+		if (!std::is_trivially_constructible<T>::value) {
 			T *elems = _get_data();
 
 			for (int i = *_get_size(); i < p_size; i++) {
@@ -311,7 +312,7 @@ Error CowData<T>::resize(int p_size) {
 		*_get_size() = p_size;
 
 	} else if (p_size < current_size) {
-		if (!__has_trivial_destructor(T)) {
+		if (!std::is_trivially_destructible<T>::value) {
 			// deinitialize no longer needed elements
 			for (uint32_t i = p_size; i < *_get_size(); i++) {
 				T *t = &_get_data()[i];

--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -36,6 +36,8 @@
 #include "core/sort_array.h"
 #include "core/vector.h"
 
+#include <type_traits>
+
 template <class T, class U = uint32_t, bool force_trivial = false>
 class LocalVector {
 private:
@@ -63,7 +65,7 @@ public:
 			CRASH_COND_MSG(!data, "Out of memory");
 		}
 
-		if (!__has_trivial_constructor(T) && !force_trivial) {
+		if (!std::is_trivially_constructible<T>::value && !force_trivial) {
 			memnew_placement(&data[count++], T(p_elem));
 		} else {
 			data[count++] = p_elem;
@@ -76,7 +78,7 @@ public:
 		for (U i = p_index; i < count; i++) {
 			data[i] = data[i + 1];
 		}
-		if (!__has_trivial_destructor(T) && !force_trivial) {
+		if (!std::is_trivially_destructible<T>::value && !force_trivial) {
 			data[count].~T();
 		}
 	}
@@ -89,7 +91,7 @@ public:
 		if (count > p_index) {
 			data[p_index] = data[count];
 		}
-		if (!__has_trivial_destructor(T) && !force_trivial) {
+		if (!std::is_trivially_destructible<T>::value && !force_trivial) {
 			data[count].~T();
 		}
 	}
@@ -129,7 +131,7 @@ public:
 	_FORCE_INLINE_ U size() const { return count; }
 	void resize(U p_size) {
 		if (p_size < count) {
-			if (!__has_trivial_destructor(T) && !force_trivial) {
+			if (!std::is_trivially_destructible<T>::value && !force_trivial) {
 				for (U i = p_size; i < count; i++) {
 					data[i].~T();
 				}
@@ -146,7 +148,7 @@ public:
 				data = (T *)memrealloc(data, capacity * sizeof(T));
 				CRASH_COND_MSG(!data, "Out of memory");
 			}
-			if (!__has_trivial_constructor(T) && !force_trivial) {
+			if (!std::is_trivially_constructible<T>::value && !force_trivial) {
 				for (U i = count; i < p_size; i++) {
 					memnew_placement(&data[i], T);
 				}

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -35,6 +35,7 @@
 #include "core/safe_refcount.h"
 
 #include <stddef.h>
+#include <type_traits>
 
 #ifndef PAD_ALIGN
 #define PAD_ALIGN 16 //must always be greater than this at much
@@ -111,7 +112,7 @@ void memdelete(T *p_class) {
 	if (!predelete_handler(p_class)) {
 		return; // doesn't want to be deleted
 	}
-	if (!__has_trivial_destructor(T)) {
+	if (!std::is_trivially_destructible<T>::value) {
 		p_class->~T();
 	}
 
@@ -123,7 +124,7 @@ void memdelete_allocator(T *p_class) {
 	if (!predelete_handler(p_class)) {
 		return; // doesn't want to be deleted
 	}
-	if (!__has_trivial_destructor(T)) {
+	if (!std::is_trivially_destructible<T>::value) {
 		p_class->~T();
 	}
 
@@ -152,7 +153,7 @@ T *memnew_arr_template(size_t p_elements, const char *p_descr = "") {
 	ERR_FAIL_COND_V(!mem, failptr);
 	*(mem - 1) = p_elements;
 
-	if (!__has_trivial_constructor(T)) {
+	if (!std::is_trivially_constructible<T>::value) {
 		T *elems = (T *)mem;
 
 		/* call operator new */
@@ -179,7 +180,7 @@ template <typename T>
 void memdelete_arr(T *p_class) {
 	uint64_t *ptr = (uint64_t *)p_class;
 
-	if (!__has_trivial_destructor(T)) {
+	if (!std::is_trivially_destructible<T>::value) {
 		uint64_t elem_count = *(ptr - 1);
 
 		for (uint64_t i = 0; i < elem_count; i++) {


### PR DESCRIPTION
Clang 15 now produces warnings for some deprecated built-in `__has_*` methods: https://github.com/llvm/llvm-project/commit/0b89d1d59f82cf5b45c250cd5c3351e43ce35ef9
This PR replaces them with the recommended methods:
- `__has_trivial_constructor(T)` -> `std::is_trivially_constructible<T>::value`
- `__has_trivial_destructor(T)` -> `std::is_trivially_destructible<T>::value`
- `__has_trivial_copy(T)` -> `std::is_trivially_copyable<T>::value`