### PR TITLE
Fix requirement for -mstackrealign comment in Android x86

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -183,7 +183,8 @@ def configure(env):
 
     env["neon_enabled"] = False
     if env["android_arch"] == "x86":
-        # The NDK adds this if targeting API < 24, so we can drop it when Rebel targets it at least
+        # For x86 targets prior to Android Nougat (API 24),
+        # -mstackrealign is needed to properly align stacks for global constructors.
         env.Append(CCFLAGS=["-mstackrealign"])
     elif env["android_arch"] == "armv7":
         env.Append(CCFLAGS="-march=armv7-a -mfloat-abi=softfp".split())


### PR DESCRIPTION
Updates the explanation for including `-mstackrealign` flag on Android x86 builds. It is needed, not added!

As explained in the [Build System Maintainers Guide](https://android.googlesource.com/platform/ndk/+/ndk-release-r23/docs/BuildSystemMaintainers.md#additional-required-arguments), `-mstackrealign` is needed on x86 targets prior to Android Nougat (API 24), because of android/ndk#635.