### PR TITLE
Make the Android default build arm64v8

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -29,7 +29,7 @@ def get_opts():
         EnumVariable(
             "android_arch",
             "Target architecture",
-            "armv7",
+            "arm64v8",
             ("armv7", "arm64v8", "x86", "x86_64"),
         ),
         BoolVariable("android_neon", "Enable NEON support (armv7 only)", True),


### PR DESCRIPTION
The default build architecture for all platforms is 64 bit; except for the Android platform. Since all new devices are 64 bit and 32 bit is only kept for backwards compatibility, it makes sense for the default to be 64 bit and it to be consistent across platforms.

Android also supports both Arm and Intel chipsets. On Android devices, except for very few devices, and the emulators, most devices use the Arm chipset. Therefore, this change makes the default Android build be for the 64 bit Arm chipset.

**Note:** This only changes the default build, all other architectures can still be built by specifying the required architecture.