### PR TITLE
Apply standard Black Python code style

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -118,28 +118,67 @@ opts = Variables(customs, ARGUMENTS)
 opts.Add("p", "Platform (alias for 'platform')", "")
 opts.Add("platform", "Target platform (%s)" % ("|".join(platform_list),), "")
 opts.Add(BoolVariable("tools", "Build the tools (a.k.a. the Rebel editor)", True))
-opts.Add(EnumVariable("target", "Compilation target", "debug", ("debug", "release_debug", "release")))
+opts.Add(
+    EnumVariable(
+        "target", "Compilation target", "debug", ("debug", "release_debug", "release")
+    )
+)
 opts.Add("arch", "Platform-dependent architecture (arm/arm64/x86/x64/mips/...)", "")
-opts.Add(EnumVariable("bits", "Target platform bits", "default", ("default", "32", "64")))
-opts.Add(EnumVariable("optimize", "Optimization type", "speed", ("speed", "size", "none")))
-opts.Add(BoolVariable("production", "Set defaults to build Rebel for use in production", False))
+opts.Add(
+    EnumVariable("bits", "Target platform bits", "default", ("default", "32", "64"))
+)
+opts.Add(
+    EnumVariable("optimize", "Optimization type", "speed", ("speed", "size", "none"))
+)
+opts.Add(
+    BoolVariable(
+        "production", "Set defaults to build Rebel for use in production", False
+    )
+)
 opts.Add(BoolVariable("use_lto", "Use link-time optimization", False))
 
 # Components
 opts.Add(BoolVariable("deprecated", "Enable deprecated features", True))
 opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", True))
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
-opts.Add("custom_modules", "A list of comma-separated directory paths containing custom modules to build.", "")
-opts.Add(BoolVariable("custom_modules_recursive", "Detect custom modules recursively for each specified path.", True))
+opts.Add(
+    "custom_modules",
+    "A list of comma-separated directory paths containing custom modules to build.",
+    "",
+)
+opts.Add(
+    BoolVariable(
+        "custom_modules_recursive",
+        "Detect custom modules recursively for each specified path.",
+        True,
+    )
+)
 
 # Advanced options
-opts.Add(BoolVariable("dev", "If yes, alias for verbose=yes warnings=extra werror=yes", False))
-opts.Add(BoolVariable("fast_unsafe", "Enable unsafe options for faster rebuilds", False))
+opts.Add(
+    BoolVariable(
+        "dev", "If yes, alias for verbose=yes warnings=extra werror=yes", False
+    )
+)
+opts.Add(
+    BoolVariable("fast_unsafe", "Enable unsafe options for faster rebuilds", False)
+)
 opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))
 opts.Add(BoolVariable("progress", "Show a progress indicator during compilation", True))
-opts.Add(EnumVariable("warnings", "Level of compilation warnings", "all", ("extra", "all", "moderate", "no")))
+opts.Add(
+    EnumVariable(
+        "warnings",
+        "Level of compilation warnings",
+        "all",
+        ("extra", "all", "moderate", "no"),
+    )
+)
 opts.Add(BoolVariable("werror", "Treat compiler warnings as errors", False))
-opts.Add("extra_suffix", "Custom extra suffix added to the base filename of all generated binary files", "")
+opts.Add(
+    "extra_suffix",
+    "Custom extra suffix added to the base filename of all generated binary files",
+    "",
+)
 opts.Add(BoolVariable("vsproj", "Generate a Visual Studio solution", False))
 opts.Add(
     BoolVariable(
@@ -149,14 +188,34 @@ opts.Add(
     )
 )
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
-opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
-opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
-opts.Add("system_certs_path", "Use this path as SSL certificates default for editor (for package maintainers)", "")
-opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
+opts.Add(
+    BoolVariable(
+        "disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False
+    )
+)
+opts.Add(
+    BoolVariable(
+        "no_editor_splash", "Don't use the custom splash screen for the editor", True
+    )
+)
+opts.Add(
+    "system_certs_path",
+    "Use this path as SSL certificates default for editor (for package maintainers)",
+    "",
+)
+opts.Add(
+    BoolVariable(
+        "use_precise_math_checks",
+        "Math checks use very precise epsilon (debug option)",
+        False,
+    )
+)
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_bullet", "Use the built-in Bullet library", True))
-opts.Add(BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True))
+opts.Add(
+    BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True)
+)
 opts.Add(BoolVariable("builtin_embree", "Use the built-in Embree library", True))
 opts.Add(BoolVariable("builtin_enet", "Use the built-in ENet library", True))
 opts.Add(BoolVariable("builtin_freetype", "Use the built-in FreeType library", True))
@@ -171,7 +230,13 @@ opts.Add(BoolVariable("builtin_mbedtls", "Use the built-in mbedTLS library", Tru
 opts.Add(BoolVariable("builtin_miniupnpc", "Use the built-in miniupnpc library", True))
 opts.Add(BoolVariable("builtin_opus", "Use the built-in Opus library", True))
 opts.Add(BoolVariable("builtin_pcre2", "Use the built-in PCRE2 library", True))
-opts.Add(BoolVariable("builtin_pcre2_with_jit", "Use JIT compiler for the built-in PCRE2 library", True))
+opts.Add(
+    BoolVariable(
+        "builtin_pcre2_with_jit",
+        "Use JIT compiler for the built-in PCRE2 library",
+        True,
+    )
+)
 opts.Add(BoolVariable("builtin_recast", "Use the built-in Recast library", True))
 opts.Add(BoolVariable("builtin_squish", "Use the built-in squish library", True))
 opts.Add(BoolVariable("builtin_xatlas", "Use the built-in xatlas library", True))
@@ -236,7 +301,9 @@ if selected_platform in platform_opts:
 
 # Update the environment to take platform-specific options into account.
 opts.Update(env_base)
-env_base["platform"] = selected_platform  # Must always be re-set after calling opts.Update().
+env_base[
+    "platform"
+] = selected_platform  # Must always be re-set after calling opts.Update().
 
 # Detect modules.
 modules_detected = OrderedDict()
@@ -279,13 +346,19 @@ for name, path in modules_detected.items():
         pass
     sys.path.remove(path)
     sys.modules.pop("config")
-    opts.Add(BoolVariable("module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled))
+    opts.Add(
+        BoolVariable(
+            "module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled
+        )
+    )
 
 methods.write_modules(modules_detected)
 
 # Update the environment again after all the module options are added.
 opts.Update(env_base)
-env_base["platform"] = selected_platform  # Must always be re-set after calling opts.Update().
+env_base[
+    "platform"
+] = selected_platform  # Must always be re-set after calling opts.Update().
 Help(opts.GenerateHelpText(env_base))
 
 # add default include paths
@@ -422,7 +495,13 @@ if selected_platform in platform_list:
     # Configure compiler warnings
     if env.msvc:  # MSVC
         # Truncations, narrowing conversions, signed/unsigned comparisons...
-        disable_nonessential_warnings = ["/wd4267", "/wd4244", "/wd4305", "/wd4018", "/wd4800"]
+        disable_nonessential_warnings = [
+            "/wd4267",
+            "/wd4244",
+            "/wd4305",
+            "/wd4018",
+            "/wd4800",
+        ]
         if env["warnings"] == "extra":
             env.Append(CCFLAGS=["/Wall"])  # Implies /W4
         elif env["warnings"] == "all":
@@ -453,7 +532,10 @@ if selected_platform in platform_list:
         if env["warnings"] == "extra":
             # Note: enable -Wimplicit-fallthrough for Clang (already part of -Wextra for GCC)
             # once we switch to C++11 or later (necessary for our FALLTHROUGH macro).
-            env.Append(CCFLAGS=["-Wall", "-Wextra", "-Wwrite-strings", "-Wno-unused-parameter"] + common_warnings)
+            env.Append(
+                CCFLAGS=["-Wall", "-Wextra", "-Wwrite-strings", "-Wno-unused-parameter"]
+                + common_warnings
+            )
             env.Append(CXXFLAGS=["-Wctor-dtor-privacy", "-Wnon-virtual-dtor"])
             if methods.using_gcc(env):
                 env.Append(
@@ -477,7 +559,9 @@ if selected_platform in platform_list:
 
         if env["werror"]:
             env.Append(CCFLAGS=["-Werror"])
-            if methods.using_gcc(env) and version[0] >= 12:  # False positives in our error macros, see GH-58747.
+            if (
+                methods.using_gcc(env) and version[0] >= 12
+            ):  # False positives in our error macros, see GH-58747.
                 env.Append(CCFLAGS=["-Wno-error=return-type"])
 
     if hasattr(detect, "get_program_suffix"):
@@ -609,7 +693,9 @@ if selected_platform in platform_list:
         if not env["module_" + x + "_enabled"]:
             if env["tools"]:
                 print(
-                    "Build option 'module_" + x + "_enabled=no' cannot be used with 'tools=yes' (editor), "
+                    "Build option 'module_"
+                    + x
+                    + "_enabled=no' cannot be used with 'tools=yes' (editor), "
                     "only with 'tools=no' (export template)."
                 )
                 sys.exit(255)
@@ -621,14 +707,18 @@ if selected_platform in platform_list:
         env.Append(
             BUILDERS={
                 "GLES3_GLSL": env.Builder(
-                    action=run_in_subprocess(gles_builders.build_gles3_headers), suffix="glsl.gen.h", src_suffix=".glsl"
+                    action=run_in_subprocess(gles_builders.build_gles3_headers),
+                    suffix="glsl.gen.h",
+                    src_suffix=".glsl",
                 )
             }
         )
         env.Append(
             BUILDERS={
                 "GLES2_GLSL": env.Builder(
-                    action=run_in_subprocess(gles_builders.build_gles2_headers), suffix="glsl.gen.h", src_suffix=".glsl"
+                    action=run_in_subprocess(gles_builders.build_gles2_headers),
+                    suffix="glsl.gen.h",
+                    src_suffix=".glsl",
                 )
             }
         )
@@ -661,7 +751,9 @@ if selected_platform in platform_list:
     # Microsoft Visual Studio Project Generation
     if env["vsproj"]:
         if os.name != "nt":
-            print("Error: The `vsproj` option is only usable on Windows with Visual Studio.")
+            print(
+                "Error: The `vsproj` option is only usable on Windows with Visual Studio."
+            )
             Exit(255)
         env["CPPPATH"] = [Dir(path) for path in env["CPPPATH"]]
         methods.generate_vs_project(env, GetOption("num_jobs"))
@@ -703,7 +795,11 @@ if "env" in locals():
 def print_elapsed_time():
     elapsed_time_sec = round(time.time() - time_at_start, 3)
     time_ms = round((elapsed_time_sec % 1) * 1000)
-    print("[Time elapsed: {}.{:03}]".format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time_sec)), time_ms))
+    print(
+        "[Time elapsed: {}.{:03}]".format(
+            time.strftime("%H:%M:%S", time.gmtime(elapsed_time_sec)), time_ms
+        )
+    )
 
 
 atexit.register(print_elapsed_time)

--- a/core/SCsub
+++ b/core/SCsub
@@ -30,7 +30,11 @@ if "SCRIPT_AES256_ENCRYPTION_KEY" in os.environ:
                 ec_valid = False
             txt += txts
     if not ec_valid:
-        print("Error: Invalid AES256 encryption key, not 64 hexadecimal characters: '" + key + "'.")
+        print(
+            "Error: Invalid AES256 encryption key, not 64 hexadecimal characters: '"
+            + key
+            + "'."
+        )
         print(
             "Unset 'SCRIPT_AES256_ENCRYPTION_KEY' in your environment "
             "or make sure that it contains exactly 64 hexadecimal characters."
@@ -39,7 +43,11 @@ if "SCRIPT_AES256_ENCRYPTION_KEY" in os.environ:
 
 # NOTE: It is safe to generate this file here, since this is still executed serially
 with open("script_encryption_key.gen.cpp", "w") as f:
-    f.write('#include "core/project_settings.h"\nuint8_t script_encryption_key[32]={' + txt + "};\n")
+    f.write(
+        '#include "core/project_settings.h"\nuint8_t script_encryption_key[32]={'
+        + txt
+        + "};\n"
+    )
 
 
 # Add required thirdparty code.
@@ -62,7 +70,9 @@ thirdparty_misc_sources = [
     "triangulator.cpp",
     "clipper.cpp",
 ]
-thirdparty_misc_sources = [thirdparty_misc_dir + file for file in thirdparty_misc_sources]
+thirdparty_misc_sources = [
+    thirdparty_misc_dir + file for file in thirdparty_misc_sources
+]
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_misc_sources)
 
 # Zlib library, can be unbundled
@@ -81,7 +91,9 @@ if env["builtin_zlib"]:
         "uncompr.c",
         "zutil.c",
     ]
-    thirdparty_zlib_sources = [thirdparty_zlib_dir + file for file in thirdparty_zlib_sources]
+    thirdparty_zlib_sources = [
+        thirdparty_zlib_dir + file for file in thirdparty_zlib_sources
+    ]
 
     env_thirdparty.Prepend(CPPPATH=[thirdparty_zlib_dir])
     # Needs to be available in main env too
@@ -99,7 +111,9 @@ thirdparty_minizip_sources = [
     "unzip.c",
     "zip.c",
 ]
-thirdparty_minizip_sources = [thirdparty_minizip_dir + file for file in thirdparty_minizip_sources]
+thirdparty_minizip_sources = [
+    thirdparty_minizip_dir + file for file in thirdparty_minizip_sources
+]
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_minizip_sources)
 
 # Zstd library, can be unbundled in theory
@@ -134,9 +148,13 @@ if env["builtin_zstd"]:
         "decompress/zstd_decompress_block.c",
         "decompress/zstd_decompress.c",
     ]
-    thirdparty_zstd_sources = [thirdparty_zstd_dir + file for file in thirdparty_zstd_sources]
+    thirdparty_zstd_sources = [
+        thirdparty_zstd_dir + file for file in thirdparty_zstd_sources
+    ]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_zstd_dir, thirdparty_zstd_dir + "common"])
+    env_thirdparty.Prepend(
+        CPPPATH=[thirdparty_zstd_dir, thirdparty_zstd_dir + "common"]
+    )
     env_thirdparty.Append(CPPDEFINES=["ZSTD_STATIC_LINKING_ONLY"])
     env.Prepend(CPPPATH=thirdparty_zstd_dir)
     # Also needed in main env includes will trigger warnings
@@ -156,7 +174,11 @@ env.add_source_files(env.core_sources, "script_encryption_key.gen.cpp")
 # Certificates
 env.Depends(
     "#core/io/certs_compressed.gen.h",
-    ["#thirdparty/certs/ca-certificates.crt", env.Value(env["builtin_certs"]), env.Value(env["system_certs_path"])],
+    [
+        "#thirdparty/certs/ca-certificates.crt",
+        env.Value(env["builtin_certs"]),
+        env.Value(env["system_certs_path"]),
+    ],
 )
 env.CommandNoCache(
     "#core/io/certs_compressed.gen.h",
@@ -173,16 +195,26 @@ env.CommandNoCache(
 
 # Authors
 env.Depends("#core/authors.gen.h", "../AUTHORS.md")
-env.CommandNoCache("#core/authors.gen.h", "../AUTHORS.md", run_in_subprocess(core_builders.make_authors_header))
+env.CommandNoCache(
+    "#core/authors.gen.h",
+    "../AUTHORS.md",
+    run_in_subprocess(core_builders.make_authors_header),
+)
 
 # Donors
 env.Depends("#core/donors.gen.h", "../DONORS.md")
-env.CommandNoCache("#core/donors.gen.h", "../DONORS.md", run_in_subprocess(core_builders.make_donors_header))
+env.CommandNoCache(
+    "#core/donors.gen.h",
+    "../DONORS.md",
+    run_in_subprocess(core_builders.make_donors_header),
+)
 
 # License
 env.Depends("#core/license.gen.h", ["../copyright", "../LICENSE"])
 env.CommandNoCache(
-    "#core/license.gen.h", ["../copyright", "../LICENSE"], run_in_subprocess(core_builders.make_license_header)
+    "#core/license.gen.h",
+    ["../copyright", "../LICENSE"],
+    run_in_subprocess(core_builders.make_license_header),
 )
 
 # Chain load SCsubs

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -29,7 +29,9 @@ def make_certs_header(target, source, env):
         # Defined here and not in env so changing it does not trigger a full rebuild.
         g.write("#define BUILTIN_CERTS_ENABLED\n")
         g.write("static const int _certs_compressed_size = " + str(len(buf)) + ";\n")
-        g.write("static const int _certs_uncompressed_size = " + str(decomp_size) + ";\n")
+        g.write(
+            "static const int _certs_uncompressed_size = " + str(decomp_size) + ";\n"
+        )
         g.write("static const unsigned char _certs_compressed[] = {\n")
         for i in range(len(buf)):
             g.write("\t" + byte_to_str(buf[i]) + ",\n")

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -24,7 +24,12 @@ if not has_module:
     env_thirdparty.disable_warnings()
     # Custom config file
     env_thirdparty.Append(
-        CPPDEFINES=[("MBEDTLS_CONFIG_FILE", '\\"thirdparty/mbedtls/include/godot_core_mbedtls_config.h\\"')]
+        CPPDEFINES=[
+            (
+                "MBEDTLS_CONFIG_FILE",
+                '\\"thirdparty/mbedtls/include/godot_core_mbedtls_config.h\\"',
+            )
+        ]
     )
     thirdparty_mbedtls_dir = "#thirdparty/mbedtls/library/"
     thirdparty_mbedtls_sources = [
@@ -36,7 +41,9 @@ if not has_module:
         "sha256.c",
         "godot_core_mbedtls_platform.c",
     ]
-    thirdparty_mbedtls_sources = [thirdparty_mbedtls_dir + file for file in thirdparty_mbedtls_sources]
+    thirdparty_mbedtls_sources = [
+        thirdparty_mbedtls_dir + file for file in thirdparty_mbedtls_sources
+    ]
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_mbedtls_sources)
     env.core_sources += thirdparty_obj
 

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -343,11 +343,13 @@ def run(target, source, env):
     versions_ext = 6
     text = ""
     text_ext = ""
-    text_free_func = "#ifndef METHOD_BIND_FREE_FUNC_H\n#define METHOD_BIND_FREE_FUNC_H\n"
-    text_free_func += "\n//including this header file allows method binding to use free functions\n"
-    text_free_func += (
-        "//note that the free function must have a pointer to an instance of the class as its first parameter\n"
+    text_free_func = (
+        "#ifndef METHOD_BIND_FREE_FUNC_H\n#define METHOD_BIND_FREE_FUNC_H\n"
     )
+    text_free_func += (
+        "\n//including this header file allows method binding to use free functions\n"
+    )
+    text_free_func += "//note that the free function must have a pointer to an instance of the class as its first parameter\n"
 
     for i in range(0, versions + 1):
         t = ""
@@ -364,10 +366,18 @@ def run(target, source, env):
         else:
             text += t
 
-        text_free_func += make_version(template_typed_free_func, i, versions, False, False)
-        text_free_func += make_version(template_typed_free_func, i, versions, False, True)
-        text_free_func += make_version(template_typed_free_func, i, versions, True, False)
-        text_free_func += make_version(template_typed_free_func, i, versions, True, True)
+        text_free_func += make_version(
+            template_typed_free_func, i, versions, False, False
+        )
+        text_free_func += make_version(
+            template_typed_free_func, i, versions, False, True
+        )
+        text_free_func += make_version(
+            template_typed_free_func, i, versions, True, False
+        )
+        text_free_func += make_version(
+            template_typed_free_func, i, versions, True, True
+        )
 
     text_free_func += "#endif"
 

--- a/doc/tools/doc_merge.py
+++ b/doc/tools/doc_merge.py
@@ -129,7 +129,9 @@ def write_class(c):
         for m in list(methods):
             qualifiers = get_tag(m, "qualifiers")
 
-            write_string(f, '<method name="' + escape(m.attrib["name"]) + '" ' + qualifiers + ">")
+            write_string(
+                f, '<method name="' + escape(m.attrib["name"]) + '" ' + qualifiers + ">"
+            )
             inc_tab()
 
             for a in list(m):
@@ -206,7 +208,14 @@ def write_class(c):
         inc_tab()
 
         for m in list(constants):
-            write_string(f, '<constant name="' + escape(m.attrib["name"]) + '" value="' + m.attrib["value"] + '">')
+            write_string(
+                f,
+                '<constant name="'
+                + escape(m.attrib["name"])
+                + '" value="'
+                + m.attrib["value"]
+                + '">',
+            )
             old_constant_descr = find_constant_descr(old_class, m.attrib["name"])
             if old_constant_descr:
                 write_string(f, escape(old_constant_descr.strip()))

--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -13,7 +13,8 @@ import xml.etree.ElementTree as ET
 ################################################################################
 
 flags = {
-    "c": platform.platform() != "Windows",  # Disable by default on windows, since we use ANSI escape codes
+    "c": platform.platform()
+    != "Windows",  # Disable by default on windows, since we use ANSI escape codes
     "b": False,
     "g": False,
     "s": False,
@@ -69,7 +70,16 @@ table_columns = [
     "signals",
     "theme_items",
 ]
-table_column_names = ["Name", "Brief Desc.", "Desc.", "Methods", "Constants", "Members", "Signals", "Theme Items"]
+table_column_names = [
+    "Name",
+    "Brief Desc.",
+    "Desc.",
+    "Methods",
+    "Constants",
+    "Members",
+    "Signals",
+    "Theme Items",
+]
 colors = {
     "name": [36],  # cyan
     "part_big_problem": [4, 31],  # underline, red
@@ -134,7 +144,9 @@ class ClassStatusProgress:
         self.total = total
 
     def __add__(self, other):
-        return ClassStatusProgress(self.described + other.described, self.total + other.total)
+        return ClassStatusProgress(
+            self.described + other.described, self.total + other.total
+        )
 
     def increment(self, described):
         if described:
@@ -146,14 +158,21 @@ class ClassStatusProgress:
 
     def to_configured_colored_string(self):
         if flags["p"]:
-            return self.to_colored_string("{percent}% ({has}/{total})", "{pad_percent}{pad_described}{s}{pad_total}")
+            return self.to_colored_string(
+                "{percent}% ({has}/{total})",
+                "{pad_percent}{pad_described}{s}{pad_total}",
+            )
         else:
             return self.to_colored_string()
 
-    def to_colored_string(self, format="{has}/{total}", pad_format="{pad_described}{s}{pad_total}"):
+    def to_colored_string(
+        self, format="{has}/{total}", pad_format="{pad_described}{s}{pad_total}"
+    ):
         ratio = float(self.described) / float(self.total) if self.total != 0 else 1
         percent = int(round(100 * ratio))
-        s = format.format(has=str(self.described), total=str(self.total), percent=str(percent))
+        s = format.format(
+            has=str(self.described), total=str(self.total), percent=str(percent)
+        )
         if self.described >= self.total:
             s = color("part_good", s)
         elif self.described >= self.total / 4 * 3:
@@ -166,7 +185,12 @@ class ClassStatusProgress:
         pad_described = "".ljust(pad_size - len(str(self.described)))
         pad_percent = "".ljust(3 - len(str(percent)))
         pad_total = "".ljust(pad_size - len(str(self.total)))
-        return pad_format.format(pad_described=pad_described, pad_total=pad_total, pad_percent=pad_percent, s=s)
+        return pad_format.format(
+            pad_described=pad_described,
+            pad_total=pad_total,
+            pad_percent=pad_percent,
+            s=s,
+        )
 
 
 class ClassStatus:
@@ -185,7 +209,9 @@ class ClassStatus:
     def __add__(self, other):
         new_status = ClassStatus()
         new_status.name = self.name
-        new_status.has_brief_description = self.has_brief_description and other.has_brief_description
+        new_status.has_brief_description = (
+            self.has_brief_description and other.has_brief_description
+        )
         new_status.has_description = self.has_description and other.has_description
         for k in self.progresses:
             new_status.progresses[k] = self.progresses[k] + other.progresses[k]
@@ -214,11 +240,14 @@ class ClassStatus:
         ok_string = color("part_good", "OK")
         missing_string = color("part_big_problem", "MISSING")
 
-        output["brief_description"] = ok_string if self.has_brief_description else missing_string
+        output["brief_description"] = (
+            ok_string if self.has_brief_description else missing_string
+        )
         output["description"] = ok_string if self.has_description else missing_string
 
         description_progress = ClassStatusProgress(
-            (self.has_brief_description + self.has_description) * overall_progress_description_weigth,
+            (self.has_brief_description + self.has_description)
+            * overall_progress_description_weigth,
             2 * overall_progress_description_weigth,
         )
         items_progress = ClassStatusProgress()
@@ -234,13 +263,17 @@ class ClassStatus:
         )
 
         if self.name.startswith("Total"):
-            output["url"] = color("url", "https://docs.rebeltoolbox.com/en/latest/classes/")
+            output["url"] = color(
+                "url", "https://docs.rebeltoolbox.com/en/latest/classes/"
+            )
             if flags["s"]:
                 output["comment"] = color("part_good", "ALL OK")
         else:
             output["url"] = color(
                 "url",
-                "https://docs.rebeltoolbox.com/en/latest/classes/class_{name}.html".format(name=self.name.lower()),
+                "https://docs.rebeltoolbox.com/en/latest/classes/class_{name}.html".format(
+                    name=self.name.lower()
+                ),
             )
 
             if flags["s"] and not flags["g"] and self.is_ok():
@@ -267,7 +300,9 @@ class ClassStatus:
             elif tag.tag in ["constants", "members", "theme_items"]:
                 for sub_tag in list(tag):
                     if not sub_tag.text is None:
-                        status.progresses[tag.tag].increment(len(sub_tag.text.strip()) > 0)
+                        status.progresses[tag.tag].increment(
+                            len(sub_tag.text.strip()) > 0
+                        )
 
             elif tag.tag in ["tutorials"]:
                 pass  # Ignore those tags for now
@@ -329,9 +364,16 @@ if flags["u"]:
 
 if len(input_file_list) < 1 or flags["h"]:
     if not flags["h"]:
-        print(color("section", "Invalid usage") + ": Please specify a classes directory")
-    print(color("section", "Usage") + ": doc_status.py [flags] <classes_dir> [class names]")
-    print("\t< and > signify required parameters, while [ and ] signify optional parameters.")
+        print(
+            color("section", "Invalid usage") + ": Please specify a classes directory"
+        )
+    print(
+        color("section", "Usage")
+        + ": doc_status.py [flags] <classes_dir> [class names]"
+    )
+    print(
+        "\t< and > signify required parameters, while [ and ] signify optional parameters."
+    )
     print(color("section", "Available flags") + ":")
     possible_synonym_list = list(long_flags)
     possible_synonym_list.sort()
@@ -407,7 +449,11 @@ for cn in filtered_classes:
 
     total_status = total_status + status
 
-    if (flags["b"] and status.is_ok()) or (flags["g"] and not status.is_ok()) or (not flags["a"]):
+    if (
+        (flags["b"] and status.is_ok())
+        or (flags["g"] and not status.is_ok())
+        or (not flags["a"])
+    ):
         continue
 
     if flags["e"] and status.is_empty():
@@ -457,12 +503,17 @@ for row in table:
         if cell_i >= len(table_column_sizes):
             table_column_sizes.append(0)
 
-        table_column_sizes[cell_i] = max(nonescape_len(cell), table_column_sizes[cell_i])
+        table_column_sizes[cell_i] = max(
+            nonescape_len(cell), table_column_sizes[cell_i]
+        )
 
 divider_string = table_row_chars[0]
 for cell_i in range(len(table[0])):
     divider_string += (
-        table_row_chars[1] + table_row_chars[2] * (table_column_sizes[cell_i]) + table_row_chars[1] + table_row_chars[0]
+        table_row_chars[1]
+        + table_row_chars[2] * (table_column_sizes[cell_i])
+        + table_row_chars[1]
+        + table_row_chars[0]
     )
 print(divider_string)
 
@@ -471,7 +522,9 @@ for row_i, row in enumerate(table):
     for cell_i, cell in enumerate(row):
         padding_needed = table_column_sizes[cell_i] - nonescape_len(cell) + 2
         if cell_i == 0:
-            row_string += table_row_chars[3] + cell + table_row_chars[3] * (padding_needed - 1)
+            row_string += (
+                table_row_chars[3] + cell + table_row_chars[3] * (padding_needed - 1)
+            )
         else:
             row_string += (
                 table_row_chars[3] * int(math.floor(float(padding_needed) / 2))

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -54,14 +54,18 @@ class PropertyDef:
 
 
 class ParameterDef:
-    def __init__(self, name, type_name, default_value):  # type: (str, TypeName, Optional[str]) -> None
+    def __init__(
+        self, name, type_name, default_value
+    ):  # type: (str, TypeName, Optional[str]) -> None
         self.name = name
         self.type_name = type_name
         self.default_value = default_value
 
 
 class SignalDef:
-    def __init__(self, name, parameters, description):  # type: (str, List[ParameterDef], Optional[str]) -> None
+    def __init__(
+        self, name, parameters, description
+    ):  # type: (str, List[ParameterDef], Optional[str]) -> None
         self.name = name
         self.parameters = parameters
         self.description = description
@@ -153,11 +157,18 @@ class State:
 
                 property_name = property.attrib["name"]
                 if property_name in class_def.properties:
-                    print_error("Duplicate property '{}', file: {}".format(property_name, class_name), self)
+                    print_error(
+                        "Duplicate property '{}', file: {}".format(
+                            property_name, class_name
+                        ),
+                        self,
+                    )
                     continue
 
                 type_name = TypeName.from_element(property)
-                setter = property.get("setter") or None  # Use or None so '' gets turned into None.
+                setter = (
+                    property.get("setter") or None
+                )  # Use or None so '' gets turned into None.
                 getter = property.get("getter") or None
                 default_value = property.get("default") or None
                 if default_value is not None:
@@ -165,7 +176,13 @@ class State:
                 overridden = property.get("override") or False
 
                 property_def = PropertyDef(
-                    property_name, type_name, setter, getter, property.text, default_value, overridden
+                    property_name,
+                    type_name,
+                    setter,
+                    getter,
+                    property.text,
+                    default_value,
+                    overridden,
                 )
                 class_def.properties[property_name] = property_def
 
@@ -191,7 +208,9 @@ class State:
                 if desc_element is not None:
                     method_desc = desc_element.text
 
-                method_def = MethodDef(method_name, return_type, params, method_desc, qualifiers)
+                method_def = MethodDef(
+                    method_name, return_type, params, method_desc, qualifiers
+                )
                 if method_name not in class_def.methods:
                     class_def.methods[method_name] = []
 
@@ -208,7 +227,12 @@ class State:
                 constant_def = ConstantDef(constant_name, value, constant.text)
                 if enum is None:
                     if constant_name in class_def.constants:
-                        print_error("Duplicate constant '{}', file: {}".format(constant_name, class_name), self)
+                        print_error(
+                            "Duplicate constant '{}', file: {}".format(
+                                constant_name, class_name
+                            ),
+                            self,
+                        )
                         continue
 
                     class_def.constants[constant_name] = constant_def
@@ -231,7 +255,12 @@ class State:
                 signal_name = signal.attrib["name"]
 
                 if signal_name in class_def.signals:
-                    print_error("Duplicate signal '{}', file: {}".format(signal_name, class_name), self)
+                    print_error(
+                        "Duplicate signal '{}', file: {}".format(
+                            signal_name, class_name
+                        ),
+                        self,
+                    )
                     continue
 
                 params = parse_arguments(signal)
@@ -280,7 +309,9 @@ class State:
                 assert link.tag == "link"
 
                 if link.text is not None:
-                    class_def.tutorials.append((link.text.strip(), link.get("title", "")))
+                    class_def.tutorials.append(
+                        (link.text.strip(), link.get("title", ""))
+                    )
 
     def sort_classes(self):  # type: () -> None
         self.classes = OrderedDict(sorted(self.classes.items(), key=lambda t: t[0]))
@@ -304,10 +335,21 @@ def parse_arguments(root):  # type: (ET.Element) -> List[ParameterDef]
 
 def main():  # type: () -> None
     parser = argparse.ArgumentParser()
-    parser.add_argument("path", nargs="+", help="A path to an XML file or a directory containing XML files to parse.")
-    parser.add_argument("--filter", default="", help="The filepath pattern for XML files to filter.")
+    parser.add_argument(
+        "path",
+        nargs="+",
+        help="A path to an XML file or a directory containing XML files to parse.",
+    )
+    parser.add_argument(
+        "--filter", default="", help="The filepath pattern for XML files to filter."
+    )
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("--output", "-o", default=".", help="The directory to save output .rst files in.")
+    group.add_argument(
+        "--output",
+        "-o",
+        default=".",
+        help="The directory to save output .rst files in.",
+    )
     group.add_argument(
         "--dry-run",
         action="store_true",
@@ -328,11 +370,15 @@ def main():  # type: () -> None
             for subdir, dirs, _ in os.walk(path):
                 if "doc_classes" in dirs:
                     doc_dir = os.path.join(subdir, "doc_classes")
-                    class_file_names = (f for f in os.listdir(doc_dir) if f.endswith(".xml"))
+                    class_file_names = (
+                        f for f in os.listdir(doc_dir) if f.endswith(".xml")
+                    )
                     file_list += (os.path.join(doc_dir, f) for f in class_file_names)
 
         elif os.path.isdir(path):
-            file_list += (os.path.join(path, f) for f in os.listdir(path) if f.endswith(".xml"))
+            file_list += (
+                os.path.join(path, f) for f in os.listdir(path) if f.endswith(".xml")
+            )
 
         elif os.path.isfile(path):
             if not path.endswith(".xml"):
@@ -387,22 +433,34 @@ def main():  # type: () -> None
         if not args.dry_run:
             print("Wrote reStructuredText files for each class to: %s" % args.output)
     else:
-        print("Errors were found in the class reference XML. Please check the messages above.")
+        print(
+            "Errors were found in the class reference XML. Please check the messages above."
+        )
         exit(1)
 
 
-def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, State, bool, str) -> None
+def make_rst_class(
+    class_def, state, dry_run, output_dir
+):  # type: (ClassDef, State, bool, str) -> None
     class_name = class_def.name
 
     if dry_run:
         f = open(os.devnull, "w", encoding="utf-8")
     else:
-        f = open(os.path.join(output_dir, "class_" + class_name.lower() + ".rst"), "w", encoding="utf-8")
+        f = open(
+            os.path.join(output_dir, "class_" + class_name.lower() + ".rst"),
+            "w",
+            encoding="utf-8",
+        )
 
     # Warn contributors not to edit this file directly
     f.write(":github_url: hide\n\n")
-    f.write(".. Generated automatically by doc/tools/make_rst.py in Rebel Engine's source tree.\n")
-    f.write(".. DO NOT EDIT THIS FILE, but the " + class_name + ".xml source instead.\n")
+    f.write(
+        ".. Generated automatically by doc/tools/make_rst.py in Rebel Engine's source tree.\n"
+    )
+    f.write(
+        ".. DO NOT EDIT THIS FILE, but the " + class_name + ".xml source instead.\n"
+    )
     f.write(".. The source is found in doc/classes or modules/<name>/doc_classes.\n\n")
 
     f.write(".. _class_" + class_name + ":\n\n")
@@ -465,9 +523,13 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
             type_rst = property_def.type_name.to_rst(state)
             default = property_def.default_value
             if default is not None and property_def.overridden:
-                ml.append((type_rst, property_def.name, default + " *(parent override)*"))
+                ml.append(
+                    (type_rst, property_def.name, default + " *(parent override)*")
+                )
             else:
-                ref = ":ref:`{0}<class_{1}_property_{0}>`".format(property_def.name, class_name)
+                ref = ":ref:`{0}<class_{1}_property_{0}>`".format(
+                    property_def.name, class_name
+                )
                 ml.append((type_rst, ref, default))
         format_table(f, ml, True)
 
@@ -488,7 +550,13 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
             ref = ":ref:`{0}<class_{2}_theme_{1}_{0}>`".format(
                 theme_item_def.name, theme_item_def.data_name, class_name
             )
-            pl.append((theme_item_def.type_name.to_rst(state), ref, theme_item_def.default_value))
+            pl.append(
+                (
+                    theme_item_def.type_name.to_rst(state),
+                    ref,
+                    theme_item_def.default_value,
+                )
+            )
         format_table(f, pl, True)
 
     # Signals
@@ -563,15 +631,25 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
             if index != 0:
                 f.write("----\n\n")
 
-            f.write(".. _class_{}_property_{}:\n\n".format(class_name, property_def.name))
-            f.write("- {} **{}**\n\n".format(property_def.type_name.to_rst(state), property_def.name))
+            f.write(
+                ".. _class_{}_property_{}:\n\n".format(class_name, property_def.name)
+            )
+            f.write(
+                "- {} **{}**\n\n".format(
+                    property_def.type_name.to_rst(state), property_def.name
+                )
+            )
 
             info = []
             if property_def.default_value is not None:
                 info.append(("*Default*", property_def.default_value))
-            if property_def.setter is not None and not property_def.setter.startswith("_"):
+            if property_def.setter is not None and not property_def.setter.startswith(
+                "_"
+            ):
                 info.append(("*Setter*", property_def.setter + "(value)"))
-            if property_def.getter is not None and not property_def.getter.startswith("_"):
+            if property_def.getter is not None and not property_def.getter.startswith(
+                "_"
+            ):
                 info.append(("*Getter*", property_def.getter + "()"))
 
             if len(info) > 0:
@@ -612,8 +690,16 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
             if index != 0:
                 f.write("----\n\n")
 
-            f.write(".. _class_{}_theme_{}_{}:\n\n".format(class_name, theme_item_def.data_name, theme_item_def.name))
-            f.write("- {} **{}**\n\n".format(theme_item_def.type_name.to_rst(state), theme_item_def.name))
+            f.write(
+                ".. _class_{}_theme_{}_{}:\n\n".format(
+                    class_name, theme_item_def.data_name, theme_item_def.name
+                )
+            )
+            f.write(
+                "- {} **{}**\n\n".format(
+                    theme_item_def.type_name.to_rst(state), theme_item_def.name
+                )
+            )
 
             info = []
             if theme_item_def.default_value is not None:
@@ -683,7 +769,12 @@ def rstize_text(text, state):  # type: (str, State) -> str
         if post_text.startswith("[codeblock]"):
             end_pos = post_text.find("[/codeblock]")
             if end_pos == -1:
-                print_error("[codeblock] without a closing tag, file: {}".format(state.current_class), state)
+                print_error(
+                    "[codeblock] without a closing tag, file: {}".format(
+                        state.current_class
+                    ),
+                    state,
+                )
                 return ""
 
             code_text = post_text[len("[codeblock]") : end_pos]
@@ -697,7 +788,10 @@ def rstize_text(text, state):  # type: (str, State) -> str
                     break
 
                 to_skip = 0
-                while code_pos + to_skip + 1 < len(code_text) and code_text[code_pos + to_skip + 1] == "\t":
+                while (
+                    code_pos + to_skip + 1 < len(code_text)
+                    and code_text[code_pos + to_skip + 1] == "\t"
+                ):
                     to_skip += 1
 
                 if to_skip > indent_level:
@@ -712,7 +806,11 @@ def rstize_text(text, state):  # type: (str, State) -> str
                     code_text = code_text[:code_pos] + "\n"
                     code_pos += 1
                 else:
-                    code_text = code_text[:code_pos] + "\n    " + code_text[code_pos + to_skip + 1 :]
+                    code_text = (
+                        code_text[:code_pos]
+                        + "\n    "
+                        + code_text[code_pos + to_skip + 1 :]
+                    )
                     code_pos += 5 - to_skip
 
             text = pre_text + "\n[codeblock]" + code_text + post_text
@@ -789,7 +887,12 @@ def rstize_text(text, state):  # type: (str, State) -> str
                 if param.find(".") != -1:
                     ss = param.split(".")
                     if len(ss) > 2:
-                        print_error("Bad reference: '{}', file: {}".format(param, state.current_class), state)
+                        print_error(
+                            "Bad reference: '{}', file: {}".format(
+                                param, state.current_class
+                            ),
+                            state,
+                        )
                     class_param, method_param = ss
 
                 else:
@@ -801,17 +904,32 @@ def rstize_text(text, state):  # type: (str, State) -> str
                     class_def = state.classes[class_param]
                     if cmd.startswith("method"):
                         if method_param not in class_def.methods:
-                            print_error("Unresolved method '{}', file: {}".format(param, state.current_class), state)
+                            print_error(
+                                "Unresolved method '{}', file: {}".format(
+                                    param, state.current_class
+                                ),
+                                state,
+                            )
                         ref_type = "_method"
 
                     elif cmd.startswith("member"):
                         if method_param not in class_def.properties:
-                            print_error("Unresolved member '{}', file: {}".format(param, state.current_class), state)
+                            print_error(
+                                "Unresolved member '{}', file: {}".format(
+                                    param, state.current_class
+                                ),
+                                state,
+                            )
                         ref_type = "_property"
 
                     elif cmd.startswith("signal"):
                         if method_param not in class_def.signals:
-                            print_error("Unresolved signal '{}', file: {}".format(param, state.current_class), state)
+                            print_error(
+                                "Unresolved signal '{}', file: {}".format(
+                                    param, state.current_class
+                                ),
+                                state,
+                            )
                         ref_type = "_signal"
 
                     elif cmd.startswith("constant"):
@@ -837,7 +955,12 @@ def rstize_text(text, state):  # type: (str, State) -> str
                                         break
 
                         if not found:
-                            print_error("Unresolved constant '{}', file: {}".format(param, state.current_class), state)
+                            print_error(
+                                "Unresolved constant '{}', file: {}".format(
+                                    param, state.current_class
+                                ),
+                                state,
+                            )
                         ref_type = "_constant"
 
                 else:
@@ -851,7 +974,9 @@ def rstize_text(text, state):  # type: (str, State) -> str
                 repl_text = method_param
                 if class_param != state.current_class:
                     repl_text = "{}.{}".format(class_param, method_param)
-                tag_text = ":ref:`{}<class_{}{}_{}>`".format(repl_text, class_param, ref_type, method_param)
+                tag_text = ":ref:`{}<class_{}{}_{}>`".format(
+                    repl_text, class_param, ref_type, method_param
+                )
                 escape_post = True
             elif cmd.find("image=") == 0:
                 tag_text = ""  # '![](' + cmd[6:] + ')'
@@ -913,7 +1038,11 @@ def rstize_text(text, state):  # type: (str, State) -> str
                 escape_post = True
 
         # Properly escape things like `[Node]s`
-        if escape_post and post_text and (post_text[0].isalnum() or post_text[0] == "("):  # not punctuation, escape
+        if (
+            escape_post
+            and post_text
+            and (post_text[0].isalnum() or post_text[0] == "(")
+        ):  # not punctuation, escape
             post_text = "\ " + post_text
 
         next_brac_pos = post_text.find("[", 0)
@@ -930,7 +1059,9 @@ def rstize_text(text, state):  # type: (str, State) -> str
             iter_pos = post_text.find("_", iter_pos, next_brac_pos)
             if iter_pos == -1:
                 break
-            if not post_text[iter_pos + 1].isalnum():  # don't escape within a snake_case word
+            if not post_text[
+                iter_pos + 1
+            ].isalnum():  # don't escape within a snake_case word
                 post_text = post_text[:iter_pos] + "\_" + post_text[iter_pos + 1 :]
                 iter_pos += 2
             else:
@@ -941,12 +1072,19 @@ def rstize_text(text, state):  # type: (str, State) -> str
         previous_pos = pos
 
     if tag_depth > 0:
-        print_error("Tag depth mismatch: too many/little open/close tags, file: {}".format(state.current_class), state)
+        print_error(
+            "Tag depth mismatch: too many/little open/close tags, file: {}".format(
+                state.current_class
+            ),
+            state,
+        )
 
     return text
 
 
-def format_table(f, data, remove_empty_columns=False):  # type: (TextIO, Iterable[Tuple[str, ...]]) -> None
+def format_table(
+    f, data, remove_empty_columns=False
+):  # type: (TextIO, Iterable[Tuple[str, ...]]) -> None
     if len(data) == 0:
         return
 
@@ -1007,7 +1145,9 @@ def make_enum(t, state):  # type: (str, State) -> str
 
     # Don't fail for `Vector3.Axis`, as this enum is a special case which is expected not to be resolved.
     if "{}.{}".format(c, e) != "Vector3.Axis":
-        print_error("Unresolved enum '{}', file: {}".format(t, state.current_class), state)
+        print_error(
+            "Unresolved enum '{}', file: {}".format(t, state.current_class), state
+        )
 
     return t
 
@@ -1025,7 +1165,9 @@ def make_method_signature(
     out = ""
 
     if make_ref:
-        out += ":ref:`{0}<class_{1}_{2}_{0}>` ".format(method_def.name, class_def.name, ref_type)
+        out += ":ref:`{0}<class_{1}_{2}_{0}>` ".format(
+            method_def.name, class_def.name, ref_type
+        )
     else:
         out += "**{}** ".format(method_def.name)
 
@@ -1041,7 +1183,11 @@ def make_method_signature(
         if arg.default_value is not None:
             out += "=" + arg.default_value
 
-    if isinstance(method_def, MethodDef) and method_def.qualifiers is not None and "vararg" in method_def.qualifiers:
+    if (
+        isinstance(method_def, MethodDef)
+        and method_def.qualifiers is not None
+        and "vararg" in method_def.qualifiers
+    ):
         if len(method_def.parameters) > 0:
             out += ", ..."
         else:
@@ -1081,7 +1227,17 @@ def make_link(url, title):  # type: (str, str) -> str
         if match.lastindex == 2:
             # Doc reference with fragment identifier: emit direct link to section with reference to page, for example:
             # `#calling-javascript-from-script in Exporting For Web`
-            return "`" + groups[1] + " <../" + groups[0] + ".html" + groups[1] + ">`_ in :doc:`../" + groups[0] + "`"
+            return (
+                "`"
+                + groups[1]
+                + " <../"
+                + groups[0]
+                + ".html"
+                + groups[1]
+                + ">`_ in :doc:`../"
+                + groups[0]
+                + "`"
+            )
             # Commented out alternative: Instead just emit:
             # `Subsection in Exporting For Web`
             # return "`Subsection <../" + groups[0] + ".html" + groups[1] + ">`__ in :doc:`../" + groups[0] + "`"

--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -5,7 +5,14 @@ import os
 import shutil
 from collections import OrderedDict
 
-EXTRACT_TAGS = ["description", "brief_description", "member", "constant", "theme_item", "link"]
+EXTRACT_TAGS = [
+    "description",
+    "brief_description",
+    "member",
+    "constant",
+    "theme_item",
+    "link",
+]
 HEADER = """\
 # LANGUAGE translation of the Rebel Engine class reference
 # Copyright (c) 2022-Present Rebel Engine contributors
@@ -208,7 +215,11 @@ def _make_translation_catalog(classes):
             if elem.tag in EXTRACT_TAGS:
                 if not elem.text or len(elem.text) == 0:
                     continue
-                line_no = elem._start_line_number if elem.text[0] != "\n" else elem._start_line_number + 1
+                line_no = (
+                    elem._start_line_number
+                    if elem.text[0] != "\n"
+                    else elem._start_line_number + 1
+                )
                 desc_str = elem.text.strip()
                 code_block_regions = _make_codeblock_regions(desc_str, desc_list.path)
                 desc_msg = _strip_and_split_desc(desc_str, code_block_regions)
@@ -259,9 +270,18 @@ def _generate_translation_catalog_file(unique_msgs, output, location_line=False)
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--path", "-p", nargs="+", default=".", help="The directory or directories containing XML files to collect."
+        "--path",
+        "-p",
+        nargs="+",
+        default=".",
+        help="The directory or directories containing XML files to collect.",
     )
-    parser.add_argument("--output", "-o", default="translation_catalog.pot", help="The path to the output file.")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="translation_catalog.pot",
+        help="The path to the output file.",
+    )
     args = parser.parse_args()
 
     output = os.path.abspath(args.output)
@@ -277,7 +297,9 @@ def main():
 
         print("\nCurrent working dir: {}".format(path))
 
-        path_classes = OrderedDict()  ## dictionary of key=class_name, value=DescList objects
+        path_classes = (
+            OrderedDict()
+        )  ## dictionary of key=class_name, value=DescList objects
         _collect_classes_dir(path, path_classes)
         classes.update(path_classes)
 

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -52,9 +52,13 @@ if env["builtin_libpng"]:
             env_neon["CC"] = env["S_compiler"]
         neon_sources = []
         neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/arm_init.c"))
-        neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/filter_neon_intrinsics.c"))
+        neon_sources.append(
+            env_neon.Object(thirdparty_dir + "/arm/filter_neon_intrinsics.c")
+        )
         neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/filter_neon.S"))
-        neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/palette_neon_intrinsics.c"))
+        neon_sources.append(
+            env_neon.Object(thirdparty_dir + "/arm/palette_neon_intrinsics.c")
+        )
         thirdparty_obj += neon_sources
 
     env.drivers_sources += thirdparty_obj

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -14,10 +14,18 @@ import editor_builders
 def _make_doc_data_class_path(to_path):
     # NOTE: It is safe to generate this file here, since this is still executed serially
     g = open_utf8(os.path.join(to_path, "doc_data_class_path.gen.h"), "w")
-    g.write("static const int _doc_data_class_path_count = " + str(len(env.doc_class_path)) + ";\n")
+    g.write(
+        "static const int _doc_data_class_path_count = "
+        + str(len(env.doc_class_path))
+        + ";\n"
+    )
     g.write("struct _DocDataClassPath { const char* name; const char* path; };\n")
 
-    g.write("static const _DocDataClassPath _doc_data_class_paths[" + str(len(env.doc_class_path) + 1) + "] = {\n")
+    g.write(
+        "static const _DocDataClassPath _doc_data_class_paths["
+        + str(len(env.doc_class_path) + 1)
+        + "] = {\n"
+    )
     for c in sorted(env.doc_class_path):
         g.write('\t{"' + c + '", "' + env.doc_class_path[c] + '"},\n')
     g.write("\t{NULL, NULL}\n")
@@ -64,7 +72,11 @@ if env["tools"]:
 
     docs = sorted(docs)
     env.Depends("#editor/doc_data_compressed.gen.h", docs)
-    env.CommandNoCache("#editor/doc_data_compressed.gen.h", docs, run_in_subprocess(editor_builders.make_doc_header))
+    env.CommandNoCache(
+        "#editor/doc_data_compressed.gen.h",
+        docs,
+        run_in_subprocess(editor_builders.make_doc_header),
+    )
 
     # Editor interface and class reference translations incur a significant size
     # cost for the editor binary (see godot-proposals#3421).
@@ -78,10 +90,14 @@ if env["tools"]:
     to_include = (
         "bg,ca,cs,de,el,eo,es_AR,es,fi,fr,gl,hu,id,it,ja,ko,lv,ms,nb,nl,pl,pt_BR,pt,ro,ru,sk,sv,th,tr,uk,vi,zh_CN,zh_TW"
     ).split(",")
-    tlist = [env.Dir("#editor/translations").abspath + "/" + f + ".po" for f in to_include]
+    tlist = [
+        env.Dir("#editor/translations").abspath + "/" + f + ".po" for f in to_include
+    ]
     env.Depends("#editor/editor_translations.gen.h", tlist)
     env.CommandNoCache(
-        "#editor/editor_translations.gen.h", tlist, run_in_subprocess(editor_builders.make_editor_translations_header)
+        "#editor/editor_translations.gen.h",
+        tlist,
+        run_in_subprocess(editor_builders.make_editor_translations_header),
     )
 
     # Documentation translations
@@ -89,7 +105,9 @@ if env["tools"]:
     tlist = [env.Dir("#doc/translations").abspath + "/" + f + ".po" for f in to_include]
     env.Depends("#editor/doc_translations.gen.h", tlist)
     env.CommandNoCache(
-        "#editor/doc_translations.gen.h", tlist, run_in_subprocess(editor_builders.make_doc_translations_header)
+        "#editor/doc_translations.gen.h",
+        tlist,
+        run_in_subprocess(editor_builders.make_doc_translations_header),
     )
 
     # Fonts
@@ -97,7 +115,11 @@ if env["tools"]:
     flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.otf"))
     flist.sort()
     env.Depends("#editor/builtin_fonts.gen.h", flist)
-    env.CommandNoCache("#editor/builtin_fonts.gen.h", flist, run_in_subprocess(editor_builders.make_fonts_header))
+    env.CommandNoCache(
+        "#editor/builtin_fonts.gen.h",
+        flist,
+        run_in_subprocess(editor_builders.make_fonts_header),
+    )
 
     env.add_source_files(env.editor_sources, "*.cpp")
     env.add_source_files(env.editor_sources, "register_exporters.gen.cpp")

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -32,7 +32,9 @@ def make_doc_header(target, source, env):
     g.write("#ifndef _DOC_DATA_RAW_H\n")
     g.write("#define _DOC_DATA_RAW_H\n")
     g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
-    g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
+    g.write(
+        "static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n"
+    )
     g.write("static const unsigned char _doc_data_compressed[] = {\n")
     for i in range(len(buf)):
         g.write("\t" + byte_to_str(buf[i]) + ",\n")
@@ -84,7 +86,9 @@ def make_translations_header(target, source, env, category):
     import zlib
     import os.path
 
-    sorted_paths = sorted(source, key=lambda path: os.path.splitext(os.path.basename(path))[0])
+    sorted_paths = sorted(
+        source, key=lambda path: os.path.splitext(os.path.basename(path))[0]
+    )
 
     xl_names = []
     for i in range(len(sorted_paths)):
@@ -94,7 +98,11 @@ def make_translations_header(target, source, env, category):
         buf = zlib.compress(buf)
         name = os.path.splitext(os.path.basename(sorted_paths[i]))[0]
 
-        g.write("static const unsigned char _{}_translation_{}_compressed[] = {{\n".format(category, name))
+        g.write(
+            "static const unsigned char _{}_translation_{}_compressed[] = {{\n".format(
+                category, name
+            )
+        )
         for j in range(len(buf)):
             g.write("\t" + byte_to_str(buf[j]) + ",\n")
 
@@ -108,10 +116,16 @@ def make_translations_header(target, source, env, category):
     g.write("\tint uncomp_size;\n")
     g.write("\tconst unsigned char* data;\n")
     g.write("};\n\n")
-    g.write("static {}TranslationList _{}_translations[] = {{\n".format(category.capitalize(), category))
+    g.write(
+        "static {}TranslationList _{}_translations[] = {{\n".format(
+            category.capitalize(), category
+        )
+    )
     for x in xl_names:
         g.write(
-            '\t{{ "{}", {}, {}, _{}_translation_{}_compressed }},\n'.format(x[0], str(x[1]), str(x[2]), category, x[0])
+            '\t{{ "{}", {}, {}, _{}_translation_{}_compressed }},\n'.format(
+                x[0], str(x[1]), str(x[2]), category, x[0]
+            )
         )
     g.write("\t{NULL, 0, 0, NULL}\n")
     g.write("};\n")

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -8,7 +8,9 @@ from platform_methods import run_in_subprocess
 import editor_icons_builders
 
 make_editor_icons_builder = Builder(
-    action=run_in_subprocess(editor_icons_builders.make_editor_icons_action), suffix=".h", src_suffix=".svg"
+    action=run_in_subprocess(editor_icons_builders.make_editor_icons_action),
+    suffix=".h",
+    src_suffix=".svg",
 )
 
 env["BUILDERS"]["MakeEditorIconsBuilder"] = make_editor_icons_builder
@@ -23,4 +25,7 @@ for path in env.module_icons_paths:
     else:
         icon_sources += Glob(path + "/*.svg")  # Custom.
 
-env.Alias("editor_icons", [env.MakeEditorIconsBuilder("#editor/editor_icons.gen.h", icon_sources)])
+env.Alias(
+    "editor_icons",
+    [env.MakeEditorIconsBuilder("#editor/editor_icons.gen.h", icon_sources)],
+)

--- a/editor/icons/editor_icons_builders.py
+++ b/editor/icons/editor_icons_builders.py
@@ -68,13 +68,21 @@ def make_editor_icons_action(target, source, env):
 
     if thumb_medium_indices:
         s.write("\n\n")
-        s.write("static const int editor_md_thumbs_count = {};\n".format(len(thumb_medium_indices)))
+        s.write(
+            "static const int editor_md_thumbs_count = {};\n".format(
+                len(thumb_medium_indices)
+            )
+        )
         s.write("static const int editor_md_thumbs_indices[] = {")
         s.write(", ".join(thumb_medium_indices))
         s.write("};\n")
     if thumb_big_indices:
         s.write("\n\n")
-        s.write("static const int editor_bg_thumbs_count = {};\n".format(len(thumb_big_indices)))
+        s.write(
+            "static const int editor_bg_thumbs_count = {};\n".format(
+                len(thumb_big_indices)
+            )
+        )
         s.write("static const int editor_bg_thumbs_indices[] = {")
         s.write(", ".join(thumb_big_indices))
         s.write("};\n")

--- a/editor/translations/extract.py
+++ b/editor/translations/extract.py
@@ -73,7 +73,9 @@ def _write_translator_comment(msg, translator_comment):
 
     # Check if a previous translator comment already exists. If so, merge them together.
     if main_po.find("TRANSLATORS:", translator_comment_pos, msg_pos) != -1:
-        translator_comment_pos = main_po.find("\n#:", translator_comment_pos, msg_pos) + 1
+        translator_comment_pos = (
+            main_po.find("\n#:", translator_comment_pos, msg_pos) + 1
+        )
         if translator_comment_pos == 0:
             print('translator_comment_pos after "TRANSLATORS:" not found')
             return
@@ -169,11 +171,15 @@ def process_file(f, fname):
 
         # Gather translator comments. It will be gathered for the next translation function.
         if reading_translator_comment:
-            reading_translator_comment, extracted_comment = _extract_translator_comment(l, is_block_translator_comment)
+            reading_translator_comment, extracted_comment = _extract_translator_comment(
+                l, is_block_translator_comment
+            )
             if extracted_comment != "":
                 translator_comment += extracted_comment + "\n"
             if not reading_translator_comment:
-                translator_comment = translator_comment[:-1]  # Remove extra \n at the end.
+                translator_comment = translator_comment[
+                    :-1
+                ]  # Remove extra \n at the end.
 
         idx = 0
         pos = 0
@@ -210,7 +216,9 @@ def process_file(f, fname):
                 # Add additional location to previous occurrence too
                 msg_pos = main_po.find('\nmsgid "' + msg + '"')
                 if msg_pos == -1:
-                    print("Someone apparently thought writing Python was as easy as GDScript. Ping Akien.")
+                    print(
+                        "Someone apparently thought writing Python was as easy as GDScript. Ping Akien."
+                    )
                 main_po = main_po[:msg_pos] + " " + location + main_po[msg_pos:]
                 unique_loc[msg].append(location)
 
@@ -236,7 +244,14 @@ shutil.move("editor.pot", "editor/translations/editor.pot")
 
 # TODO: Make that in a portable way, if we care; if not, kudos to Unix users
 if os.name == "posix":
-    added = subprocess.check_output(r"git diff editor/translations/editor.pot | grep \+msgid | wc -l", shell=True)
-    removed = subprocess.check_output(r"git diff editor/translations/editor.pot | grep \\\-msgid | wc -l", shell=True)
+    added = subprocess.check_output(
+        r"git diff editor/translations/editor.pot | grep \+msgid | wc -l", shell=True
+    )
+    removed = subprocess.check_output(
+        r"git diff editor/translations/editor.pot | grep \\\-msgid | wc -l", shell=True
+    )
     print("\n# Template changes compared to the staged status:")
-    print("#   Additions: %s msgids.\n#   Deletions: %s msgids." % (int(added), int(removed)))
+    print(
+        "#   Additions: %s msgids.\n#   Deletions: %s msgids."
+        % (int(added), int(removed))
+    )

--- a/gles_builders.py
+++ b/gles_builders.py
@@ -54,15 +54,45 @@ def include_file_in_legacygl_header(filename, header_data, depth):
 
             import os.path
 
-            included_file = os.path.relpath(os.path.dirname(filename) + "/" + includeline)
-            if not included_file in header_data.vertex_included_files and header_data.reading == "vertex":
+            included_file = os.path.relpath(
+                os.path.dirname(filename) + "/" + includeline
+            )
+            if (
+                not included_file in header_data.vertex_included_files
+                and header_data.reading == "vertex"
+            ):
                 header_data.vertex_included_files += [included_file]
-                if include_file_in_legacygl_header(included_file, header_data, depth + 1) is None:
-                    print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
-            elif not included_file in header_data.fragment_included_files and header_data.reading == "fragment":
+                if (
+                    include_file_in_legacygl_header(
+                        included_file, header_data, depth + 1
+                    )
+                    is None
+                ):
+                    print(
+                        "Error in file '"
+                        + filename
+                        + "': #include "
+                        + includeline
+                        + "could not be found!"
+                    )
+            elif (
+                not included_file in header_data.fragment_included_files
+                and header_data.reading == "fragment"
+            ):
                 header_data.fragment_included_files += [included_file]
-                if include_file_in_legacygl_header(included_file, header_data, depth + 1) is None:
-                    print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
+                if (
+                    include_file_in_legacygl_header(
+                        included_file, header_data, depth + 1
+                    )
+                    is None
+                ):
+                    print(
+                        "Error in file '"
+                        + filename
+                        + "': #include "
+                        + includeline
+                        + "could not be found!"
+                    )
 
             line = fs.readline()
 
@@ -126,7 +156,9 @@ def include_file_in_legacygl_header(filename, header_data, depth):
                     header_data.ubos += [(x, ubo)]
                     header_data.ubo_names += [x]
 
-        elif line.find("uniform") != -1 and line.find("{") == -1 and line.find(";") != -1:
+        elif (
+            line.find("uniform") != -1 and line.find("{") == -1 and line.find(";") != -1
+        ):
             uline = line.replace("uniform", "")
             uline = uline.replace(";", "")
             lines = uline.split(",")
@@ -202,12 +234,21 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
     fd.write("#define " + out_file_ifdef + class_suffix + "_120\n")
 
     out_file_class = (
-        out_file_base.replace(".glsl.gen.h", "").title().replace("_", "").replace(".", "") + "Shader" + class_suffix
+        out_file_base.replace(".glsl.gen.h", "")
+        .title()
+        .replace("_", "")
+        .replace(".", "")
+        + "Shader"
+        + class_suffix
     )
     fd.write("\n\n")
     fd.write('#include "' + include + '"\n\n\n')
     fd.write("class " + out_file_class + " : public Shader" + class_suffix + " {\n\n")
-    fd.write('\t virtual String get_shader_name() const { return "' + out_file_class + '"; }\n')
+    fd.write(
+        '\t virtual String get_shader_name() const { return "'
+        + out_file_class
+        + '"; }\n'
+    )
 
     fd.write("public:\n\n")
 
@@ -223,7 +264,9 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
             fd.write("\t\t" + x.upper() + ",\n")
         fd.write("\t};\n\n")
 
-    fd.write("\t_FORCE_INLINE_ int get_uniform(Uniforms p_uniform) const { return _get_uniform(p_uniform); }\n\n")
+    fd.write(
+        "\t_FORCE_INLINE_ int get_uniform(Uniforms p_uniform) const { return _get_uniform(p_uniform); }\n\n"
+    )
     if header_data.conditionals:
         fd.write(
             "\t_FORCE_INLINE_ void set_conditional(Conditionals p_conditional,bool p_enable)  {  _set_conditional(p_conditional,p_enable); }\n\n"
@@ -370,7 +413,9 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
     enum_value_count = 0
 
     if header_data.enums:
-        fd.write("\t\t//Written using math, given nonstandarity of 64 bits integer constants..\n")
+        fd.write(
+            "\t\t//Written using math, given nonstandarity of 64 bits integer constants..\n"
+        )
         fd.write("\t\tstatic const Enum _enums[]={\n")
 
         bitofs = len(header_data.conditionals)
@@ -389,7 +434,11 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
                 c = {}
                 c["set_mask"] = "uint64_t(" + str(i) + ")<<" + str(bitofs)
                 c["clear_mask"] = (
-                    "((uint64_t(1)<<40)-1) ^ (((uint64_t(1)<<" + str(bits) + ") - 1)<<" + str(bitofs) + ")"
+                    "((uint64_t(1)<<40)-1) ^ (((uint64_t(1)<<"
+                    + str(bits)
+                    + ") - 1)<<"
+                    + str(bitofs)
+                    + ")"
                 )
                 enum_vals.append(c)
                 enum_constants.append(x[i])
@@ -397,7 +446,15 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
             strs += "NULL}"
 
             fd.write(
-                "\t\t\t{(uint64_t(1<<" + str(bits) + ")-1)<<" + str(bitofs) + "," + str(bitofs) + "," + strs + "},\n"
+                "\t\t\t{(uint64_t(1<<"
+                + str(bits)
+                + ")-1)<<"
+                + str(bitofs)
+                + ","
+                + str(bitofs)
+                + ","
+                + strs
+                + "},\n"
             )
             bitofs += bits
 
@@ -448,7 +505,13 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
             name = x[0]
             cond = x[1]
             if cond in conditionals_found:
-                fd.write('\t\t\t{"' + name + '",' + str(conditionals_found.index(cond)) + "},\n")
+                fd.write(
+                    '\t\t\t{"'
+                    + name
+                    + '",'
+                    + str(conditionals_found.index(cond))
+                    + "},\n"
+                )
             else:
                 fd.write('\t\t\t{"' + name + '",-1},\n')
 
@@ -488,7 +551,11 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
         fd.write(str(ord("\n")) + ",")
     fd.write("\t\t0};\n\n")
 
-    fd.write("\t\tstatic const int _vertex_code_start=" + str(header_data.vertex_offset) + ";\n")
+    fd.write(
+        "\t\tstatic const int _vertex_code_start="
+        + str(header_data.vertex_offset)
+        + ";\n"
+    )
 
     fd.write("\t\tstatic const char _fragment_code[]={\n")
     for x in header_data.fragment_lines:
@@ -498,7 +565,11 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
         fd.write(str(ord("\n")) + ",")
     fd.write("\t\t0};\n\n")
 
-    fd.write("\t\tstatic const int _fragment_code_start=" + str(header_data.fragment_offset) + ";\n")
+    fd.write(
+        "\t\tstatic const int _fragment_code_start="
+        + str(header_data.fragment_offset)
+        + ";\n"
+    )
 
     if output_attribs:
         if gles2:
@@ -570,7 +641,9 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
         for x in enum_constants:
             fd.write("\t\t" + x.upper() + ",\n")
         fd.write("\t};\n\n")
-        fd.write("\tvoid set_enum_conditional(EnumConditionals p_cond) { _set_enum_conditional(p_cond); }\n")
+        fd.write(
+            "\tvoid set_enum_conditional(EnumConditionals p_cond) { _set_enum_conditional(p_cond); }\n"
+        )
 
     fd.write("};\n\n")
     fd.write("#endif\n\n")
@@ -579,13 +652,22 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs, gles2
 
 def build_gles3_headers(target, source, env):
     for x in source:
-        build_legacygl_header(str(x), include="drivers/gles3/shader_gles3.h", class_suffix="GLES3", output_attribs=True)
+        build_legacygl_header(
+            str(x),
+            include="drivers/gles3/shader_gles3.h",
+            class_suffix="GLES3",
+            output_attribs=True,
+        )
 
 
 def build_gles2_headers(target, source, env):
     for x in source:
         build_legacygl_header(
-            str(x), include="drivers/gles2/shader_gles2.h", class_suffix="GLES2", output_attribs=True, gles2=True
+            str(x),
+            include="drivers/gles2/shader_gles2.h",
+            class_suffix="GLES2",
+            output_attribs=True,
+            gles2=True,
         )
 
 

--- a/main/SCsub
+++ b/main/SCsub
@@ -21,16 +21,26 @@ gensource = env.CommandNoCache(
 env.add_source_files(env.main_sources, gensource)
 
 env.Depends("#main/splash.gen.h", "#main/splash.png")
-env.CommandNoCache("#main/splash.gen.h", "#main/splash.png", run_in_subprocess(main_builders.make_splash))
+env.CommandNoCache(
+    "#main/splash.gen.h",
+    "#main/splash.png",
+    run_in_subprocess(main_builders.make_splash),
+)
 
 if not env["no_editor_splash"]:
     env.Depends("#main/splash_editor.gen.h", "#main/splash_editor.png")
     env.CommandNoCache(
-        "#main/splash_editor.gen.h", "#main/splash_editor.png", run_in_subprocess(main_builders.make_splash_editor)
+        "#main/splash_editor.gen.h",
+        "#main/splash_editor.png",
+        run_in_subprocess(main_builders.make_splash_editor),
     )
 
 env.Depends("#main/app_icon.gen.h", "#main/app_icon.png")
-env.CommandNoCache("#main/app_icon.gen.h", "#main/app_icon.png", run_in_subprocess(main_builders.make_app_icon))
+env.CommandNoCache(
+    "#main/app_icon.gen.h",
+    "#main/app_icon.png",
+    run_in_subprocess(main_builders.make_app_icon),
+)
 
 if env["tools"]:
     SConscript("tests/SCsub")

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -41,7 +41,9 @@ def make_splash_editor(target, source, env):
         g.write("#define BOOT_SPLASH_EDITOR_H\n")
         # The editor splash background color is taken from the default editor theme's background color.
         # This helps achieve a visually "smoother" transition between the splash screen and the editor.
-        g.write("static const Color boot_splash_editor_bg_color = Color(0.5, 0.5, 0.5);\n")
+        g.write(
+            "static const Color boot_splash_editor_bg_color = Color(0.5, 0.5, 0.5);\n"
+        )
         g.write("static const unsigned char boot_splash_editor_png[] = {\n")
         for i in range(len(buf)):
             g.write(byte_to_str(buf[i]) + ",\n")
@@ -99,7 +101,9 @@ def make_default_controller_mappings(target, source, env):
                 if guid in platform_mappings[current_platform]:
                     g.write(
                         "// WARNING - DATABASE {} OVERWROTE PRIOR MAPPING: {} {}\n".format(
-                            src_path, current_platform, platform_mappings[current_platform][guid]
+                            src_path,
+                            current_platform,
+                            platform_mappings[current_platform][guid],
                         )
                     )
                 platform_mappings[current_platform][guid] = line

--- a/methods.py
+++ b/methods.py
@@ -17,7 +17,11 @@ def add_source_files(self, sources, files):
         # Keep SCons project-absolute path as they are (no wildcard support)
         if files.startswith("#"):
             if "*" in files:
-                print("ERROR: Wildcards can't be expanded in SCons project-absolute path: '{}'".format(files))
+                print(
+                    "ERROR: Wildcards can't be expanded in SCons project-absolute path: '{}'".format(
+                        files
+                    )
+                )
                 return
             files = [files]
         else:
@@ -33,7 +37,11 @@ def add_source_files(self, sources, files):
     for path in files:
         obj = self.Object(path)
         if obj in sources:
-            print('WARNING: Object "{}" already included in environment sources.'.format(obj))
+            print(
+                'WARNING: Object "{}" already included in environment sources.'.format(
+                    obj
+                )
+            )
             continue
         sources.append(obj)
 
@@ -80,10 +88,19 @@ def update_version(module_version_string=""):
     godot_status = str(version.status)
     if os.getenv("GODOT_VERSION_STATUS") != None:
         godot_status = str(os.getenv("GODOT_VERSION_STATUS"))
-        print("Using version status '{}', overriding the original '{}'.".format(godot_status, str(version.status)))
+        print(
+            "Using version status '{}', overriding the original '{}'.".format(
+                godot_status, str(version.status)
+            )
+        )
     f.write('#define VERSION_STATUS "' + godot_status + '"\n')
     f.write('#define VERSION_BUILD "' + str(build_name) + '"\n')
-    f.write('#define VERSION_MODULE_CONFIG "' + str(version.module_config) + module_version_string + '"\n')
+    f.write(
+        '#define VERSION_MODULE_CONFIG "'
+        + str(version.module_config)
+        + module_version_string
+        + '"\n'
+    )
     f.write("#define VERSION_YEAR " + str(version.year) + "\n")
     f.write('#define VERSION_WEBSITE "' + str(version.website) + '"\n')
     f.close()
@@ -277,7 +294,9 @@ def convert_custom_modules_path(path):
     if not os.path.isdir(path):
         raise ValueError(err_msg % "point to an existing directory.")
     if path == os.path.realpath("modules"):
-        raise ValueError(err_msg % "be a directory other than built-in `modules` directory.")
+        raise ValueError(
+            err_msg % "be a directory other than built-in `modules` directory."
+        )
     return path
 
 
@@ -390,12 +409,19 @@ def split_lib(self, libname, src_list=None, env_lib=None):
     # impacts the linker call, we need to hack our way into the linking commands
     # LINKCOM and SHLINKCOM to set those flags.
 
-    if "-Wl,--start-group" in env["LINKCOM"] and "-Wl,--start-group" in env["SHLINKCOM"]:
+    if (
+        "-Wl,--start-group" in env["LINKCOM"]
+        and "-Wl,--start-group" in env["SHLINKCOM"]
+    ):
         # Already added by a previous call, skip.
         return
 
-    env["LINKCOM"] = str(env["LINKCOM"]).replace("$_LIBFLAGS", "-Wl,--start-group $_LIBFLAGS -Wl,--end-group")
-    env["SHLINKCOM"] = str(env["LINKCOM"]).replace("$_LIBFLAGS", "-Wl,--start-group $_LIBFLAGS -Wl,--end-group")
+    env["LINKCOM"] = str(env["LINKCOM"]).replace(
+        "$_LIBFLAGS", "-Wl,--start-group $_LIBFLAGS -Wl,--end-group"
+    )
+    env["SHLINKCOM"] = str(env["LINKCOM"]).replace(
+        "$_LIBFLAGS", "-Wl,--start-group $_LIBFLAGS -Wl,--end-group"
+    )
 
 
 def save_active_platforms(apnames, ap):
@@ -540,29 +566,40 @@ def detect_visual_c_compiler_version(tools_env):
 
         # find() works with -1 so big ifs below are needed... the simplest solution, in fact
         # First test if amd64 and amd64_x86 compilers are present in the path
-        vc_amd64_compiler_detection_index = tools_env["PATH"].find(tools_env["VCINSTALLDIR"] + "BIN\\amd64;")
+        vc_amd64_compiler_detection_index = tools_env["PATH"].find(
+            tools_env["VCINSTALLDIR"] + "BIN\\amd64;"
+        )
         if vc_amd64_compiler_detection_index > -1:
             vc_chosen_compiler_index = vc_amd64_compiler_detection_index
             vc_chosen_compiler_str = "amd64"
 
-        vc_amd64_x86_compiler_detection_index = tools_env["PATH"].find(tools_env["VCINSTALLDIR"] + "BIN\\amd64_x86;")
+        vc_amd64_x86_compiler_detection_index = tools_env["PATH"].find(
+            tools_env["VCINSTALLDIR"] + "BIN\\amd64_x86;"
+        )
         if vc_amd64_x86_compiler_detection_index > -1 and (
-            vc_chosen_compiler_index == -1 or vc_chosen_compiler_index > vc_amd64_x86_compiler_detection_index
+            vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_amd64_x86_compiler_detection_index
         ):
             vc_chosen_compiler_index = vc_amd64_x86_compiler_detection_index
             vc_chosen_compiler_str = "amd64_x86"
 
         # Now check the 32 bit compilers
-        vc_x86_compiler_detection_index = tools_env["PATH"].find(tools_env["VCINSTALLDIR"] + "BIN;")
+        vc_x86_compiler_detection_index = tools_env["PATH"].find(
+            tools_env["VCINSTALLDIR"] + "BIN;"
+        )
         if vc_x86_compiler_detection_index > -1 and (
-            vc_chosen_compiler_index == -1 or vc_chosen_compiler_index > vc_x86_compiler_detection_index
+            vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_x86_compiler_detection_index
         ):
             vc_chosen_compiler_index = vc_x86_compiler_detection_index
             vc_chosen_compiler_str = "x86"
 
-        vc_x86_amd64_compiler_detection_index = tools_env["PATH"].find(tools_env["VCINSTALLDIR"] + "BIN\\x86_amd64;")
+        vc_x86_amd64_compiler_detection_index = tools_env["PATH"].find(
+            tools_env["VCINSTALLDIR"] + "BIN\\x86_amd64;"
+        )
         if vc_x86_amd64_compiler_detection_index > -1 and (
-            vc_chosen_compiler_index == -1 or vc_chosen_compiler_index > vc_x86_amd64_compiler_detection_index
+            vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_x86_amd64_compiler_detection_index
         ):
             vc_chosen_compiler_index = vc_x86_amd64_compiler_detection_index
             vc_chosen_compiler_str = "x86_amd64"
@@ -571,35 +608,46 @@ def detect_visual_c_compiler_version(tools_env):
     if "VCTOOLSINSTALLDIR" in tools_env:
         # Newer versions have a different path available
         vc_amd64_compiler_detection_index = (
-            tools_env["PATH"].upper().find(tools_env["VCTOOLSINSTALLDIR"].upper() + "BIN\\HOSTX64\\X64;")
+            tools_env["PATH"]
+            .upper()
+            .find(tools_env["VCTOOLSINSTALLDIR"].upper() + "BIN\\HOSTX64\\X64;")
         )
         if vc_amd64_compiler_detection_index > -1:
             vc_chosen_compiler_index = vc_amd64_compiler_detection_index
             vc_chosen_compiler_str = "amd64"
 
         vc_amd64_x86_compiler_detection_index = (
-            tools_env["PATH"].upper().find(tools_env["VCTOOLSINSTALLDIR"].upper() + "BIN\\HOSTX64\\X86;")
+            tools_env["PATH"]
+            .upper()
+            .find(tools_env["VCTOOLSINSTALLDIR"].upper() + "BIN\\HOSTX64\\X86;")
         )
         if vc_amd64_x86_compiler_detection_index > -1 and (
-            vc_chosen_compiler_index == -1 or vc_chosen_compiler_index > vc_amd64_x86_compiler_detection_index
+            vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_amd64_x86_compiler_detection_index
         ):
             vc_chosen_compiler_index = vc_amd64_x86_compiler_detection_index
             vc_chosen_compiler_str = "amd64_x86"
 
         vc_x86_compiler_detection_index = (
-            tools_env["PATH"].upper().find(tools_env["VCTOOLSINSTALLDIR"].upper() + "BIN\\HOSTX86\\X86;")
+            tools_env["PATH"]
+            .upper()
+            .find(tools_env["VCTOOLSINSTALLDIR"].upper() + "BIN\\HOSTX86\\X86;")
         )
         if vc_x86_compiler_detection_index > -1 and (
-            vc_chosen_compiler_index == -1 or vc_chosen_compiler_index > vc_x86_compiler_detection_index
+            vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_x86_compiler_detection_index
         ):
             vc_chosen_compiler_index = vc_x86_compiler_detection_index
             vc_chosen_compiler_str = "x86"
 
         vc_x86_amd64_compiler_detection_index = (
-            tools_env["PATH"].upper().find(tools_env["VCTOOLSINSTALLDIR"].upper() + "BIN\\HOSTX86\\X64;")
+            tools_env["PATH"]
+            .upper()
+            .find(tools_env["VCTOOLSINSTALLDIR"].upper() + "BIN\\HOSTX86\\X64;")
         )
         if vc_x86_amd64_compiler_detection_index > -1 and (
-            vc_chosen_compiler_index == -1 or vc_chosen_compiler_index > vc_x86_amd64_compiler_detection_index
+            vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_x86_amd64_compiler_detection_index
         ):
             vc_chosen_compiler_index = vc_x86_amd64_compiler_detection_index
             vc_chosen_compiler_str = "x86_amd64"
@@ -608,7 +656,11 @@ def detect_visual_c_compiler_version(tools_env):
 
 
 def find_visual_c_batch_file(env):
-    from SCons.Tool.MSCommon.vc import get_default_version, get_host_target, find_batch_file
+    from SCons.Tool.MSCommon.vc import (
+        get_default_version,
+        get_host_target,
+        find_batch_file,
+    )
 
     # Syntax changed in SCons 4.4.0.
     from SCons import __version__ as scons_raw_version
@@ -695,7 +747,9 @@ def generate_vs_project(env, num_jobs):
             if env["custom_modules"]:
                 common_build_postfix.append("custom_modules=%s" % env["custom_modules"])
 
-            result = " ^& ".join(common_build_prefix + [" ".join([commands] + common_build_postfix)])
+            result = " ^& ".join(
+                common_build_prefix + [" ".join([commands] + common_build_postfix)]
+            )
             return result
 
         add_to_vs_project(env, env.core_sources)
@@ -720,9 +774,15 @@ def generate_vs_project(env, num_jobs):
         release_variants = ["release|Win32"] + ["release|x64"]
         release_debug_variants = ["release_debug|Win32"] + ["release_debug|x64"]
         variants = debug_variants + release_variants + release_debug_variants
-        debug_targets = ["bin\\rebel.windows.tools.32.exe"] + ["bin\\rebel.windows.tools.64.exe"]
-        release_targets = ["bin\\rebel.windows.opt.32.exe"] + ["bin\\rebel.windows.opt.64.exe"]
-        release_debug_targets = ["bin\\rebel.windows.opt.tools.32.exe"] + ["bin\\rebel.windows.opt.tools.64.exe"]
+        debug_targets = ["bin\\rebel.windows.tools.32.exe"] + [
+            "bin\\rebel.windows.tools.64.exe"
+        ]
+        release_targets = ["bin\\rebel.windows.opt.32.exe"] + [
+            "bin\\rebel.windows.opt.64.exe"
+        ]
+        release_debug_targets = ["bin\\rebel.windows.opt.tools.32.exe"] + [
+            "bin\\rebel.windows.opt.tools.64.exe"
+        ]
         targets = debug_targets + release_targets + release_debug_targets
         if not env.get("MSVS"):
             env["MSVS"]["PROJECTSUFFIX"] = ".vcxproj"
@@ -784,9 +844,19 @@ def get_darwin_sdk_version(platform):
         raise Exception("Invalid platform argument passed to get_darwin_sdk_version")
 
     try:
-        return float(decode_utf8(subprocess.check_output(["xcrun", "--sdk", sdk_name, "--show-sdk-version"]).strip()))
+        return float(
+            decode_utf8(
+                subprocess.check_output(
+                    ["xcrun", "--sdk", sdk_name, "--show-sdk-version"]
+                ).strip()
+            )
+        )
     except (subprocess.CalledProcessError, OSError):
-        print("Failed to find SDK version while running xcrun --sdk {} --show-sdk-version.".format(sdk_name))
+        print(
+            "Failed to find SDK version while running xcrun --sdk {} --show-sdk-version.".format(
+                sdk_name
+            )
+        )
         return 0.0
 
 
@@ -806,11 +876,19 @@ def detect_darwin_sdk_path(platform, env):
 
     if not env[var_name]:
         try:
-            sdk_path = decode_utf8(subprocess.check_output(["xcrun", "--sdk", sdk_name, "--show-sdk-path"]).strip())
+            sdk_path = decode_utf8(
+                subprocess.check_output(
+                    ["xcrun", "--sdk", sdk_name, "--show-sdk-path"]
+                ).strip()
+            )
             if sdk_path:
                 env[var_name] = sdk_path
         except (subprocess.CalledProcessError, OSError):
-            print("Failed to find SDK path while running xcrun --sdk {} --show-sdk-path.".format(sdk_name))
+            print(
+                "Failed to find SDK path while running xcrun --sdk {} --show-sdk-path.".format(
+                    sdk_name
+                )
+            )
             raise
 
 
@@ -823,7 +901,9 @@ def get_compiler_version(env):
         # Not using -dumpversion as some GCC distros only return major, and
         # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
         try:
-            version = decode_utf8(subprocess.check_output([env.subst(env["CXX"]), "--version"]).strip())
+            version = decode_utf8(
+                subprocess.check_output([env.subst(env["CXX"]), "--version"]).strip()
+            )
         except (subprocess.CalledProcessError, OSError):
             print("Couldn't parse CXX environment variable to infer compiler version.")
             return None
@@ -900,7 +980,10 @@ def show_progress(env):
                 return
             if env["verbose"]:
                 # Utter something
-                screen.write("\rPurging %d %s from cache...\n" % (len(files), len(files) > 1 and "files" or "file"))
+                screen.write(
+                    "\rPurging %d %s from cache...\n"
+                    % (len(files), len(files) > 1 and "files" or "file")
+                )
             [os.remove(f) for f in files]
 
         def file_list(self):
@@ -909,7 +992,10 @@ def show_progress(env):
                 return []
             # Gather a list of (filename, (size, atime)) within the
             # cache directory
-            file_stat = [(x, os.stat(x)[6:8]) for x in glob.glob(os.path.join(self.path, "*", "*"))]
+            file_stat = [
+                (x, os.stat(x)[6:8])
+                for x in glob.glob(os.path.join(self.path, "*", "*"))
+            ]
             if file_stat == []:
                 # Nothing to do
                 return []

--- a/misc/hooks/pre-commit-black
+++ b/misc/hooks/pre-commit-black
@@ -4,7 +4,7 @@
 
 # The application and options.
 application="black"
-options="-l 120"
+options=""
 
 # Files and file extensions to parse.
 include_files="SConstruct SCsub"

--- a/misc/hooks/pre-commit-style-check
+++ b/misc/hooks/pre-commit-style-check
@@ -112,11 +112,11 @@ while read -r file; do
     # and the format of these diffs are slightly different.
     case $application_name in
     "clang-format")
-        "$application" "$options" "$file" | \
+        "$application" ${options:+"$options"} "$file" | \
             diff -u "$file" - | \
             sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch_file";;
     "black")
-        "$application" "$options" --diff "$file" | \
+        "$application" ${options:+"$options"} --diff "$file" | \
             sed -e "1s|--- |--- a/|" -e "2s|+++ |+++ b/|" >> "$patch_file";;
     *)
         echo "Unrecognised application: $application_name."

--- a/misc/hooks/pre-commit-style-check
+++ b/misc/hooks/pre-commit-style-check
@@ -175,7 +175,7 @@ while true; do
                 response="N"
             fi
         elif [ -x "$xmessage" ]; then
-            $xmessage -file "$patch_file" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply this patch?"
+            $xmessage -file "$patch_file" -buttons "Apply:100,Apply and stage:200,Do not apply:0" -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply this patch?"
             exit_code=$?
             if [ "$exit_code" = "100" ]; then
                 response="Y"

--- a/misc/scripts/black_format.sh
+++ b/misc/scripts/black_format.sh
@@ -13,7 +13,7 @@ PY_FILES=$(find \( -path "./.git" \
                 -o -name "SCsub" \
                 -o -name "*.py" \
                 \) -print)
-black -l 120 $PY_FILES
+black $PY_FILES
 
 # If a diff has been created, notify the user and exit with error.
 if [[ $(git diff) ]]; then

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -11,7 +11,11 @@ env_modules = env.Clone()
 Export("env_modules")
 
 env.Depends("modules_enabled.gen.h", Value(env.module_list))
-env.CommandNoCache("modules_enabled.gen.h", Value(env.module_list), modules_builders.generate_modules_enabled)
+env.CommandNoCache(
+    "modules_enabled.gen.h",
+    Value(env.module_list),
+    modules_builders.generate_modules_enabled,
+)
 
 env.modules_sources = []
 env_modules.add_source_files(env.modules_sources, "register_module_types.gen.cpp")

--- a/modules/denoise/SCsub
+++ b/modules/denoise/SCsub
@@ -119,14 +119,18 @@ weights_in_path = thirdparty_dir + "weights/rtlightmap_hdr.tza"
 weights_out_path = thirdparty_dir + "weights/rtlightmap_hdr.gen.cpp"
 
 env_thirdparty.Depends(weights_out_path, weights_in_path)
-env_thirdparty.CommandNoCache(weights_out_path, weights_in_path, resource_to_cpp.tza_to_cpp)
+env_thirdparty.CommandNoCache(
+    weights_out_path, weights_in_path, resource_to_cpp.tza_to_cpp
+)
 
 # Godot source files
 
 module_obj = []
 
 env_oidn.add_source_files(module_obj, "denoise_wrapper.cpp")
-env_modules.add_source_files(module_obj, ["register_types.cpp", "lightmap_denoiser.cpp"])
+env_modules.add_source_files(
+    module_obj, ["register_types.cpp", "lightmap_denoiser.cpp"]
+)
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -98,7 +98,9 @@ if env["builtin_freetype"]:
     # and then plain strings for system library. We insert between the two.
     inserted = False
     for idx, linklib in enumerate(env["LIBS"]):
-        if isbasestring(linklib):  # first system lib such as "X11", otherwise SCons lib object
+        if isbasestring(
+            linklib
+        ):  # first system lib such as "X11", otherwise SCons lib object
             env["LIBS"].insert(idx, lib)
             inserted = True
             break

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -9,7 +9,9 @@ env_gdnative.add_source_files(env.modules_sources, "register_types.cpp")
 env_gdnative.add_source_files(env.modules_sources, "android/*.cpp")
 env_gdnative.add_source_files(env.modules_sources, "gdnative/*.cpp")
 env_gdnative.add_source_files(env.modules_sources, "nativescript/*.cpp")
-env_gdnative.add_source_files(env.modules_sources, "gdnative_library_singleton_editor.cpp")
+env_gdnative.add_source_files(
+    env.modules_sources, "gdnative_library_singleton_editor.cpp"
+)
 env_gdnative.add_source_files(env.modules_sources, "gdnative_library_editor_plugin.cpp")
 
 env_gdnative.Prepend(CPPPATH=["#modules/gdnative/include/"])

--- a/modules/gdnative/gdnative_builders.py
+++ b/modules/gdnative/gdnative_builders.py
@@ -12,19 +12,27 @@ def _spaced(e):
 
 
 def _build_gdnative_api_struct_header(api):
-    gdnative_api_init_macro = ["\textern const godot_gdnative_core_api_struct *_gdnative_wrapper_api_struct;"]
+    gdnative_api_init_macro = [
+        "\textern const godot_gdnative_core_api_struct *_gdnative_wrapper_api_struct;"
+    ]
 
     for ext in api["extensions"]:
         name = ext["name"]
         gdnative_api_init_macro.append(
-            "\textern const godot_gdnative_ext_{0}_api_struct *_gdnative_wrapper_{0}_api_struct;".format(name)
+            "\textern const godot_gdnative_ext_{0}_api_struct *_gdnative_wrapper_{0}_api_struct;".format(
+                name
+            )
         )
 
-    gdnative_api_init_macro.append("\t_gdnative_wrapper_api_struct = options->api_struct;")
+    gdnative_api_init_macro.append(
+        "\t_gdnative_wrapper_api_struct = options->api_struct;"
+    )
     gdnative_api_init_macro.append(
         "\tfor (unsigned int i = 0; i < _gdnative_wrapper_api_struct->num_extensions; i++) { "
     )
-    gdnative_api_init_macro.append("\t\tswitch (_gdnative_wrapper_api_struct->extensions[i]->type) {")
+    gdnative_api_init_macro.append(
+        "\t\tswitch (_gdnative_wrapper_api_struct->extensions[i]->type) {"
+    )
 
     for ext in api["extensions"]:
         name = ext["name"]
@@ -50,7 +58,9 @@ def _build_gdnative_api_struct_header(api):
         "#include <pluginscript/godot_pluginscript.h>",
         "#include <videodecoder/godot_videodecoder.h>",
         "",
-        "#define GDNATIVE_API_INIT(options) do {  \\\n" + "  \\\n".join(gdnative_api_init_macro) + "  \\\n } while (0)",
+        "#define GDNATIVE_API_INIT(options) do {  \\\n"
+        + "  \\\n".join(gdnative_api_init_macro)
+        + "  \\\n } while (0)",
         "",
         "#ifdef __cplusplus",
         'extern "C" {',
@@ -73,7 +83,13 @@ def _build_gdnative_api_struct_header(api):
         ret_val += [
             "typedef struct godot_gdnative_ext_"
             + name
-            + ("" if not include_version else ("_{0}_{1}".format(ext["version"]["major"], ext["version"]["minor"])))
+            + (
+                ""
+                if not include_version
+                else (
+                    "_{0}_{1}".format(ext["version"]["major"], ext["version"]["minor"])
+                )
+            )
             + "_api_struct {",
             "\tunsigned int type;",
             "\tgodot_gdnative_api_version version;",
@@ -81,13 +97,24 @@ def _build_gdnative_api_struct_header(api):
         ]
 
         for funcdef in ext["api"]:
-            args = ", ".join(["%s%s" % (_spaced(t), n) for t, n in funcdef["arguments"]])
-            ret_val.append("\t%s(*%s)(%s);" % (_spaced(funcdef["return_type"]), funcdef["name"], args))
+            args = ", ".join(
+                ["%s%s" % (_spaced(t), n) for t, n in funcdef["arguments"]]
+            )
+            ret_val.append(
+                "\t%s(*%s)(%s);"
+                % (_spaced(funcdef["return_type"]), funcdef["name"], args)
+            )
 
         ret_val += [
             "} godot_gdnative_ext_"
             + name
-            + ("" if not include_version else ("_{0}_{1}".format(ext["version"]["major"], ext["version"]["minor"])))
+            + (
+                ""
+                if not include_version
+                else (
+                    "_{0}_{1}".format(ext["version"]["major"], ext["version"]["minor"])
+                )
+            )
             + "_api_struct;",
             "",
         ]
@@ -109,8 +136,13 @@ def _build_gdnative_api_struct_header(api):
         ]
 
         for funcdef in core["api"]:
-            args = ", ".join(["%s%s" % (_spaced(t), n) for t, n in funcdef["arguments"]])
-            ret_val.append("\t%s(*%s)(%s);" % (_spaced(funcdef["return_type"]), funcdef["name"], args))
+            args = ", ".join(
+                ["%s%s" % (_spaced(t), n) for t, n in funcdef["arguments"]]
+            )
+            ret_val.append(
+                "\t%s(*%s)(%s);"
+                % (_spaced(funcdef["return_type"]), funcdef["name"], args)
+            )
 
         ret_val += [
             "} godot_gdnative_core_"
@@ -139,7 +171,9 @@ def _build_gdnative_api_struct_header(api):
 
     for funcdef in api["core"]["api"]:
         args = ", ".join(["%s%s" % (_spaced(t), n) for t, n in funcdef["arguments"]])
-        out.append("\t%s(*%s)(%s);" % (_spaced(funcdef["return_type"]), funcdef["name"], args))
+        out.append(
+            "\t%s(*%s)(%s);" % (_spaced(funcdef["return_type"]), funcdef["name"], args)
+        )
 
     out += [
         "} godot_gdnative_core_api_struct;",
@@ -155,13 +189,24 @@ def _build_gdnative_api_struct_header(api):
 
 
 def _build_gdnative_api_struct_source(api):
-    out = ["/* THIS FILE IS GENERATED DO NOT EDIT */", "", "#include <gdnative_api_struct.gen.h>", ""]
+    out = [
+        "/* THIS FILE IS GENERATED DO NOT EDIT */",
+        "",
+        "#include <gdnative_api_struct.gen.h>",
+        "",
+    ]
 
     def get_extension_struct_name(name, ext, include_version=True):
         return (
             "godot_gdnative_ext_"
             + name
-            + ("" if not include_version else ("_{0}_{1}".format(ext["version"]["major"], ext["version"]["minor"])))
+            + (
+                ""
+                if not include_version
+                else (
+                    "_{0}_{1}".format(ext["version"]["major"], ext["version"]["minor"])
+                )
+            )
             + "_api_struct"
         )
 
@@ -169,7 +214,13 @@ def _build_gdnative_api_struct_source(api):
         return (
             "api_extension_"
             + name
-            + ("" if not include_version else ("_{0}_{1}".format(ext["version"]["major"], ext["version"]["minor"])))
+            + (
+                ""
+                if not include_version
+                else (
+                    "_{0}_{1}".format(ext["version"]["major"], ext["version"]["minor"])
+                )
+            )
             + "_struct"
         )
 
@@ -186,12 +237,19 @@ def _build_gdnative_api_struct_source(api):
             + get_extension_struct_instance_name(name, ext, include_version)
             + " = {",
             "\tGDNATIVE_EXT_" + ext["type"] + ",",
-            "\t{" + str(ext["version"]["major"]) + ", " + str(ext["version"]["minor"]) + "},",
+            "\t{"
+            + str(ext["version"]["major"])
+            + ", "
+            + str(ext["version"]["minor"])
+            + "},",
             "\t"
             + (
                 "NULL"
                 if not ext["next"]
-                else ("(const godot_gdnative_api_struct *)&" + get_extension_struct_instance_name(name, ext["next"]))
+                else (
+                    "(const godot_gdnative_api_struct *)&"
+                    + get_extension_struct_instance_name(name, ext["next"])
+                )
             )
             + ",",
         ]
@@ -211,17 +269,26 @@ def _build_gdnative_api_struct_source(api):
 
         ret_val += [
             "extern const godot_gdnative_core_"
-            + ("{0}_{1}_api_struct api_{0}_{1}".format(core["version"]["major"], core["version"]["minor"]))
+            + (
+                "{0}_{1}_api_struct api_{0}_{1}".format(
+                    core["version"]["major"], core["version"]["minor"]
+                )
+            )
             + " = {",
             "\tGDNATIVE_" + core["type"] + ",",
-            "\t{" + str(core["version"]["major"]) + ", " + str(core["version"]["minor"]) + "},",
+            "\t{"
+            + str(core["version"]["major"])
+            + ", "
+            + str(core["version"]["minor"])
+            + "},",
             "\t"
             + (
                 "NULL"
                 if not core["next"]
                 else (
                     "(const godot_gdnative_api_struct *)& api_{0}_{1}".format(
-                        core["next"]["version"]["major"], core["next"]["version"]["minor"]
+                        core["next"]["version"]["major"],
+                        core["next"]["version"]["minor"],
                     )
                 )
             )
@@ -253,7 +320,11 @@ def _build_gdnative_api_struct_source(api):
     out += [
         "extern const godot_gdnative_core_api_struct api_struct = {",
         "\tGDNATIVE_" + api["core"]["type"] + ",",
-        "\t{" + str(api["core"]["version"]["major"]) + ", " + str(api["core"]["version"]["minor"]) + "},",
+        "\t{"
+        + str(api["core"]["version"]["major"])
+        + ", "
+        + str(api["core"]["version"]["minor"])
+        + "},",
         "\t(const godot_gdnative_api_struct *)&api_1_1,",
         "\t" + str(len(api["extensions"])) + ",",
         "\tgdnative_extensions_pointers,",
@@ -298,18 +369,28 @@ def _build_gdnative_wrapper_code(api):
 
     for ext in api["extensions"]:
         name = ext["name"]
-        out.append("godot_gdnative_ext_" + name + "_api_struct *_gdnative_wrapper_" + name + "_api_struct = 0;")
+        out.append(
+            "godot_gdnative_ext_"
+            + name
+            + "_api_struct *_gdnative_wrapper_"
+            + name
+            + "_api_struct = 0;"
+        )
 
     out += [""]
 
     for funcdef in api["core"]["api"]:
         args = ", ".join(["%s%s" % (_spaced(t), n) for t, n in funcdef["arguments"]])
-        out.append("%s%s(%s) {" % (_spaced(funcdef["return_type"]), funcdef["name"], args))
+        out.append(
+            "%s%s(%s) {" % (_spaced(funcdef["return_type"]), funcdef["name"], args)
+        )
 
         args = ", ".join(["%s" % n for t, n in funcdef["arguments"]])
 
         return_line = "\treturn " if funcdef["return_type"] != "void" else "\t"
-        return_line += "_gdnative_wrapper_api_struct->" + funcdef["name"] + "(" + args + ");"
+        return_line += (
+            "_gdnative_wrapper_api_struct->" + funcdef["name"] + "(" + args + ");"
+        )
 
         out.append(return_line)
         out.append("}")
@@ -318,13 +399,25 @@ def _build_gdnative_wrapper_code(api):
     for ext in api["extensions"]:
         name = ext["name"]
         for funcdef in ext["api"]:
-            args = ", ".join(["%s%s" % (_spaced(t), n) for t, n in funcdef["arguments"]])
-            out.append("%s%s(%s) {" % (_spaced(funcdef["return_type"]), funcdef["name"], args))
+            args = ", ".join(
+                ["%s%s" % (_spaced(t), n) for t, n in funcdef["arguments"]]
+            )
+            out.append(
+                "%s%s(%s) {" % (_spaced(funcdef["return_type"]), funcdef["name"], args)
+            )
 
             args = ", ".join(["%s" % n for t, n in funcdef["arguments"]])
 
             return_line = "\treturn " if funcdef["return_type"] != "void" else "\t"
-            return_line += "_gdnative_wrapper_" + name + "_api_struct->" + funcdef["name"] + "(" + args + ");"
+            return_line += (
+                "_gdnative_wrapper_"
+                + name
+                + "_api_struct->"
+                + funcdef["name"]
+                + "("
+                + args
+                + ");"
+            )
 
             out.append(return_line)
             out.append("}")

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -21,7 +21,9 @@ if env_mono["mono_glue"]:
     import os.path
 
     if not os.path.isfile("glue/mono_glue.gen.cpp"):
-        raise RuntimeError("Mono glue sources not found. Did you forget to run '--generate-mono-glue'?")
+        raise RuntimeError(
+            "Mono glue sources not found. Did you forget to run '--generate-mono-glue'?"
+        )
 
 # Configure Thread Local Storage
 
@@ -58,7 +60,9 @@ if env["platform"] in ["osx", "iphone"]:
     env_mono.add_source_files(env.modules_sources, "mono_gd/support/*.mm")
     env_mono.add_source_files(env.modules_sources, "mono_gd/support/*.m")
 elif env["platform"] == "android":
-    env_mono.add_source_files(env.modules_sources, "mono_gd/android_mono_config.gen.cpp")
+    env_mono.add_source_files(
+        env.modules_sources, "mono_gd/android_mono_config.gen.cpp"
+    )
 
 if env["tools"]:
     env_mono.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/mono/build_scripts/api_solution_build.py
+++ b/modules/mono/build_scripts/api_solution_build.py
@@ -18,12 +18,18 @@ def build_api_solution(source, target, env):
 
     from .solution_builder import build_solution
 
-    build_solution(env, solution_path, build_config, extra_msbuild_args=extra_msbuild_args)
+    build_solution(
+        env, solution_path, build_config, extra_msbuild_args=extra_msbuild_args
+    )
 
     # Copy targets
 
-    core_src_dir = os.path.abspath(os.path.join(solution_path, os.pardir, "GodotSharp", "bin", build_config))
-    editor_src_dir = os.path.abspath(os.path.join(solution_path, os.pardir, "GodotSharpEditor", "bin", build_config))
+    core_src_dir = os.path.abspath(
+        os.path.join(solution_path, os.pardir, "GodotSharp", "bin", build_config)
+    )
+    editor_src_dir = os.path.abspath(
+        os.path.join(solution_path, os.pardir, "GodotSharpEditor", "bin", build_config)
+    )
 
     dst_dir = os.path.abspath(os.path.join(str(target[0]), os.pardir))
 
@@ -64,10 +70,16 @@ def build(env_mono):
         output_dir = Dir("#bin").abspath
         editor_api_dir = os.path.join(output_dir, "GodotSharp", "Api", build_config)
 
-        targets = [os.path.join(editor_api_dir, filename) for filename in target_filenames]
+        targets = [
+            os.path.join(editor_api_dir, filename) for filename in target_filenames
+        ]
 
         cmd = env_mono.CommandNoCache(
-            targets, depend_cmd, build_api_solution, module_dir=os.getcwd(), solution_build_config=build_config
+            targets,
+            depend_cmd,
+            build_api_solution,
+            module_dir=os.getcwd(),
+            solution_build_config=build_config,
         )
         env_mono.AlwaysBuild(cmd)
 

--- a/modules/mono/build_scripts/gen_cs_glue_version.py
+++ b/modules/mono/build_scripts/gen_cs_glue_version.py
@@ -16,5 +16,7 @@ def generate_header(solution_dir, version_header_dst):
         version_header.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         version_header.write("#ifndef CS_GLUE_VERSION_H\n")
         version_header.write("#define CS_GLUE_VERSION_H\n\n")
-        version_header.write("#define CS_GLUE_VERSION UINT32_C(" + str(glue_version) + ")\n")
+        version_header.write(
+            "#define CS_GLUE_VERSION UINT32_C(" + str(glue_version) + ")\n"
+        )
         version_header.write("\n#endif // CS_GLUE_VERSION_H\n")

--- a/modules/mono/build_scripts/godot_tools_build.py
+++ b/modules/mono/build_scripts/godot_tools_build.py
@@ -32,7 +32,11 @@ def build(env_mono, api_sln_cmd):
     if env_mono["target"] == "debug":
         target_filenames += ["GodotTools.pdb"]
 
-    targets = [os.path.join(editor_tools_dir, filename) for filename in target_filenames]
+    targets = [
+        os.path.join(editor_tools_dir, filename) for filename in target_filenames
+    ]
 
-    cmd = env_mono.CommandNoCache(targets, api_sln_cmd, build_godot_tools, module_dir=os.getcwd())
+    cmd = env_mono.CommandNoCache(
+        targets, api_sln_cmd, build_godot_tools, module_dir=os.getcwd()
+    )
     env_mono.AlwaysBuild(cmd)

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -9,7 +9,12 @@ if os.name == "nt":
     from . import mono_reg_utils as monoreg
 
 
-android_arch_dirs = {"armv7": "armeabi-v7a", "arm64v8": "arm64-v8a", "x86": "x86", "x86_64": "x86_64"}
+android_arch_dirs = {
+    "armv7": "armeabi-v7a",
+    "arm64v8": "arm64-v8a",
+    "x86": "x86",
+    "x86_64": "x86_64",
+}
 
 
 def get_android_out_dir(env):
@@ -26,7 +31,9 @@ def find_name_in_dir_files(directory, names, prefixes=[""], extensions=[""]):
             extension = "." + extension
         for prefix in prefixes:
             for curname in names:
-                if os.path.isfile(os.path.join(directory, prefix + curname + extension)):
+                if os.path.isfile(
+                    os.path.join(directory, prefix + curname + extension)
+                ):
                     return curname
     return ""
 
@@ -98,20 +105,29 @@ def configure(env, env_mono):
     mono_lib_names = ["mono-2.0-sgen", "monosgen-2.0"]
 
     if is_android and not env["android_arch"] in android_arch_dirs:
-        raise RuntimeError("This module does not support the specified 'android_arch': " + env["android_arch"])
+        raise RuntimeError(
+            "This module does not support the specified 'android_arch': "
+            + env["android_arch"]
+        )
 
     if tools_enabled and not module_supports_tools_on(env["platform"]):
         # TODO:
         # Android: We have to add the data directory to the apk, concretely the Api and Tools folders.
-        raise RuntimeError("This module does not currently support building for this platform with tools enabled")
+        raise RuntimeError(
+            "This module does not currently support building for this platform with tools enabled"
+        )
 
     if is_android and mono_static:
         # FIXME: When static linking and doing something that requires libmono-native, we get a dlopen error as 'libmono-native'
         # seems to depend on 'libmonosgen-2.0'. Could be fixed by re-directing to '__Internal' with a dllmap or in the dlopen hook.
-        raise RuntimeError("Statically linking Mono is not currently supported for this platform")
+        raise RuntimeError(
+            "Statically linking Mono is not currently supported for this platform"
+        )
 
     if not mono_static and (is_javascript or is_ios):
-        raise RuntimeError("Dynamically linking Mono is not currently supported for this platform")
+        raise RuntimeError(
+            "Dynamically linking Mono is not currently supported for this platform"
+        )
 
     if not mono_prefix and (os.getenv("MONO32_PREFIX") or os.getenv("MONO64_PREFIX")):
         print(
@@ -162,10 +178,14 @@ def configure(env, env_mono):
             else:
                 mono_static_lib_name = "libmonosgen-2.0"
 
-            mono_static_lib_file = find_file_in_dir(mono_lib_path, [mono_static_lib_name], extensions=lib_suffixes)
+            mono_static_lib_file = find_file_in_dir(
+                mono_lib_path, [mono_static_lib_name], extensions=lib_suffixes
+            )
 
             if not mono_static_lib_file:
-                raise RuntimeError("Could not find static mono library in: " + mono_lib_path)
+                raise RuntimeError(
+                    "Could not find static mono library in: " + mono_lib_path
+                )
 
             if env.msvc:
                 env.Append(LINKFLAGS=mono_static_lib_file)
@@ -175,14 +195,25 @@ def configure(env, env_mono):
                 env.Append(LINKFLAGS="LIBCMT.lib")
                 env.Append(LINKFLAGS="Psapi.lib")
             else:
-                mono_static_lib_file_path = os.path.join(mono_lib_path, mono_static_lib_file)
-                env.Append(LINKFLAGS=["-Wl,-whole-archive", mono_static_lib_file_path, "-Wl,-no-whole-archive"])
+                mono_static_lib_file_path = os.path.join(
+                    mono_lib_path, mono_static_lib_file
+                )
+                env.Append(
+                    LINKFLAGS=[
+                        "-Wl,-whole-archive",
+                        mono_static_lib_file_path,
+                        "-Wl,-no-whole-archive",
+                    ]
+                )
 
                 env.Append(LIBS=["psapi"])
                 env.Append(LIBS=["version"])
         else:
             mono_lib_name = find_name_in_dir_files(
-                mono_lib_path, mono_lib_names, prefixes=["", "lib"], extensions=lib_suffixes
+                mono_lib_path,
+                mono_lib_names,
+                prefixes=["", "lib"],
+                extensions=lib_suffixes,
             )
 
             if not mono_lib_name:
@@ -195,10 +226,14 @@ def configure(env, env_mono):
 
             mono_bin_path = os.path.join(mono_root, "bin")
 
-            mono_dll_file = find_file_in_dir(mono_bin_path, mono_lib_names, prefixes=["", "lib"], extensions=[".dll"])
+            mono_dll_file = find_file_in_dir(
+                mono_bin_path, mono_lib_names, prefixes=["", "lib"], extensions=[".dll"]
+            )
 
             if not mono_dll_file:
-                raise RuntimeError("Could not find mono shared library in: " + mono_bin_path)
+                raise RuntimeError(
+                    "Could not find mono shared library in: " + mono_bin_path
+                )
 
             copy_file(mono_bin_path, "#bin", mono_dll_file)
     else:
@@ -218,7 +253,10 @@ def configure(env, env_mono):
 
         if not mono_root and is_macos:
             # Try with some known directories under OSX
-            hint_dirs = ["/Library/Frameworks/Mono.framework/Versions/Current", "/usr/local/var/homebrew/linked/mono"]
+            hint_dirs = [
+                "/Library/Frameworks/Mono.framework/Versions/Current",
+                "/usr/local/var/homebrew/linked/mono",
+            ]
             for hint_dir in hint_dirs:
                 if os.path.isdir(hint_dir):
                     mono_root = hint_dir
@@ -245,7 +283,9 @@ def configure(env, env_mono):
             env.Append(LIBPATH=[mono_lib_path])
             env_mono.Prepend(CPPPATH=os.path.join(mono_root, "include", "mono-2.0"))
 
-            mono_lib = find_name_in_dir_files(mono_lib_path, mono_lib_names, prefixes=["lib"], extensions=[".a"])
+            mono_lib = find_name_in_dir_files(
+                mono_lib_path, mono_lib_names, prefixes=["lib"], extensions=[".a"]
+            )
 
             if not mono_lib:
                 raise RuntimeError("Could not find mono library in: " + mono_lib_path)
@@ -292,10 +332,23 @@ def configure(env, env_mono):
                             copy_mono_lib("libmono-ilgen")
                 else:
                     assert is_desktop(env["platform"]) or is_android or is_javascript
-                    env.Append(LINKFLAGS=["-Wl,-whole-archive", mono_lib_file, "-Wl,-no-whole-archive"])
+                    env.Append(
+                        LINKFLAGS=[
+                            "-Wl,-whole-archive",
+                            mono_lib_file,
+                            "-Wl,-no-whole-archive",
+                        ]
+                    )
 
                 if is_javascript:
-                    env.Append(LIBS=["mono-icall-table", "mono-native", "mono-ilgen", "mono-ee-interp"])
+                    env.Append(
+                        LIBS=[
+                            "mono-icall-table",
+                            "mono-native",
+                            "mono-ilgen",
+                            "mono-ee-interp",
+                        ]
+                    )
 
                     wasm_src_dir = os.path.join(mono_root, "src")
                     if not os.path.isdir(wasm_src_dir):
@@ -339,11 +392,16 @@ def configure(env, env_mono):
 
             if not mono_static:
                 mono_so_file = find_file_in_dir(
-                    mono_lib_path, mono_lib_names, prefixes=["lib"], extensions=[sharedlib_ext]
+                    mono_lib_path,
+                    mono_lib_names,
+                    prefixes=["lib"],
+                    extensions=[sharedlib_ext],
                 )
 
                 if not mono_so_file:
-                    raise RuntimeError("Could not find mono shared library in: " + mono_lib_path)
+                    raise RuntimeError(
+                        "Could not find mono shared library in: " + mono_lib_path
+                    )
         else:
             assert not mono_static
 
@@ -358,14 +416,21 @@ def configure(env, env_mono):
             tmpenv.ParseConfig("pkg-config monosgen-2 --libs-only-L")
 
             for hint_dir in tmpenv["LIBPATH"]:
-                file_found = find_file_in_dir(hint_dir, mono_lib_names, prefixes=["lib"], extensions=[sharedlib_ext])
+                file_found = find_file_in_dir(
+                    hint_dir,
+                    mono_lib_names,
+                    prefixes=["lib"],
+                    extensions=[sharedlib_ext],
+                )
                 if file_found:
                     mono_lib_path = hint_dir
                     mono_so_file = file_found
                     break
 
             if not mono_so_file:
-                raise RuntimeError("Could not find mono shared library in: " + str(tmpenv["LIBPATH"]))
+                raise RuntimeError(
+                    "Could not find mono shared library in: " + str(tmpenv["LIBPATH"])
+                )
 
         if not mono_static:
             libs_output_dir = get_android_out_dir(env) if is_android else "#bin"
@@ -375,7 +440,11 @@ def configure(env, env_mono):
         if is_desktop(env["platform"]):
             if not mono_root:
                 mono_root = (
-                    subprocess.check_output(["pkg-config", "mono-2", "--variable=prefix"]).decode("utf8").strip()
+                    subprocess.check_output(
+                        ["pkg-config", "mono-2", "--variable=prefix"]
+                    )
+                    .decode("utf8")
+                    .strip()
                 )
 
             make_template_dir(env, mono_root)
@@ -384,8 +453,12 @@ def configure(env, env_mono):
             from . import make_android_mono_config
 
             module_dir = os.getcwd()
-            config_file_path = os.path.join(module_dir, "build_scripts", "mono_android_config.xml")
-            make_android_mono_config.generate_compressed_config(config_file_path, "mono_gd/")
+            config_file_path = os.path.join(
+                module_dir, "build_scripts", "mono_android_config.xml"
+            )
+            make_android_mono_config.generate_compressed_config(
+                config_file_path, "mono_gd/"
+            )
 
             # Copy the required shared libraries
             copy_mono_shared_libs(env, mono_root, None)
@@ -396,7 +469,11 @@ def configure(env, env_mono):
 
     if copy_mono_root:
         if not mono_root:
-            mono_root = subprocess.check_output(["pkg-config", "mono-2", "--variable=prefix"]).decode("utf8").strip()
+            mono_root = (
+                subprocess.check_output(["pkg-config", "mono-2", "--variable=prefix"])
+                .decode("utf8")
+                .strip()
+            )
 
         if tools_enabled:
             # Only supported for editor builds.
@@ -462,7 +539,9 @@ def copy_mono_root_files(env, mono_root, mono_bcl):
     mono_framework_facades_dir = os.path.join(mono_framework_dir, "Facades")
 
     editor_mono_framework_dir = os.path.join(editor_mono_root_dir, "lib", "mono", "4.5")
-    editor_mono_framework_facades_dir = os.path.join(editor_mono_framework_dir, "Facades")
+    editor_mono_framework_facades_dir = os.path.join(
+        editor_mono_framework_dir, "Facades"
+    )
 
     if not os.path.isdir(editor_mono_framework_dir):
         os.makedirs(editor_mono_framework_dir)
@@ -498,11 +577,20 @@ def copy_mono_etc_dir(mono_root, target_mono_config_dir, platform):
         if not mono_etc_dir:
             raise RuntimeError("Mono installation etc directory not found")
 
-    copy_tree(os.path.join(mono_etc_dir, "2.0"), os.path.join(target_mono_config_dir, "2.0"))
-    copy_tree(os.path.join(mono_etc_dir, "4.0"), os.path.join(target_mono_config_dir, "4.0"))
-    copy_tree(os.path.join(mono_etc_dir, "4.5"), os.path.join(target_mono_config_dir, "4.5"))
+    copy_tree(
+        os.path.join(mono_etc_dir, "2.0"), os.path.join(target_mono_config_dir, "2.0")
+    )
+    copy_tree(
+        os.path.join(mono_etc_dir, "4.0"), os.path.join(target_mono_config_dir, "4.0")
+    )
+    copy_tree(
+        os.path.join(mono_etc_dir, "4.5"), os.path.join(target_mono_config_dir, "4.5")
+    )
     if os.path.isdir(os.path.join(mono_etc_dir, "mconfig")):
-        copy_tree(os.path.join(mono_etc_dir, "mconfig"), os.path.join(target_mono_config_dir, "mconfig"))
+        copy_tree(
+            os.path.join(mono_etc_dir, "mconfig"),
+            os.path.join(target_mono_config_dir, "mconfig"),
+        )
 
     for file in glob(os.path.join(mono_etc_dir, "*")):
         if os.path.isfile(file):
@@ -526,7 +614,10 @@ def copy_mono_shared_libs(env, mono_root, target_mono_root_dir):
             os.makedirs(target_mono_bin_dir)
 
         mono_posix_helper_file = find_file_in_dir(
-            src_mono_bin_dir, ["MonoPosixHelper"], prefixes=["", "lib"], extensions=[".dll"]
+            src_mono_bin_dir,
+            ["MonoPosixHelper"],
+            prefixes=["", "lib"],
+            extensions=[".dll"],
         )
         copy(
             os.path.join(src_mono_bin_dir, mono_posix_helper_file),
@@ -539,7 +630,9 @@ def copy_mono_shared_libs(env, mono_root, target_mono_root_dir):
             copy(btls_dll_path, target_mono_bin_dir)
     else:
         target_mono_lib_dir = (
-            get_android_out_dir(env) if platform == "android" else os.path.join(target_mono_root_dir, "lib")
+            get_android_out_dir(env)
+            if platform == "android"
+            else os.path.join(target_mono_root_dir, "lib")
         )
 
         if not os.path.isdir(target_mono_lib_dir):
@@ -549,9 +642,14 @@ def copy_mono_shared_libs(env, mono_root, target_mono_root_dir):
 
         lib_file_names = []
         if platform == "osx":
-            lib_file_names = [lib_name + ".dylib" for lib_name in ["libmono-btls-shared", "libMonoPosixHelper"]]
+            lib_file_names = [
+                lib_name + ".dylib"
+                for lib_name in ["libmono-btls-shared", "libMonoPosixHelper"]
+            ]
 
-            if os.path.isfile(os.path.join(src_mono_lib_dir, "libmono-native-compat.dylib")):
+            if os.path.isfile(
+                os.path.join(src_mono_lib_dir, "libmono-native-compat.dylib")
+            ):
                 lib_file_names += ["libmono-native-compat.dylib"]
             else:
                 lib_file_names += ["libmono-native.dylib"]
@@ -571,7 +669,9 @@ def copy_mono_shared_libs(env, mono_root, target_mono_root_dir):
             ]
 
         for lib_file_name in lib_file_names:
-            copy_if_exists(os.path.join(src_mono_lib_dir, lib_file_name), target_mono_lib_dir)
+            copy_if_exists(
+                os.path.join(src_mono_lib_dir, lib_file_name), target_mono_lib_dir
+            )
 
 
 def pkgconfig_try_find_mono_root(mono_lib_names, sharedlib_ext):
@@ -579,7 +679,11 @@ def pkgconfig_try_find_mono_root(mono_lib_names, sharedlib_ext):
     tmpenv.AppendENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
     tmpenv.ParseConfig("pkg-config monosgen-2 --libs-only-L")
     for hint_dir in tmpenv["LIBPATH"]:
-        name_found = find_name_in_dir_files(hint_dir, mono_lib_names, prefixes=["lib"], extensions=[sharedlib_ext])
-        if name_found and os.path.isdir(os.path.join(hint_dir, "..", "include", "mono-2.0")):
+        name_found = find_name_in_dir_files(
+            hint_dir, mono_lib_names, prefixes=["lib"], extensions=[sharedlib_ext]
+        )
+        if name_found and os.path.isdir(
+            os.path.join(hint_dir, "..", "include", "mono-2.0")
+        ):
             return os.path.join(hint_dir, "..")
     return ""

--- a/modules/mono/build_scripts/mono_reg_utils.py
+++ b/modules/mono/build_scripts/mono_reg_utils.py
@@ -76,7 +76,13 @@ def find_msbuild_tools_path_reg():
         vswhere = os.getenv("PROGRAMFILES")
     vswhere += r"\Microsoft Visual Studio\Installer\vswhere.exe"
 
-    vswhere_args = ["-latest", "-products", "*", "-requires", "Microsoft.Component.MSBuild"]
+    vswhere_args = [
+        "-latest",
+        "-products",
+        "*",
+        "-requires",
+        "Microsoft.Component.MSBuild",
+    ]
 
     try:
         lines = subprocess.check_output([vswhere] + vswhere_args).splitlines()

--- a/modules/mono/build_scripts/solution_builder.py
+++ b/modules/mono/build_scripts/solution_builder.py
@@ -16,7 +16,9 @@ def find_dotnet_cli():
             hint_path = os.path.join(hint_dir, "dotnet")
             if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
                 return hint_path
-            if os.path.isfile(hint_path + ".exe") and os.access(hint_path + ".exe", os.X_OK):
+            if os.path.isfile(hint_path + ".exe") and os.access(
+                hint_path + ".exe", os.X_OK
+            ):
                 return hint_path + ".exe"
     else:
         for hint_dir in os.environ["PATH"].split(os.pathsep):
@@ -49,7 +51,9 @@ def find_msbuild_unix():
         hint_path = os.path.join(hint_dir, "msbuild")
         if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
             return hint_path
-        if os.path.isfile(hint_path + ".exe") and os.access(hint_path + ".exe", os.X_OK):
+        if os.path.isfile(hint_path + ".exe") and os.access(
+            hint_path + ".exe", os.X_OK
+        ):
             return hint_path + ".exe"
 
     return None
@@ -142,7 +146,12 @@ def build_solution(env, solution_path, build_config, extra_msbuild_args=[]):
 
     # Build solution
 
-    msbuild_args += [solution_path, "/restore", "/t:Build", "/p:Configuration=" + build_config]
+    msbuild_args += [
+        solution_path,
+        "/restore",
+        "/t:Build",
+        "/p:Configuration=" + build_config,
+    ]
     msbuild_args += extra_msbuild_args
 
     run_command(msbuild_path, msbuild_args, env_override=msbuild_env, name="msbuild")

--- a/modules/mono/build_scripts/tls_configure.py
+++ b/modules/mono/build_scripts/tls_configure.py
@@ -7,14 +7,18 @@ def supported(result):
 
 def check_cxx11_thread_local(conf):
     print("Checking for `thread_local` support...", end=" ")
-    result = conf.TryCompile("thread_local int foo = 0; int main() { return foo; }", ".cpp")
+    result = conf.TryCompile(
+        "thread_local int foo = 0; int main() { return foo; }", ".cpp"
+    )
     print(supported(result))
     return bool(result)
 
 
 def check_declspec_thread(conf):
     print("Checking for `__declspec(thread)` support...", end=" ")
-    result = conf.TryCompile("__declspec(thread) int foo = 0; int main() { return foo; }", ".cpp")
+    result = conf.TryCompile(
+        "__declspec(thread) int foo = 0; int main() { return foo; }", ".cpp"
+    )
     print(supported(result))
     return bool(result)
 

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -1,4 +1,13 @@
-supported_platforms = ["windows", "osx", "x11", "server", "android", "haiku", "javascript", "iphone"]
+supported_platforms = [
+    "windows",
+    "osx",
+    "x11",
+    "server",
+    "android",
+    "haiku",
+    "javascript",
+    "iphone",
+]
 
 
 def can_build(env, platform):
@@ -9,7 +18,9 @@ def configure(env):
     platform = env["platform"]
 
     if platform not in supported_platforms:
-        raise RuntimeError("This module does not currently support building for this platform")
+        raise RuntimeError(
+            "This module does not currently support building for this platform"
+        )
 
     env.use_ptrcall = True
     env.add_module_version_string("mono")
@@ -36,17 +47,25 @@ def configure(env):
             PathVariable.PathAccept,
         )
     )
-    envvars.Add(BoolVariable("mono_static", "Statically link Mono", default_mono_static))
+    envvars.Add(
+        BoolVariable("mono_static", "Statically link Mono", default_mono_static)
+    )
     envvars.Add(BoolVariable("mono_glue", "Build with the Mono glue sources", True))
     envvars.Add(BoolVariable("build_cil", "Build C# solutions", True))
     envvars.Add(
-        BoolVariable("copy_mono_root", "Make a copy of the Mono installation directory to bundle with the editor", True)
+        BoolVariable(
+            "copy_mono_root",
+            "Make a copy of the Mono installation directory to bundle with the editor",
+            True,
+        )
     )
 
     # TODO: It would be great if this could be detected automatically instead
     envvars.Add(
         BoolVariable(
-            "mono_bundles_zlib", "Specify if the Mono runtime was built with bundled zlib", default_mono_bundles_zlib
+            "mono_bundles_zlib",
+            "Specify if the Mono runtime was built with bundled zlib",
+            default_mono_bundles_zlib,
         )
     )
 

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -203,7 +203,9 @@ if env["builtin_opus"]:
             "silk/float/sort_FLP.c",
         ]
 
-    thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources + opus_sources_silk]
+    thirdparty_sources = [
+        thirdparty_dir + file for file in thirdparty_sources + opus_sources_silk
+    ]
 
     # also requires libogg
     if env["builtin_libogg"]:
@@ -219,7 +221,9 @@ if env["builtin_opus"]:
         "silk/fixed",
         "silk/float",
     ]
-    env_opus.Prepend(CPPPATH=[thirdparty_dir + "/" + dir for dir in thirdparty_include_paths])
+    env_opus.Prepend(
+        CPPPATH=[thirdparty_dir + "/" + dir for dir in thirdparty_include_paths]
+    )
 
     if env["platform"] == "android":
         if "android_arch" in env and env["android_arch"] == "armv7":

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -60,7 +60,14 @@ if env["builtin_embree"]:
     thirdparty_sources = [thirdparty_dir + file for file in embree_src]
 
     env_raycast.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "include"])
-    env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL", "NDEBUG"])
+    env_raycast.Append(
+        CPPDEFINES=[
+            "EMBREE_TARGET_SSE2",
+            "EMBREE_LOWEST_ISA",
+            "TASKING_INTERNAL",
+            "NDEBUG",
+        ]
+    )
 
     if not env.msvc:
         if env["arch"] in ["x86", "x86_64"]:

--- a/modules/raycast/godot_update_embree.py
+++ b/modules/raycast/godot_update_embree.py
@@ -72,7 +72,9 @@ if os.path.exists(dir_name):
 subprocess.run(["git", "clone", "https://github.com/embree/embree.git", "embree-tmp"])
 os.chdir("embree-tmp")
 
-commit_hash = str(subprocess.check_output(["git", "rev-parse", "HEAD"], universal_newlines=True)).strip()
+commit_hash = str(
+    subprocess.check_output(["git", "rev-parse", "HEAD"], universal_newlines=True)
+).strip()
 
 all_files = set(cpp_files)
 
@@ -181,11 +183,19 @@ with open(os.path.join(dest_dir, "kernels/config.h"), "w") as config_file:
 
 with open("CMakeLists.txt", "r") as cmake_file:
     cmake_content = cmake_file.read()
-    major_version = int(re.compile(r"EMBREE_VERSION_MAJOR\s(\d+)").findall(cmake_content)[0])
-    minor_version = int(re.compile(r"EMBREE_VERSION_MINOR\s(\d+)").findall(cmake_content)[0])
-    patch_version = int(re.compile(r"EMBREE_VERSION_PATCH\s(\d+)").findall(cmake_content)[0])
+    major_version = int(
+        re.compile(r"EMBREE_VERSION_MAJOR\s(\d+)").findall(cmake_content)[0]
+    )
+    minor_version = int(
+        re.compile(r"EMBREE_VERSION_MINOR\s(\d+)").findall(cmake_content)[0]
+    )
+    patch_version = int(
+        re.compile(r"EMBREE_VERSION_PATCH\s(\d+)").findall(cmake_content)[0]
+    )
 
-with open(os.path.join(dest_dir, "include/embree3/rtcore_config.h"), "w") as config_file:
+with open(
+    os.path.join(dest_dir, "include/embree3/rtcore_config.h"), "w"
+) as config_file:
     config_file.write(
         f"""
 // Copyright 2009-2021 Intel Corporation

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -26,7 +26,9 @@ if env["builtin_miniupnpc"]:
         "receivedata.c",
         "addr_is_reserved.c",
     ]
-    thirdparty_sources = [thirdparty_dir + "miniupnpc/" + file for file in thirdparty_sources]
+    thirdparty_sources = [
+        thirdparty_dir + "miniupnpc/" + file for file in thirdparty_sources
+    ]
 
     env_upnp.Prepend(CPPPATH=[thirdparty_dir])
     env_upnp.Append(CPPDEFINES=["MINIUPNP_STATICLIB"])

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -108,7 +108,10 @@ libvpx_sources_intrin_x86_sse2 = [
     "vpx_dsp/x86/loopfilter_sse2.c",
 ]
 libvpx_sources_intrin_x86_ssse3 = ["vpx_dsp/x86/vpx_subpixel_8t_intrin_ssse3.c"]
-libvpx_sources_intrin_x86_avx2 = ["vpx_dsp/x86/loopfilter_avx2.c", "vpx_dsp/x86/vpx_subpixel_8t_intrin_avx2.c"]
+libvpx_sources_intrin_x86_avx2 = [
+    "vpx_dsp/x86/loopfilter_avx2.c",
+    "vpx_dsp/x86/vpx_subpixel_8t_intrin_avx2.c",
+]
 libvpx_sources_x86asm = [
     "vp8/common/x86/copy_sse2.asm",
     "vp8/common/x86/copy_sse3.asm",
@@ -134,7 +137,10 @@ libvpx_sources_x86asm = [
     "vpx_dsp/x86/vpx_subpixel_bilinear_ssse3.asm",
     "vpx_ports/emms.asm",
 ]
-libvpx_sources_x86_64asm = ["vp8/common/x86/loopfilter_block_sse2_x86_64.asm", "vpx_dsp/x86/inv_txfm_ssse3_x86_64.asm"]
+libvpx_sources_x86_64asm = [
+    "vp8/common/x86/loopfilter_block_sse2_x86_64.asm",
+    "vpx_dsp/x86/inv_txfm_ssse3_x86_64.asm",
+]
 
 libvpx_sources_arm = [
     "vpx_ports/arm_cpudetect.c",
@@ -197,17 +203,31 @@ libvpx_sources_arm_neon_gas_apple = [
 libvpx_sources = [libvpx_dir + file for file in libvpx_sources]
 libvpx_sources_mt = [libvpx_dir + file for file in libvpx_sources_mt]
 libvpx_sources_intrin_x86 = [libvpx_dir + file for file in libvpx_sources_intrin_x86]
-libvpx_sources_intrin_x86_mmx = [libvpx_dir + file for file in libvpx_sources_intrin_x86_mmx]
-libvpx_sources_intrin_x86_sse2 = [libvpx_dir + file for file in libvpx_sources_intrin_x86_sse2]
-libvpx_sources_intrin_x86_ssse3 = [libvpx_dir + file for file in libvpx_sources_intrin_x86_ssse3]
-libvpx_sources_intrin_x86_avx2 = [libvpx_dir + file for file in libvpx_sources_intrin_x86_avx2]
+libvpx_sources_intrin_x86_mmx = [
+    libvpx_dir + file for file in libvpx_sources_intrin_x86_mmx
+]
+libvpx_sources_intrin_x86_sse2 = [
+    libvpx_dir + file for file in libvpx_sources_intrin_x86_sse2
+]
+libvpx_sources_intrin_x86_ssse3 = [
+    libvpx_dir + file for file in libvpx_sources_intrin_x86_ssse3
+]
+libvpx_sources_intrin_x86_avx2 = [
+    libvpx_dir + file for file in libvpx_sources_intrin_x86_avx2
+]
 libvpx_sources_x86asm = [libvpx_dir + file for file in libvpx_sources_x86asm]
 libvpx_sources_x86_64asm = [libvpx_dir + file for file in libvpx_sources_x86_64asm]
 libvpx_sources_arm = [libvpx_dir + file for file in libvpx_sources_arm]
 libvpx_sources_arm_neon = [libvpx_dir + file for file in libvpx_sources_arm_neon]
-libvpx_sources_arm_neon_gas = [libvpx_dir + file for file in libvpx_sources_arm_neon_gas]
-libvpx_sources_arm_neon_armasm_ms = [libvpx_dir + file for file in libvpx_sources_arm_neon_armasm_ms]
-libvpx_sources_arm_neon_gas_apple = [libvpx_dir + file for file in libvpx_sources_arm_neon_gas_apple]
+libvpx_sources_arm_neon_gas = [
+    libvpx_dir + file for file in libvpx_sources_arm_neon_gas
+]
+libvpx_sources_arm_neon_armasm_ms = [
+    libvpx_dir + file for file in libvpx_sources_arm_neon_armasm_ms
+]
+libvpx_sources_arm_neon_gas_apple = [
+    libvpx_dir + file for file in libvpx_sources_arm_neon_gas_apple
+]
 
 
 env_libvpx = env_modules.Clone()
@@ -224,15 +244,25 @@ if env["platform"] == "uwp":
         webm_cpu_arm = True
     else:
         webm_cpu_x86 = True
-elif env["platform"] != "windows":  # Disable for Windows, yasm SIMD optimizations trigger crash (GH-50862).
+elif (
+    env["platform"] != "windows"
+):  # Disable for Windows, yasm SIMD optimizations trigger crash (GH-50862).
     import platform
 
-    is_x11_or_server_arm = (env["platform"] == "x11" or env["platform"] == "server") and (
+    is_x11_or_server_arm = (
+        env["platform"] == "x11" or env["platform"] == "server"
+    ) and (
         platform.machine().startswith("arm") or platform.machine().startswith("aarch")
     )
-    is_macos_x86 = env["platform"] == "osx" and ("arch" in env and (env["arch"] != "arm64"))
-    is_ios_x86 = env["platform"] == "iphone" and ("arch" in env and env["arch"].startswith("x86"))
-    is_android_x86 = env["platform"] == "android" and env["android_arch"].startswith("x86")
+    is_macos_x86 = env["platform"] == "osx" and (
+        "arch" in env and (env["arch"] != "arm64")
+    )
+    is_ios_x86 = env["platform"] == "iphone" and (
+        "arch" in env and env["arch"].startswith("x86")
+    )
+    is_android_x86 = env["platform"] == "android" and env["android_arch"].startswith(
+        "x86"
+    )
     if is_android_x86:
         cpu_bits = "32" if env["android_arch"] == "x86" else "64"
     webm_cpu_x86 = (
@@ -269,7 +299,9 @@ if webm_cpu_x86:
     for yasm_path in yasm_paths:
         try:
             yasm_found = True
-            subprocess.Popen([yasm_path, "--version"], stdout=devnull, stderr=devnull).communicate()
+            subprocess.Popen(
+                [yasm_path, "--version"], stdout=devnull, stderr=devnull
+            ).communicate()
         except Exception:
             yasm_found = False
         if yasm_found:
@@ -323,7 +355,9 @@ if webm_cpu_arm:
     webm_simd_optimizations = True
 
 if webm_simd_optimizations == False and env["platform"] != "windows":
-    print("WebM SIMD optimizations are disabled. Check if your CPU architecture, CPU bits or platform are supported!")
+    print(
+        "WebM SIMD optimizations are disabled. Check if your CPU architecture, CPU bits or platform are supported!"
+    )
 
 env_libvpx.add_source_files(env.modules_sources, libvpx_sources)
 
@@ -332,7 +366,9 @@ if webm_multithread:
 
 if webm_cpu_x86:
     is_clang_or_gcc = (
-        ("gcc" in os.path.basename(env["CC"])) or ("clang" in os.path.basename(env["CC"])) or ("osxcross" in env)
+        ("gcc" in os.path.basename(env["CC"]))
+        or ("clang" in os.path.basename(env["CC"]))
+        or ("osxcross" in env)
     )
 
     env_libvpx_mmx = env_libvpx.Clone()
@@ -343,17 +379,23 @@ if webm_cpu_x86:
     env_libvpx_sse2 = env_libvpx.Clone()
     if cpu_bits == "32" and is_clang_or_gcc:
         env_libvpx_sse2.Append(CCFLAGS=["-msse2"])
-    env_libvpx_sse2.add_source_files(env.modules_sources, libvpx_sources_intrin_x86_sse2)
+    env_libvpx_sse2.add_source_files(
+        env.modules_sources, libvpx_sources_intrin_x86_sse2
+    )
 
     env_libvpx_ssse3 = env_libvpx.Clone()
     if is_clang_or_gcc:
         env_libvpx_ssse3.Append(CCFLAGS=["-mssse3"])
-    env_libvpx_ssse3.add_source_files(env.modules_sources, libvpx_sources_intrin_x86_ssse3)
+    env_libvpx_ssse3.add_source_files(
+        env.modules_sources, libvpx_sources_intrin_x86_ssse3
+    )
 
     env_libvpx_avx2 = env_libvpx.Clone()
     if is_clang_or_gcc:
         env_libvpx_avx2.Append(CCFLAGS=["-mavx2"])
-    env_libvpx_avx2.add_source_files(env.modules_sources, libvpx_sources_intrin_x86_avx2)
+    env_libvpx_avx2.add_source_files(
+        env.modules_sources, libvpx_sources_intrin_x86_avx2
+    )
 
     env_libvpx.add_source_files(env.modules_sources, libvpx_sources_intrin_x86)
 
@@ -364,15 +406,21 @@ elif webm_cpu_arm:
     env_libvpx.add_source_files(env.modules_sources, libvpx_sources_arm)
     if env["platform"] == "android":
         env_libvpx.Prepend(CPPPATH=[libvpx_dir + "third_party/android"])
-        env_libvpx.add_source_files(env.modules_sources, [libvpx_dir + "third_party/android/cpu-features.c"])
+        env_libvpx.add_source_files(
+            env.modules_sources, [libvpx_dir + "third_party/android/cpu-features.c"]
+        )
 
     env_libvpx_neon = env_libvpx.Clone()
     env_libvpx_neon.add_source_files(env.modules_sources, libvpx_sources_arm_neon)
 
     if env["platform"] == "uwp":
-        env_libvpx.add_source_files(env.modules_sources, libvpx_sources_arm_neon_armasm_ms)
+        env_libvpx.add_source_files(
+            env.modules_sources, libvpx_sources_arm_neon_armasm_ms
+        )
     elif env["platform"] == "iphone":
-        env_libvpx.add_source_files(env.modules_sources, libvpx_sources_arm_neon_gas_apple)
+        env_libvpx.add_source_files(
+            env.modules_sources, libvpx_sources_arm_neon_gas_apple
+        )
     elif (is_x11_or_server_arm and cpu_bits == "32") or (
         env["platform"] == "android" and not env["android_arch"] == "arm64v8"
     ):

--- a/modules/websocket/config.py
+++ b/modules/websocket/config.py
@@ -7,7 +7,12 @@ def configure(env):
 
 
 def get_doc_classes():
-    return ["WebSocketClient", "WebSocketMultiplayerPeer", "WebSocketPeer", "WebSocketServer"]
+    return [
+        "WebSocketClient",
+        "WebSocketMultiplayerPeer",
+        "WebSocketPeer",
+        "WebSocketServer",
+    ]
 
 
 def get_doc_path():

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -30,7 +30,9 @@ env_thirdparty.disable_warnings()
 thirdparty_obj = env_thirdparty.SharedObject("#thirdparty/misc/ifaddrs-android.cc")
 android_objects.append(thirdparty_obj)
 
-lib = env_android.add_shared_library("#bin/librebel", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
+lib = env_android.add_shared_library(
+    "#bin/librebel", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"]
+)
 
 # Needed to force rebuilding the platform files when the thirdparty code is updated.
 env.Depends(lib, thirdparty_obj)
@@ -45,7 +47,9 @@ elif env["android_arch"] == "x86":
 elif env["android_arch"] == "x86_64":
     lib_arch_dir = "x86_64"
 else:
-    print("WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin")
+    print(
+        "WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin"
+    )
 
 if lib_arch_dir != "":
     if env["target"] == "release":
@@ -55,10 +59,17 @@ if lib_arch_dir != "":
 
     out_dir = "#platform/android/java/lib/libs/" + lib_type_dir + "/" + lib_arch_dir
     env_android.Command(
-        out_dir + "/librebel_android.so", "#bin/librebel" + env["SHLIBSUFFIX"], Move("$TARGET", "$SOURCE")
+        out_dir + "/librebel_android.so",
+        "#bin/librebel" + env["SHLIBSUFFIX"],
+        Move("$TARGET", "$SOURCE"),
     )
 
     stl_lib_path = (
-        str(env["ANDROID_NDK_ROOT"]) + "/sources/cxx-stl/llvm-libc++/libs/" + lib_arch_dir + "/libc++_shared.so"
+        str(env["ANDROID_NDK_ROOT"])
+        + "/sources/cxx-stl/llvm-libc++/libs/"
+        + lib_arch_dir
+        + "/libc++_shared.so"
     )
-    env_android.Command(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
+    env_android.Command(
+        out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE")
+    )

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -21,8 +21,17 @@ def get_opts():
 
     return [
         ("ANDROID_SDK_ROOT", "Path to the Android SDK", get_env_android_sdk_root()),
-        ("ndk_platform", 'Target platform (android-<api>, e.g. "android-19")', "android-19"),
-        EnumVariable("android_arch", "Target architecture", "armv7", ("armv7", "arm64v8", "x86", "x86_64")),
+        (
+            "ndk_platform",
+            'Target platform (android-<api>, e.g. "android-19")',
+            "android-19",
+        ),
+        EnumVariable(
+            "android_arch",
+            "Target architecture",
+            "armv7",
+            ("armv7", "arm64v8", "x86", "x86_64"),
+        ),
         BoolVariable("android_neon", "Enable NEON support (armv7 only)", True),
     ]
 
@@ -118,7 +127,10 @@ def configure(env):
         bin_utils = target_triple
         env.extra_suffix = ".x86_64" + env.extra_suffix
 
-    target_option = ["-target", target_triple + str(get_min_sdk_version(env["ndk_platform"]))]
+    target_option = [
+        "-target",
+        target_triple + str(get_min_sdk_version(env["ndk_platform"])),
+    ]
     env.Append(CCFLAGS=target_option)
     env.Append(LINKFLAGS=target_option)
 
@@ -206,4 +218,6 @@ def configure(env):
 
     env.Prepend(CPPPATH=["#platform/android"])
     env.Append(CPPDEFINES=["ANDROID_ENABLED", "UNIX_ENABLED", "NO_FCNTL"])
-    env.Append(LIBS=["OpenSLES", "EGL", "GLESv3", "GLESv2", "android", "log", "z", "dl"])
+    env.Append(
+        LIBS=["OpenSLES", "EGL", "GLESv3", "GLESv2", "android", "log", "z", "dl"]
+    )

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -34,8 +34,14 @@ def combine_libs(target=None, source=None, env=None):
     else:
         libtool = "$IPHONEPATH/usr/bin/libtool"
     env.Execute(
-        libtool + ' -static -o "' + lib_path + '" ' + " ".join([('"' + lib.srcnode().abspath + '"') for lib in source])
+        libtool
+        + ' -static -o "'
+        + lib_path
+        + '" '
+        + " ".join([('"' + lib.srcnode().abspath + '"') for lib in source])
     )
 
 
-combine_command = env_ios.Command("#bin/librebel" + env_ios["LIBSUFFIX"], [ios_lib] + env_ios["LIBS"], combine_libs)
+combine_command = env_ios.Command(
+    "#bin/librebel" + env_ios["LIBSUFFIX"], [ios_lib] + env_ios["LIBS"], combine_libs
+)

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -70,7 +70,12 @@ def configure(env):
         env["bits"] = "32"
     elif env["arch"] == "x86_64":
         env["bits"] = "64"
-    elif env["arch"] == "arm" or env["arch"] == "arm32" or env["arch"] == "armv7" or env["bits"] == "32":  # arm
+    elif (
+        env["arch"] == "arm"
+        or env["arch"] == "arm32"
+        or env["arch"] == "armv7"
+        or env["bits"] == "32"
+    ):  # arm
         env["arch"] = "arm"
         env["bits"] = "32"
     else:  # armv64
@@ -184,7 +189,16 @@ def configure(env):
         ]
     )
 
-    env["ENV"]["CODESIGN_ALLOCATE"] = "/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate"
+    env["ENV"][
+        "CODESIGN_ALLOCATE"
+    ] = "/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate"
 
     env.Prepend(CPPPATH=["#platform/iphone"])
-    env.Append(CPPDEFINES=["IPHONE_ENABLED", "UNIX_ENABLED", "GLES_ENABLED", "COREAUDIO_ENABLED"])
+    env.Append(
+        CPPDEFINES=[
+            "IPHONE_ENABLED",
+            "UNIX_ENABLED",
+            "GLES_ENABLED",
+            "COREAUDIO_ENABLED",
+        ]
+    )

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -54,7 +54,9 @@ if env["gdnative_enabled"]:
 
     # The side library, containing all Godot code.
     wasm_env = env.Clone()
-    wasm_env.Append(CPPDEFINES=["WASM_GDNATIVE"])  # So that OS knows it can run GDNative libraries.
+    wasm_env.Append(
+        CPPDEFINES=["WASM_GDNATIVE"]
+    )  # So that OS knows it can run GDNative libraries.
     wasm_env.Append(CCFLAGS=["-s", "SIDE_MODULE=2"])
     wasm_env.Append(LINKFLAGS=["-s", "SIDE_MODULE=2"])
     wasm = wasm_env.add_program("#bin/rebel.side${PROGSUFFIX}.wasm", javascript_files)
@@ -65,7 +67,9 @@ else:
         build_targets.append("#bin/rebel${PROGSUFFIX}.worker.js")
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
     sys_env.Append(LIBS=["idbfs.js"])
-    build = sys_env.Program(build_targets, javascript_files + ["javascript_runtime.cpp"])
+    build = sys_env.Program(
+        build_targets, javascript_files + ["javascript_runtime.cpp"]
+    )
 
 sys_env.Depends(build[0], sys_env["JS_LIBS"])
 sys_env.Depends(build[0], sys_env["JS_PRE"])
@@ -84,7 +88,11 @@ wrap_list = [
     build[0],
     js_engine,
 ]
-js_wrapped = env.Textfile("#bin/rebel", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
+js_wrapped = env.Textfile(
+    "#bin/rebel",
+    [env.File(f) for f in wrap_list],
+    TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js",
+)
 
 # Extra will be the thread worker, or the GDNative side, or None
 extra = build[2] if len(build) > 2 else None

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -32,15 +32,29 @@ def get_opts():
         ("initial_memory", "Initial WASM memory (in MiB)", 32),
         BoolVariable("use_assertions", "Use Emscripten runtime assertions", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
-        BoolVariable("use_ubsan", "Use Emscripten undefined behavior sanitizer (UBSAN)", False),
+        BoolVariable(
+            "use_ubsan", "Use Emscripten undefined behavior sanitizer (UBSAN)", False
+        ),
         BoolVariable("use_asan", "Use Emscripten address sanitizer (ASAN)", False),
         BoolVariable("use_lsan", "Use Emscripten leak sanitizer (LSAN)", False),
         BoolVariable("use_safe_heap", "Use Emscripten SAFE_HEAP sanitizer", False),
         # eval() can be a security concern, so it can be disabled.
         BoolVariable("javascript_eval", "Enable JavaScript eval interface", True),
-        BoolVariable("threads_enabled", "Enable WebAssembly Threads support (limited browser support)", False),
-        BoolVariable("gdnative_enabled", "Enable WebAssembly GDNative support (produces bigger binaries)", False),
-        BoolVariable("use_closure_compiler", "Use closure compiler to minimize JavaScript code", False),
+        BoolVariable(
+            "threads_enabled",
+            "Enable WebAssembly Threads support (limited browser support)",
+            False,
+        ),
+        BoolVariable(
+            "gdnative_enabled",
+            "Enable WebAssembly GDNative support (produces bigger binaries)",
+            False,
+        ),
+        BoolVariable(
+            "use_closure_compiler",
+            "Use closure compiler to minimize JavaScript code",
+            False,
+        ),
     ]
 
 
@@ -88,7 +102,9 @@ def configure(env):
 
     if env["tools"]:
         if not env["threads_enabled"]:
-            print("Threads must be enabled to build the editor. Please add the 'threads_enabled=yes' option")
+            print(
+                "Threads must be enabled to build the editor. Please add the 'threads_enabled=yes' option"
+            )
             sys.exit(255)
         if env["initial_memory"] < 64:
             print("Editor build requires at least 64MiB of initial memory. Forcing it.")
@@ -131,7 +147,9 @@ def configure(env):
         # For emscripten support code.
         env.Append(LINKFLAGS=["--closure", "1"])
         # Register builder for our Engine files
-        jscc = env.Builder(generator=run_closure_compiler, suffix=".cc.js", src_suffix=".js")
+        jscc = env.Builder(
+            generator=run_closure_compiler, suffix=".cc.js", src_suffix=".js"
+        )
         env.Append(BUILDERS={"BuildJS": jscc})
 
     # Add helper method for adding libraries, externs, pre-js.
@@ -159,7 +177,11 @@ def configure(env):
 
     # Use TempFileMunge since some AR invocations are too long for cmd.exe.
     # Use POSIX-style paths, required with TempFileMunge.
-    env["ARCOM_POSIX"] = env["ARCOM"].replace("$TARGET", "$TARGET.posix").replace("$SOURCES", "$SOURCES.posix")
+    env["ARCOM_POSIX"] = (
+        env["ARCOM"]
+        .replace("$TARGET", "$TARGET.posix")
+        .replace("$SOURCES", "$SOURCES.posix")
+    )
     env["ARCOM"] = "${TEMPFILE(ARCOM_POSIX)}"
 
     # All intermediate files are just LLVM bitcode.
@@ -180,7 +202,9 @@ def configure(env):
         env.Append(CPPDEFINES=["JAVASCRIPT_EVAL_ENABLED"])
 
     if env["threads_enabled"] and env["gdnative_enabled"]:
-        print("Threads and GDNative support can't be both enabled due to WebAssembly limitations")
+        print(
+            "Threads and GDNative support can't be both enabled due to WebAssembly limitations"
+        )
         sys.exit(255)
 
     # Thread support (via SharedArrayBuffer).
@@ -197,7 +221,10 @@ def configure(env):
     if env["gdnative_enabled"]:
         major, minor, patch = get_compiler_version(env)
         if major < 2 or (major == 2 and minor == 0 and patch < 10):
-            print("GDNative support requires emscripten >= 2.0.10, detected: %s.%s.%s" % (major, minor, patch))
+            print(
+                "GDNative support requires emscripten >= 2.0.10, detected: %s.%s.%s"
+                % (major, minor, patch)
+            )
             sys.exit(255)
         env.Append(CCFLAGS=["-s", "RELOCATABLE=1"])
         env.Append(LINKFLAGS=["-s", "RELOCATABLE=1"])

--- a/platform/javascript/emscripten_helpers.py
+++ b/platform/javascript/emscripten_helpers.py
@@ -4,7 +4,12 @@ from SCons.Util import WhereIs
 
 
 def run_closure_compiler(target, source, env, for_signature):
-    closure_bin = os.path.join(os.path.dirname(WhereIs("emcc")), "node_modules", ".bin", "google-closure-compiler")
+    closure_bin = os.path.join(
+        os.path.dirname(WhereIs("emcc")),
+        "node_modules",
+        ".bin",
+        "google-closure-compiler",
+    )
     cmd = [WhereIs("node"), closure_bin]
     cmd.extend(["--compilation_level", "ADVANCED_OPTIMIZATIONS"])
     for f in env["JSEXTERNS"]:
@@ -79,7 +84,9 @@ def create_template_zip(env, js, wasm, extra):
             "@GODOT_OPT_CACHE@": json.dumps(opt_cache),
             "@GODOT_OFFLINE_PAGE@": "offline.html",
         }
-        html = env.Substfile(target="#bin/rebel${PROGSUFFIX}.html", source=html, SUBST_DICT=subst_dict)
+        html = env.Substfile(
+            target="#bin/rebel${PROGSUFFIX}.html", source=html, SUBST_DICT=subst_dict
+        )
         in_files.append(html)
         out_files.append(zip_dir.File(binary_name + ".html"))
         # And logo/favicon
@@ -89,7 +96,9 @@ def create_template_zip(env, js, wasm, extra):
         out_files.append(zip_dir.File("favicon.png"))
         # PWA
         service_worker = env.Substfile(
-            target="#bin/rebel${PROGSUFFIX}.service.worker.js", source=service_worker, SUBST_DICT=subst_dict
+            target="#bin/rebel${PROGSUFFIX}.service.worker.js",
+            source=service_worker,
+            SUBST_DICT=subst_dict,
         )
         in_files.append(service_worker)
         out_files.append(zip_dir.File("service.worker.js"))

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -24,13 +24,34 @@ def get_opts():
     return [
         ("osxcross_sdk", "OSXCross SDK version", "darwin14"),
         ("MACOS_SDK_PATH", "Path to the macOS SDK", ""),
-        EnumVariable("macports_clang", "Build using Clang from MacPorts", "no", ("no", "5.0", "devel")),
-        BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
-        BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
-        BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
-        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
+        EnumVariable(
+            "macports_clang",
+            "Build using Clang from MacPorts",
+            "no",
+            ("no", "5.0", "devel"),
+        ),
+        BoolVariable(
+            "debug_symbols",
+            "Add debugging symbols to release/release_debug builds",
+            True,
+        ),
+        BoolVariable(
+            "separate_debug_symbols",
+            "Create a separate file containing debugging symbols",
+            False,
+        ),
+        BoolVariable(
+            "use_ubsan",
+            "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)",
+            False,
+        ),
+        BoolVariable(
+            "use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False
+        ),
         BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
-        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
+        BoolVariable(
+            "use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False
+        ),
     ]
 
 
@@ -93,9 +114,13 @@ def configure(env):
             env["CC"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang"
             env["CXX"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang++"
             env["AR"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ar"
-            env["RANLIB"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ranlib"
+            env["RANLIB"] = (
+                mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ranlib"
+            )
             env["AS"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-as"
-            env.Append(CPPDEFINES=["__MACPORTS__"])  # hack to fix libvpx MM256_BROADCASTSI128_SI256 define
+            env.Append(
+                CPPDEFINES=["__MACPORTS__"]
+            )  # hack to fix libvpx MM256_BROADCASTSI128_SI256 define
         else:
             env["CC"] = "clang"
             env["CXX"] = "clang++"
@@ -123,7 +148,9 @@ def configure(env):
         env["AR"] = basecmd + "ar"
         env["RANLIB"] = basecmd + "ranlib"
         env["AS"] = basecmd + "as"
-        env.Append(CPPDEFINES=["__MACPORTS__"])  # hack to fix libvpx MM256_BROADCASTSI128_SI256 define
+        env.Append(
+            CPPDEFINES=["__MACPORTS__"]
+        )  # hack to fix libvpx MM256_BROADCASTSI128_SI256 define
 
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"]:
         env.extra_suffix += "s"

--- a/platform/osx/platform_osx_builders.py
+++ b/platform/osx/platform_osx_builders.py
@@ -11,7 +11,12 @@ def make_debug_osx(target, source, env):
     if env["macports_clang"] != "no":
         mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
         mpclangver = env["macports_clang"]
-        os.system(mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-dsymutil {0} -o {0}.dSYM".format(target[0]))
+        os.system(
+            mpprefix
+            + "/libexec/llvm-"
+            + mpclangver
+            + "/bin/llvm-dsymutil {0} -o {0}.dSYM".format(target[0])
+        )
     else:
         os.system("dsymutil {0} -o {0}.dSYM".format(target[0]))
     os.system("strip -u -r {0}".format(target[0]))

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -32,15 +32,39 @@ def get_opts():
 
     return [
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
-        BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True),
-        BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
-        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
+        BoolVariable(
+            "use_static_cpp",
+            "Link libgcc and libstdc++ statically for better portability",
+            True,
+        ),
+        BoolVariable(
+            "use_ubsan",
+            "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)",
+            False,
+        ),
+        BoolVariable(
+            "use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False
+        ),
         BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
-        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
-        BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
-        BoolVariable("use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False),
-        BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
-        BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
+        BoolVariable(
+            "use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False
+        ),
+        BoolVariable(
+            "debug_symbols",
+            "Add debugging symbols to release/release_debug builds",
+            True,
+        ),
+        BoolVariable(
+            "use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False
+        ),
+        BoolVariable(
+            "separate_debug_symbols",
+            "Create a separate file containing debugging symbols",
+            False,
+        ),
+        BoolVariable(
+            "execinfo", "Use libexecinfo on systems where glibc is not available", False
+        ),
     ]
 
 
@@ -99,7 +123,13 @@ def configure(env):
         env.extra_suffix = ".llvm" + env.extra_suffix
         env.Append(LIBS=["atomic"])
 
-    if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
+    if (
+        env["use_ubsan"]
+        or env["use_asan"]
+        or env["use_lsan"]
+        or env["use_tsan"]
+        or env["use_msan"]
+    ):
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
@@ -158,7 +188,9 @@ def configure(env):
 
         import subprocess
 
-        bullet_version = subprocess.check_output(["pkg-config", "bullet", "--modversion"]).strip()
+        bullet_version = subprocess.check_output(
+            ["pkg-config", "bullet", "--modversion"]
+        ).strip()
         if str(bullet_version) < min_bullet_version:
             # Abort as system bullet was requested but too old
             print(
@@ -231,7 +263,11 @@ def configure(env):
     # Embree is only compatible with x86_64. Yet another unreliable hack that will break
     # cross-compilation, this will really need to be handle better. Thankfully only affects
     # people who disable builtin_embree (likely distro packagers).
-    if env["tools"] and not env["builtin_embree"] and (is64 and platform.machine() == "x86_64"):
+    if (
+        env["tools"]
+        and not env["builtin_embree"]
+        and (is64 and platform.machine() == "x86_64")
+    ):
         # No pkgconfig file so far, hardcode expected lib name.
         env.Append(LIBS=["embree3"])
 
@@ -245,7 +281,17 @@ def configure(env):
     env.Append(CPPDEFINES=["SERVER_ENABLED", "UNIX_ENABLED"])
 
     if platform.system() == "Darwin":
-        env.Append(LINKFLAGS=["-framework", "Cocoa", "-framework", "Carbon", "-lz", "-framework", "IOKit"])
+        env.Append(
+            LINKFLAGS=[
+                "-framework",
+                "Cocoa",
+                "-framework",
+                "Carbon",
+                "-lz",
+                "-framework",
+                "IOKit",
+            ]
+        )
 
     env.Append(LIBS=["pthread"])
 

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -24,7 +24,11 @@ def can_build():
 
 def get_opts():
     return [
-        ("msvc_version", "MSVC version to use (ignored if the VCINSTALLDIR environment variable is set)", None),
+        (
+            "msvc_version",
+            "MSVC version to use (ignored if the VCINSTALLDIR environment variable is set)",
+            None,
+        ),
     ]
 
 
@@ -74,7 +78,11 @@ def configure(env):
     ## Compiler configuration
 
     env["ENV"] = os.environ
-    vc_base_path = os.environ["VCTOOLSINSTALLDIR"] if "VCTOOLSINSTALLDIR" in os.environ else os.environ["VCINSTALLDIR"]
+    vc_base_path = (
+        os.environ["VCTOOLSINSTALLDIR"]
+        if "VCTOOLSINSTALLDIR" in os.environ
+        else os.environ["VCINSTALLDIR"]
+    )
 
     # Force to use Unicode encoding
     env.AppendUnique(CCFLAGS=["/utf-8"])
@@ -98,7 +106,9 @@ def configure(env):
 
     arch = ""
     if str(os.getenv("Platform")).lower() == "arm":
-        print("Compiled program architecture will be an ARM executable. (forcing bits=32).")
+        print(
+            "Compiled program architecture will be an ARM executable. (forcing bits=32)."
+        )
 
         arch = "arm"
         env["bits"] = "32"
@@ -114,10 +124,14 @@ def configure(env):
 
         if compiler_version_str == "amd64" or compiler_version_str == "x86_amd64":
             env["bits"] = "64"
-            print("Compiled program architecture will be a x64 executable (forcing bits=64).")
+            print(
+                "Compiled program architecture will be a x64 executable (forcing bits=64)."
+            )
         elif compiler_version_str == "x86" or compiler_version_str == "amd64_x86":
             env["bits"] = "32"
-            print("Compiled program architecture will be a x86 executable. (forcing bits=32).")
+            print(
+                "Compiled program architecture will be a x86 executable. (forcing bits=32)."
+            )
         else:
             print(
                 "Failed to detect MSVC compiler architecture version... Defaulting to 32-bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup."
@@ -150,7 +164,14 @@ def configure(env):
 
     env.Prepend(CPPPATH=["#platform/uwp", "#drivers/windows"])
     env.Append(CPPDEFINES=["UWP_ENABLED", "WINDOWS_ENABLED", "TYPED_METHOD_BIND"])
-    env.Append(CPPDEFINES=["GLES_ENABLED", "GL_GLEXT_PROTOTYPES", "EGL_EGLEXT_PROTOTYPES", "ANGLE_ENABLED"])
+    env.Append(
+        CPPDEFINES=[
+            "GLES_ENABLED",
+            "GL_GLEXT_PROTOTYPES",
+            "EGL_EGLEXT_PROTOTYPES",
+            "ANGLE_ENABLED",
+        ]
+    )
     winver = "0x0602"  # Windows 8 is the minimum target for UWP build
     env.Append(CPPDEFINES=[("WINVER", winver), ("_WIN32_WINNT", winver), "WIN32"])
 
@@ -162,7 +183,9 @@ def configure(env):
     env.Append(
         CCFLAGS='/FS /MP /GS /wd"4453" /wd"28204" /wd"4291" /Zc:wchar_t /Gm- /fp:precise /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo'.split()
     )
-    env.Append(CPPDEFINES=["_UNICODE", "UNICODE", ("WINAPI_FAMILY", "WINAPI_FAMILY_APP")])
+    env.Append(
+        CPPDEFINES=["_UNICODE", "UNICODE", ("WINAPI_FAMILY", "WINAPI_FAMILY_APP")]
+    )
     env.Append(CXXFLAGS=["/ZW"])
     env.Append(
         CCFLAGS=[

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -32,4 +32,6 @@ if env["vsproj"]:
 
 if not os.getenv("VCINSTALLDIR"):
     if env["debug_symbols"] and env["separate_debug_symbols"]:
-        env.AddPostAction(prog, run_in_subprocess(platform_windows_builders.make_debug_mingw))
+        env.AddPostAction(
+            prog, run_in_subprocess(platform_windows_builders.make_debug_mingw)
+        )

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -63,14 +63,34 @@ def get_opts():
         # Targeted Windows version: 7 (and later), minimum supported version
         # XP support dropped after EOL due to missing API for IPv6 and other issues
         # Vista support dropped after EOL due to GH-10243
-        ("target_win_version", "Targeted Windows version, >= 0x0601 (Windows 7)", "0x0601"),
-        BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
-        BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
-        ("msvc_version", "MSVC version to use. Ignored if VCINSTALLDIR is set in shell env.", None),
-        BoolVariable("use_mingw", "Use the Mingw compiler, even if MSVC is installed.", False),
+        (
+            "target_win_version",
+            "Targeted Windows version, >= 0x0601 (Windows 7)",
+            "0x0601",
+        ),
+        BoolVariable(
+            "debug_symbols",
+            "Add debugging symbols to release/release_debug builds",
+            True,
+        ),
+        BoolVariable(
+            "separate_debug_symbols",
+            "Create a separate file containing debugging symbols",
+            False,
+        ),
+        (
+            "msvc_version",
+            "MSVC version to use. Ignored if VCINSTALLDIR is set in shell env.",
+            None,
+        ),
+        BoolVariable(
+            "use_mingw", "Use the Mingw compiler, even if MSVC is installed.", False
+        ),
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
-        BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True),
+        BoolVariable(
+            "use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True
+        ),
         BoolVariable("use_asan", "Use address sanitizer (ASAN)", False),
     ]
 
@@ -90,7 +110,9 @@ def build_res_file(target, source, env):
     for x in range(len(source)):
         cmd = cmdbase + "-i " + str(source[x]) + " -o " + str(target[x])
         try:
-            out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
+            out = subprocess.Popen(
+                cmd, shell=True, stderr=subprocess.PIPE
+            ).communicate()
             if len(out[1]):
                 return 1
         except Exception:
@@ -108,7 +130,9 @@ def setup_msvc_manual(env):
             argument (example: scons p=windows) and SCons will attempt to detect what MSVC compiler will be executed and inform you.
             """
         )
-        raise SCons.Errors.UserError("Bits argument should not be used when using VCINSTALLDIR")
+        raise SCons.Errors.UserError(
+            "Bits argument should not be used when using VCINSTALLDIR"
+        )
 
     # Force bits arg
     # (Actually msys2 mingw can support 64-bit, we could detect that)
@@ -123,9 +147,13 @@ def setup_msvc_manual(env):
     if compiler_version_str == "amd64" or compiler_version_str == "x86_amd64":
         env["bits"] = "64"
         env["x86_libtheora_opt_vc"] = False
-        print("Compiled program architecture will be a 64 bit executable (forcing bits=64).")
+        print(
+            "Compiled program architecture will be a 64 bit executable (forcing bits=64)."
+        )
     elif compiler_version_str == "x86" or compiler_version_str == "amd64_x86":
-        print("Compiled program architecture will be a 32 bit executable. (forcing bits=32).")
+        print(
+            "Compiled program architecture will be a 32 bit executable. (forcing bits=32)."
+        )
     else:
         print(
             "Failed to manually detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup, or avoid setting VCINSTALLDIR."
@@ -159,7 +187,10 @@ def setup_msvc_auto(env):
         env["bits"] = "64"
     else:
         env["bits"] = "32"
-    print("Found MSVC version %s, arch %s, bits=%s" % (env["MSVC_VERSION"], env["TARGET_ARCH"], env["bits"]))
+    print(
+        "Found MSVC version %s, arch %s, bits=%s"
+        % (env["MSVC_VERSION"], env["TARGET_ARCH"], env["bits"])
+    )
     if env["TARGET_ARCH"] in ("amd64", "x86_64"):
         env["x86_libtheora_opt_vc"] = False
 
@@ -392,9 +423,23 @@ def configure_mingw(env):
     ## Compile flags
 
     env.Append(CCFLAGS=["-mwindows"])
-    env.Append(LINKFLAGS=["-Wl,--nxcompat"])  # DEP protection. Not enabling ASLR for now, Mono crashes.
-    env.Append(CPPDEFINES=["WINDOWS_ENABLED", "OPENGL_ENABLED", "WASAPI_ENABLED", "WINMIDI_ENABLED"])
-    env.Append(CPPDEFINES=[("WINVER", env["target_win_version"]), ("_WIN32_WINNT", env["target_win_version"])])
+    env.Append(
+        LINKFLAGS=["-Wl,--nxcompat"]
+    )  # DEP protection. Not enabling ASLR for now, Mono crashes.
+    env.Append(
+        CPPDEFINES=[
+            "WINDOWS_ENABLED",
+            "OPENGL_ENABLED",
+            "WASAPI_ENABLED",
+            "WINMIDI_ENABLED",
+        ]
+    )
+    env.Append(
+        CPPDEFINES=[
+            ("WINVER", env["target_win_version"]),
+            ("_WIN32_WINNT", env["target_win_version"]),
+        ]
+    )
     env.Append(
         LIBS=[
             "mingw32",
@@ -424,7 +469,11 @@ def configure_mingw(env):
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
 
     # resrc
-    env.Append(BUILDERS={"RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")})
+    env.Append(
+        BUILDERS={
+            "RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")
+        }
+    )
 
 
 def configure(env):
@@ -434,7 +483,9 @@ def configure(env):
     print("Configuring for Windows: target=%s, bits=%s" % (env["target"], env["bits"]))
 
     if os.name == "nt":
-        env["ENV"] = os.environ  # this makes build less repeatable, but simplifies some things
+        env[
+            "ENV"
+        ] = os.environ  # this makes build less repeatable, but simplifies some things
         env["ENV"]["TMP"] = os.environ["TMP"]
 
     # First figure out which compiler, version, and target arch we're using

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -13,9 +13,17 @@ def make_debug_mingw(target, source, env):
         mingw_prefix = env["mingw_prefix_32"]
     else:
         mingw_prefix = env["mingw_prefix_64"]
-    os.system(mingw_prefix + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(target[0]))
-    os.system(mingw_prefix + "strip --strip-debug --strip-unneeded {0}".format(target[0]))
-    os.system(mingw_prefix + "objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(target[0]))
+    os.system(
+        mingw_prefix
+        + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(target[0])
+    )
+    os.system(
+        mingw_prefix + "strip --strip-debug --strip-unneeded {0}".format(target[0])
+    )
+    os.system(
+        mingw_prefix
+        + "objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(target[0])
+    )
 
 
 if __name__ == "__main__":

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -67,18 +67,42 @@ def get_opts():
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable("use_lld", "Use the LLD linker", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
-        BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True),
-        BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
-        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
+        BoolVariable(
+            "use_static_cpp",
+            "Link libgcc and libstdc++ statically for better portability",
+            True,
+        ),
+        BoolVariable(
+            "use_ubsan",
+            "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)",
+            False,
+        ),
+        BoolVariable(
+            "use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False
+        ),
         BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
-        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
-        BoolVariable("use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False),
+        BoolVariable(
+            "use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False
+        ),
+        BoolVariable(
+            "use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False
+        ),
         BoolVariable("pulseaudio", "Detect and use PulseAudio", True),
         BoolVariable("udev", "Use udev for gamepad connection callbacks", True),
-        BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
-        BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
+        BoolVariable(
+            "debug_symbols",
+            "Add debugging symbols to release/release_debug builds",
+            True,
+        ),
+        BoolVariable(
+            "separate_debug_symbols",
+            "Create a separate file containing debugging symbols",
+            False,
+        ),
         BoolVariable("touch", "Enable touch events", True),
-        BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
+        BoolVariable(
+            "execinfo", "Use libexecinfo on systems where glibc is not available", False
+        ),
     ]
 
 
@@ -144,10 +168,18 @@ def configure(env):
                 # A convenience so you don't need to write use_lto too when using SCons
                 env["use_lto"] = True
         else:
-            print("Using LLD with GCC is not supported yet. Try compiling with 'use_llvm=yes'.")
+            print(
+                "Using LLD with GCC is not supported yet. Try compiling with 'use_llvm=yes'."
+            )
             sys.exit(255)
 
-    if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
+    if (
+        env["use_ubsan"]
+        or env["use_asan"]
+        or env["use_lsan"]
+        or env["use_tsan"]
+        or env["use_msan"]
+    ):
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
@@ -248,7 +280,9 @@ def configure(env):
 
         import subprocess
 
-        bullet_version = subprocess.check_output(["pkg-config", "bullet", "--modversion"]).strip()
+        bullet_version = subprocess.check_output(
+            ["pkg-config", "bullet", "--modversion"]
+        ).strip()
         if str(bullet_version) < min_bullet_version:
             # Abort as system bullet was requested but too old
             print(
@@ -328,25 +362,35 @@ def configure(env):
     if os.system("pkg-config --exists alsa") == 0:  # 0 means found
         env["alsa"] = True
         env.Append(CPPDEFINES=["ALSA_ENABLED", "ALSAMIDI_ENABLED"])
-        env.ParseConfig("pkg-config alsa --cflags")  # Only cflags, we dlopen the library.
+        env.ParseConfig(
+            "pkg-config alsa --cflags"
+        )  # Only cflags, we dlopen the library.
     else:
         print("Warning: ALSA libraries not found. Disabling the ALSA audio driver.")
 
     if env["pulseaudio"]:
         if os.system("pkg-config --exists libpulse") == 0:  # 0 means found
             env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED"])
-            env.ParseConfig("pkg-config libpulse --cflags")  # Only cflags, we dlopen the library.
+            env.ParseConfig(
+                "pkg-config libpulse --cflags"
+            )  # Only cflags, we dlopen the library.
         else:
-            print("Warning: PulseAudio development libraries not found. Disabling the PulseAudio audio driver.")
+            print(
+                "Warning: PulseAudio development libraries not found. Disabling the PulseAudio audio driver."
+            )
 
     if platform.system() == "Linux":
         env.Append(CPPDEFINES=["JOYDEV_ENABLED"])
         if env["udev"]:
             if os.system("pkg-config --exists libudev") == 0:  # 0 means found
                 env.Append(CPPDEFINES=["UDEV_ENABLED"])
-                env.ParseConfig("pkg-config libudev --cflags")  # Only cflags, we dlopen the library.
+                env.ParseConfig(
+                    "pkg-config libudev --cflags"
+                )  # Only cflags, we dlopen the library.
             else:
-                print("Warning: libudev development libraries not found. Disabling controller hotplugging support.")
+                print(
+                    "Warning: libudev development libraries not found. Disabling controller hotplugging support."
+                )
     else:
         env["udev"] = False  # Linux specific
 
@@ -355,7 +399,15 @@ def configure(env):
         env.ParseConfig("pkg-config zlib --cflags --libs")
 
     env.Prepend(CPPPATH=["#platform/x11"])
-    env.Append(CPPDEFINES=["X11_ENABLED", "UNIX_ENABLED", "OPENGL_ENABLED", "GLES_ENABLED", ("_FILE_OFFSET_BITS", 64)])
+    env.Append(
+        CPPDEFINES=[
+            "X11_ENABLED",
+            "UNIX_ENABLED",
+            "OPENGL_ENABLED",
+            "GLES_ENABLED",
+            ("_FILE_OFFSET_BITS", 64),
+        ]
+    )
 
     env.ParseConfig("pkg-config gl --cflags --libs")
 
@@ -374,8 +426,12 @@ def configure(env):
         import subprocess
         import re
 
-        linker_version_str = subprocess.check_output([env.subst(env["LINK"]), "-Wl,--version"]).decode("utf-8")
-        gnu_ld_version = re.search("^GNU ld [^$]*(\d+\.\d+)$", linker_version_str, re.MULTILINE)
+        linker_version_str = subprocess.check_output(
+            [env.subst(env["LINK"]), "-Wl,--version"]
+        ).decode("utf-8")
+        gnu_ld_version = re.search(
+            "^GNU ld [^$]*(\d+\.\d+)$", linker_version_str, re.MULTILINE
+        )
         if not gnu_ld_version:
             print(
                 "Warning: Creating template binaries enabled for PCK embedding is currently only supported with GNU ld, not gold or LLD."

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -36,7 +36,11 @@ def run_in_subprocess(builder_function):
         subprocess_env["PYTHONPATH"] = os.pathsep.join([os.getcwd()] + sys.path)
 
         # Keep only JSON serializable environment items
-        filtered_env = dict((key, value) for key, value in env.items() if isinstance(value, JSON_SERIALIZABLE_TYPES))
+        filtered_env = dict(
+            (key, value)
+            for key, value in env.items()
+            if isinstance(value, JSON_SERIALIZABLE_TYPES)
+        )
 
         # Save parameters
         args = (target, source, filtered_env)
@@ -52,20 +56,24 @@ def run_in_subprocess(builder_function):
             % (module_path, json_path, json_file_size, target, source)
         )
         try:
-            exit_code = subprocess.call([sys.executable, module_path, json_path], env=subprocess_env)
+            exit_code = subprocess.call(
+                [sys.executable, module_path, json_path], env=subprocess_env
+            )
         finally:
             try:
                 os.remove(json_path)
             except (OSError, IOError) as e:
                 # Do not fail the entire build if it cannot delete a temporary file
                 print(
-                    "WARNING: Could not delete temporary file: path=%r; [%s] %s" % (json_path, e.__class__.__name__, e)
+                    "WARNING: Could not delete temporary file: path=%r; [%s] %s"
+                    % (json_path, e.__class__.__name__, e)
                 )
 
         # Must succeed
         if exit_code:
             raise RuntimeError(
-                "Failed to run builder function in subprocess: module_path=%r; data=%r" % (module_path, data)
+                "Failed to run builder function in subprocess: module_path=%r; data=%r"
+                % (module_path, data)
             )
 
     return wrapper


### PR DESCRIPTION
Applies the standard Black Python code style by removing the extended line length limit.

Includes two fixes to the `pre-commit-style-check` script:
- Removes unnecessary quotes and properly quotes the `xmessage` `buttons` option.
- Allows options to be optional.
