### PR TITLE
Update README.md files for translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   <img src="rebel-logo.svg" width="256" alt="Rebel Engine logo"/>
 </p>
 
+[![Translation status](https://hosted.weblate.org/widget/rebel-toolbox/svg-badge.svg)](https://hosted.weblate.org/engage/rebel-toolbox/)
+
 Rebel Engine is a cross-platform game engine and game development tool for creating desktop (Windows, Linux and MacOS), mobile (Android and iPhone) and web games (HTML5).
 
 ## Background
@@ -20,3 +22,12 @@ Rebel Engine was forked from [Godot 3.4.5](https://github.com/godotengine/godot/
 ## Free and Open Source Software
 
 Rebel Engine is Free and Open Source Software; released under the [MIT license](https://mit-license.org/). Games developed with Rebel Engine remain entirely the property of the game developer.
+
+## Documentation
+
+Rebel Toolbox user documentation, including the Rebel Engine API documentation, is available at https://docs.rebeltoolbox.com.
+
+Rebel Toolbox documenation is maintained via the [Rebel Documentation](https://github.com/RebelToolbox/RebelDocumentation) repository.
+The Rebel Engine API documentation is maintained here via XML files in the [`docs`](https://github.com/RebelToolbox/RebelEngine/tree/main/docs) folder.
+
+Rebel Toolbox translations are maintained via our [Weblate project](https://hosted.weblate.org/engage/rebel-toolbox/).

--- a/editor/translations/README.md
+++ b/editor/translations/README.md
@@ -1,23 +1,36 @@
-# How to contribute translations
+# Rebel Editor Translations
 
-Godot's translation work is coordinated on
-[Hosted Weblate](https://hosted.weblate.org/projects/godot-engine/godot),
-an open source web-based translation platform, where contributors can work
-together on translations using various internationalization features.
-Creating an account there is free, and you can also login directly with
-your GitHub, BitBucket, Google or Facebook account.
+This folder contains the Rebel Editor translation files that are synched with Weblate.
 
-To avoid merge conflicts when syncing translations from Weblate (currently
-this is done manually), we ask all contributors to work there instead of
-making pull requests on this repository.
+If you want to contribute to the Rebel Toolbox translations, please use our [Weblate](https://hosted.weblate.org/engage/rebel-toolbox/) project:
+https://hosted.weblate.org/projects/rebel-toolbox/
 
-Link if you missed it: https://hosted.weblate.org/projects/godot-engine/godot
+## Rebel Editor Source Text Strings
 
-## Adding new languages
+The Rebel Editor source files use three tags to identify souce text strings:
+- `TTR`: Text string only available when using the editor.
+- `RTR`: Text string available in game and when using the editor.
+- `TTRC`: C-strings
 
-If you want to translate for a language which is not featured yet on Weblate,
-you can add it (when logged in) by clicking the "Start new translation"
-button at the bottom of the page.
+The `editor.pot` file contains all the extracted text strings enclosed in these tags.
+The text strings in source files are extracted into the `editor.pot` file using `make update`.
+`make update` runs the `tools/scripts/extract_editor_strings.py` script.
 
-Alternatively, you can use this
-[direct link](https://hosted.weblate.org/new-lang/godot-engine/godot/).
+Each language has its own translation file; its `.po` file.
+Updates to the `editor.pot` file are merged into each `.po` file using `make merge`.
+The updating and merging tasks can be combined by running `make`.
+
+## Rebel Editor Translations
+
+The `editor.pot` file and all the `.po` files in this folder are synched with the Weblate project.
+The Rebel Editor Weblate component is:
+https://hosted.weblate.org/projects/rebel-toolbox/rebel-editor/
+
+All updates to the translations are done on Weblate by the Weblate community.
+Commits on Weblate are then synched with the `.po` files here.
+
+If your language is not yet available, you can add a new language to the Weblate component.
+New languages are added on Weblate:
+https://hosted.weblate.org/new-lang/rebel-toolbox/rebel-editor/
+
+For more information on Weblate and contributing to translations visit [Weblate](https://hosted.weblate.org/engage/rebel-toolbox/).

--- a/translations/README.md
+++ b/translations/README.md
@@ -1,10 +1,37 @@
-# Rebel Engine API translations
+# Rebel Engine API Translations
 
-This folder contains the Rebel Engine API translation files.
-These files are generated automatically.
-The text strings to be translated are exported from the API XML files in the `docs` folder.
-These text strings are then uploaded to Weblate, where they are translated by the community.
-The translated strings are then downloaded from Weblate into this folder.
+This folder contains the Rebel Engine API translation files that are synched with Weblate.
 
-If you want to contribute to the Rebel Engine API translations, please use our Weblate project:
-https://hosted.weblate.org/projects/rebel-engine/
+If you want to contribute to the Rebel Toolbox translations, please use our [Weblate](https://hosted.weblate.org/engage/rebel-toolbox/) project:
+https://hosted.weblate.org/projects/rebel-toolbox/
+
+## Rebel Engine API Source Text Strings
+
+The Rebel Engine API source files are the XML files in the [`docs`](https://github.com/RebelToolbox/RebelEngine/tree/main/docs) folder.
+Rebel Engine also has a number of included modules listed under the [`modules`](https://github.com/RebelToolbox/RebelEngine/tree/main/modules) folder.
+Modules that extend the API have their own `docs` folder with additional API XML files.
+The Rebel Engine API text strings to be translated are extracted from all these API XML files.
+
+The `api.pot` file contains all the extracted API XML files' text strings.
+The text strings in the XML files are extracted into the `api.pot` file using `make update`.
+`make update` runs the `tools/scripts/extract_api_strings.py` script.
+`make update` ensures that the script scans the `docs` folder and each modules' `docs` folder.
+
+Each language has its own translation file; its `.po` file.
+Updates to the `api.pot` file are merged into each `.po` file using `make merge`.
+The updating and merging tasks can be combined by running `make`.
+
+## Rebel Engine API Translations
+
+The `api.pot` file and all the `.po` files in this folder are synched with the Weblate project.
+The Rebel Engine API Weblate component is:
+https://hosted.weblate.org/projects/rebel-toolbox/rebel-engine-api/
+
+All updates to the translations are done on Weblate by the Weblate community.
+Commits on Weblate are then synched with the `.po` files here.
+
+If your language is not yet available, you can add a new language to the Weblate component.
+New languages are added on Weblate:
+https://hosted.weblate.org/new-lang/rebel-toolbox/rebel-engine-api/
+
+For more information on Weblate and contributing to translations visit [Weblate](https://hosted.weblate.org/engage/rebel-toolbox/).


### PR DESCRIPTION
Updates the main `README.md` and `README.md` files in the translations folders to provide an explanation of how translation files are created, updated and managed. Specifically, it includes links to our [Weblate](https://hosted.weblate.org/engage/rebel-toolbox/) project and a status badge on the main README.