### PR TITLE
Fix store to null pointer error in Image.fill()

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2455,6 +2455,7 @@ void Image::blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, c
 }
 
 void Image::fill(const Color &c) {
+	ERR_FAIL_COND(data.size() == 0);
 	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot fill in compressed or custom image formats.");
 
 	lock();


### PR DESCRIPTION
Currently, `Image::fill()` attempts to set the first pixel (0, 0) even when there is no data:
https://github.com/RebelToolbox/RebelEngine/blob/84921e316caf6aff1be81a489fb02e023cd0e65d/core/image.cpp#L2468
This PR triggers a `ERR_FAIL_COND` error if an attempt is made to fill an image that has no data. 