### PR TITLE
Fix read from unknown address in Image::get_pixel

### DIFF
--- a/core/image.h
+++ b/core/image.h
@@ -168,6 +168,9 @@ private:
 		create(p_width, p_height, p_use_mipmaps, p_format, p_data);
 	}
 
+	Color _get_pixel(uint8_t *ptr, int p_x, int p_y) const;
+	void _set_pixel(uint8_t *ptr, int p_x, int p_y, const Color &p_color);
+
 	Format format;
 	PoolVector<uint8_t> data;
 	int width, height;


### PR DESCRIPTION
Currently calls to `Image::get_pixel()` and `Image::set_pixel()` only perform validity checks when debug is enabled. The checks performed are:
- Has the `Image` been locked?
- Has the Image been initialised (performed when locking the image)?
- Are the `x` and `y` parameters within the image dimensions?

This is presumably done for performance reasons, but it can result in reads and writes from and to invalid memory addresses when running a released game.

This PR separates internal and external calls to `Image::get_pixel()` and `Image::set_pixel()`. Validity checks are always performed when external calls are made to `Image::get_pixel()` and `Image::set_pixel()`. Validity checks are not performed when internal calls are made to `Image::get_pixel()` and `Image::set_pixel()`. Validity checks are not desired on internal calls, because they are made during nested loop calls, and validity checks are not required on internal calls, because validity checks will have already been performed outside of the nested loops.