### PR TITLE
Fix methods with array parameters with mismatched bounds

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -1059,7 +1059,7 @@ InputDefault::JoyEvent InputDefault::_get_mapped_axis_event(const JoyDeviceMappi
 	return event;
 }
 
-void InputDefault::_get_mapped_hat_events(const JoyDeviceMapping &mapping, int p_hat, JoyEvent r_events[]) {
+void InputDefault::_get_mapped_hat_events(const JoyDeviceMapping &mapping, int p_hat, JoyEvent r_events[HAT_MAX]) {
 	for (int i = 0; i < mapping.bindings.size(); i++) {
 		const JoyBinding binding = mapping.bindings[i];
 		if (binding.inputType == TYPE_HAT && binding.input.hat.hat == p_hat) {

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -729,7 +729,7 @@ void CSGBrushOperation::MeshMerge::mark_inside_faces() {
 	}
 }
 
-void CSGBrushOperation::MeshMerge::add_face(const Vector3 p_points[], const Vector2 p_uvs[], bool p_smooth, bool p_invert, const Ref<Material> &p_material, bool p_from_b) {
+void CSGBrushOperation::MeshMerge::add_face(const Vector3 p_points[3], const Vector2 p_uvs[3], bool p_smooth, bool p_invert, const Ref<Material> &p_material, bool p_from_b) {
 	int indices[3];
 	for (int i = 0; i < 3; i++) {
 		VertexKey vk;


### PR DESCRIPTION
When a function or method is declared with a bounded array as a parameter, the compiler will check that the argument passed, when that function or method is called, has a sufficient size or attempts to access more than the maximum number of elements.
This PR fixes array parameter bounds mismatches between the method declarations and the definitions.