### PR TITLE
Copy, don't move, built Android library into Java libraries folder

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -61,7 +61,7 @@ if lib_arch_dir != "":
     env_android.Command(
         out_dir + "/librebel_android.so",
         "#bin/librebel" + env["SHLIBSUFFIX"],
-        Move("$TARGET", "$SOURCE"),
+        Copy("$TARGET", "$SOURCE"),
     )
 
     stl_lib_path = (


### PR DESCRIPTION
Currently, when building a Rebel Engine Android library, the library file is moved (and renamed) from the bin directory into the appropriate Java libraries folder. However, to make it easier to locate and identify the built libraries for other purposes, this PR copies, instead of moves, the libraries into the Java libraries folders; leaving a copy in the bin folder. 