### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/actions/build-cache/action.yml
+++ b/.github/actions/build-cache/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     # Upload cache on completion and check it out now
     - name: Load .scons_cache directory
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{inputs.scons-cache}}
         key: ${{inputs.cache-name}}-${{env.BRANCH_NAME}}-${{github.ref}}-${{github.sha}}

--- a/.github/actions/build-dependencies/action.yml
+++ b/.github/actions/build-dependencies/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     # Use python 3.x release (works cross platform)
     - name: Set up Python 3.x
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         # Semantic version range syntax or exact version of a Python version
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -27,8 +27,9 @@ jobs:
           sudo apt-get update
 
       - name: Set up Java 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: zulu
           java-version: 11
 
       - name: Setup build cache

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -23,13 +23,13 @@ jobs:
       # Additional cache for Emscripten generated system libraries
       - name: Load Emscripten cache
         id: javascript-template-emscripten-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{env.EM_CACHE_FOLDER}}
           key: ${{env.EM_VERSION}}-${{github.job}}
 
       - name: Set up Emscripten latest
-        uses: mymindstorm/setup-emsdk@v10
+        uses: mymindstorm/setup-emsdk@v14
         with:
           version: ${{env.EM_VERSION}}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload patch file
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: patch-files
           path: |


### PR DESCRIPTION
Currently, the Rebel Engine GitHub workflows are raising warnings:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: .... For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-java@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```
The end-of-life date for Node.js 16 was brought forward by seven months to coincide with the end of support of OpenSSL 1.1.1 on 11th September 2023.[[1](https://nodejs.org/en/blog/announcements/nodejs16-eol/)]. This prompted GitHub to initiate the deprecation process for GitHub Actions using Node.js 16 and transition all actions to run on Node 20 by Spring 2024.[[2](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)].

This PR upgrades the GitHub workflow's actions to use the latest versions:
- [actions/cache](https://github.com/actions/cache): v4
- [actions/checkout](https://github.com/actions/checkout): v4
- [actions/setup-java](https://github.com/actions/setup-java): v4
- [actions/setup-python](https://github.com/actions/setup-python): v5
- [actions/upload-artifact](https://github.com/actions/upload-artifact): v4
- [mymindstorm/setup-emsdk](https://github.com/mymindstorm/setup-emsdk): v14


[1] https://nodejs.org/en/blog/announcements/nodejs16-eol/
[2] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/