### PR TITLE
Always use MinGW when cross-compiling for Windows on POSIX platforms

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -58,13 +58,14 @@ methods.save_active_platforms(active_platforms, active_platform_ids)
 custom_tools = ["default"]
 
 platform_arg = ARGUMENTS.get("platform", ARGUMENTS.get("p", False))
+use_mingw = ARGUMENTS.get("use_mingw", False)
 
 if platform_arg == "android":
     custom_tools = ["clang", "clang++", "as", "ar", "link"]
 elif platform_arg == "javascript":
     # Use generic POSIX build toolchain for Emscripten.
     custom_tools = ["cc", "c++", "ar", "link", "textfile", "zip"]
-elif os.name == "nt" and methods.get_cmdline_bool("use_mingw", False):
+elif use_mingw or (os.name == "posix" and platform_arg == "windows"):
     custom_tools = ["mingw"]
 
 # We let SCons build its default ENV as it includes OS-specific things which we don't

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -395,8 +395,6 @@ def configure_mingw(env):
         # issues reaching the linker command line size limit, which also
         # seem to induce huge slowdown for 'ar' (GH-30892).
         env["split_libmodules"] = True
-    else:
-        env["PROGSUFFIX"] = env["PROGSUFFIX"] + ".exe"  # for linux cross-compilation
 
     if env["bits"] == "default":
         if os.name == "nt":
@@ -497,7 +495,7 @@ def configure(env):
         ] = os.environ  # this makes build less repeatable, but simplifies some things
         env["ENV"]["TMP"] = os.environ["TMP"]
 
-    if env["use_mingw"]:
+    if env["use_mingw"] or (os.name == "posix"):
         setup_mingw(env)
         configure_mingw(env)
         env.msvc = False


### PR DESCRIPTION
Currently, when building for Windows, the default is to use Microsoft's Visual C++ compiler (MSVC). However, this compiler is not available on POSIX systems i.e. Linux and MacOS.
Furthermore, currently, Windows release versions are built using the MinGW cross-compiler on Linux. Therefore, it makes sense that, when building for Windows on POSIX systems, the default compiler is the MinGW compiler.
This PR makes MinGW the default compiler on POSIX systems.