### PR TITLE
Fix segmentation fault when converting RGBE images to SRGB

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -3022,8 +3022,8 @@ Ref<Image> Image::rgbe_to_srgb() {
 
 	lock();
 	new_image->lock();
-	uint8_t *dst_ptr = write_lock.ptr();
-	uint8_t *src_ptr = new_image->write_lock.ptr();
+	uint8_t *src_ptr = write_lock.ptr();
+	uint8_t *dst_ptr = new_image->write_lock.ptr();
 	for (int row = 0; row < height; row++) {
 		for (int col = 0; col < width; col++) {
 			new_image->_set_pixel(dst_ptr, col, row, _get_pixel(src_ptr, col, row).to_srgb());


### PR DESCRIPTION
#12 introduced a bug that causes the engine to crash when converting RGBE images to SRGB.

This PR corrects the inverted mapping between the source and destination arrays.