### PR TITLE
Fix Android JNI name mismatch

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -214,7 +214,7 @@ def configure(env):
     # Link flags
 
     env.Append(LINKFLAGS="-Wl,--gc-sections -Wl,--no-undefined -Wl,-z,now".split())
-    env.Append(LINKFLAGS="-Wl,-soname,libgodot_android.so")
+    env.Append(LINKFLAGS="-Wl,-soname,librebel_android.so")
 
     env.Prepend(CPPPATH=["#platform/android"])
     env.Append(CPPDEFINES=["ANDROID_ENABLED", "UNIX_ENABLED", "NO_FCNTL"])

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -158,7 +158,7 @@ ext.getExportPath = {
 ext.getExportFilename = {
     String exportFilename = project.hasProperty("export_filename") ? project.property("export_filename") : ""
     if (exportFilename == null || exportFilename.isEmpty()) {
-        exportFilename = "godot_android"
+        exportFilename = "rebel_android"
     }
     return exportFilename
 }

--- a/platform/android/java/lib/src/com/rebeltoolbox/rebelengine/RebelEngine.java
+++ b/platform/android/java/lib/src/com/rebeltoolbox/rebelengine/RebelEngine.java
@@ -18,7 +18,7 @@ public class RebelEngine {
     public static RebelIO io;
 
     static {
-        System.loadLibrary("godot_android");
+        System.loadLibrary("rebel_android");
     }
 
     /**

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -12,8 +12,8 @@
 // environment we can't cache it. For IO we call all access methods from our
 // thread and we thus get a valid JNIEnv from ThreadAndroid.
 
-GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv* p_env, jobject io_object) {
-    io_object = p_env->NewGlobalRef(io_object);
+GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv* p_env, jobject p_io_object) {
+    io_object = p_env->NewGlobalRef(p_io_object);
     if (io_object) {
         cls = p_env->GetObjectClass(io_object);
         if (cls) {

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -16,7 +16,7 @@
 #include <jni.h>
 
 // Class that makes functions in
-// java/src/com/rebeltoolbox/rebelengine/GodotIO.java callable from C++
+// java/src/com/rebeltoolbox/rebelengine/RebelIO.java callable from C++
 class GodotIOJavaWrapper {
 private:
     jobject io_object;

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -95,12 +95,13 @@ static void _initialize_java_modules() {
                 singletonClass,
                 "initialize",
                 "(Landroid/app/Activity;)Lcom/rebeltoolbox/rebelengine/"
-                "Godot$SingletonBase;"
+                "RebelFragment$SingletonBase;"
             );
             ERR_CONTINUE_MSG(
                 !initialize,
-                "Couldn't find proper initialize function 'public static "
-                "Godot.SingletonBase Class::initialize(Activity p_activity)' "
+                "Couldn't find proper initialize function "
+                "'public static RebelFragment.SingletonBase Class::initialize("
+                "Activity p_activity)'"
                 "initializer for singleton class: "
                     + m + "."
             );
@@ -147,7 +148,7 @@ JNIEXPORT void JNICALL Java_com_rebeltoolbox_rebelengine_RebelEngine_initialize(
         env,
         godot_java->get_member_object(
             "io",
-            "Lcom/rebeltoolbox/rebelengine/GodotIO;",
+            "Lcom/rebeltoolbox/rebelengine/RebelIO;",
             env
         )
     );
@@ -160,8 +161,8 @@ JNIEXPORT void JNICALL Java_com_rebeltoolbox_rebelengine_RebelEngine_initialize(
 
     DirAccessJAndroid::setup(godot_io_java->get_instance());
     NetSocketAndroid::setup(godot_java->get_member_object(
-        "netUtils",
-        "Lcom/rebeltoolbox/rebelengine/utils/GodotNetUtils;",
+        "wifiMulticastLock",
+        "Lcom/rebeltoolbox/rebelengine/utils/WifiMulticastLock;",
         env
     ));
 

--- a/platform/android/net_socket_android.cpp
+++ b/platform/android/net_socket_android.cpp
@@ -8,36 +8,40 @@
 
 #include "thread_jandroid.h"
 
-jobject NetSocketAndroid::net_utils                 = 0;
-jclass NetSocketAndroid::cls                        = 0;
+jobject NetSocketAndroid::wifi_multicast_lock       = 0;
+jclass NetSocketAndroid::wifi_multicast_lock_class  = 0;
 jmethodID NetSocketAndroid::_multicast_lock_acquire = 0;
 jmethodID NetSocketAndroid::_multicast_lock_release = 0;
 
-void NetSocketAndroid::setup(jobject p_net_utils) {
+void NetSocketAndroid::setup(jobject p_wifi_multicast_lock) {
     JNIEnv* env = get_jni_env();
 
-    net_utils = env->NewGlobalRef(p_net_utils);
-
-    jclass c = env->GetObjectClass(net_utils);
-    cls      = (jclass)env->NewGlobalRef(c);
-
-    _multicast_lock_acquire =
-        env->GetMethodID(cls, "multicastLockAcquire", "()V");
-    _multicast_lock_release =
-        env->GetMethodID(cls, "multicastLockRelease", "()V");
+    wifi_multicast_lock       = env->NewGlobalRef(p_wifi_multicast_lock);
+    jclass lock_class         = env->GetObjectClass(wifi_multicast_lock);
+    wifi_multicast_lock_class = (jclass)env->NewGlobalRef(lock_class);
+    _multicast_lock_acquire   = env->GetMethodID(
+        wifi_multicast_lock_class,
+        "multicastLockAcquire",
+        "()V"
+    );
+    _multicast_lock_release = env->GetMethodID(
+        wifi_multicast_lock_class,
+        "multicastLockRelease",
+        "()V"
+    );
 }
 
 void NetSocketAndroid::multicast_lock_acquire() {
     if (_multicast_lock_acquire) {
         JNIEnv* env = get_jni_env();
-        env->CallVoidMethod(net_utils, _multicast_lock_acquire);
+        env->CallVoidMethod(wifi_multicast_lock, _multicast_lock_acquire);
     }
 }
 
 void NetSocketAndroid::multicast_lock_release() {
     if (_multicast_lock_release) {
         JNIEnv* env = get_jni_env();
-        env->CallVoidMethod(net_utils, _multicast_lock_release);
+        env->CallVoidMethod(wifi_multicast_lock, _multicast_lock_release);
     }
 }
 

--- a/platform/android/net_socket_android.h
+++ b/platform/android/net_socket_android.h
@@ -22,8 +22,8 @@
  */
 class NetSocketAndroid : public NetSocketPosix {
 private:
-    static jobject net_utils;
-    static jclass cls;
+    static jobject wifi_multicast_lock;
+    static jclass wifi_multicast_lock_class;
     static jmethodID _multicast_lock_acquire;
     static jmethodID _multicast_lock_release;
 
@@ -38,7 +38,7 @@ protected:
 
 public:
     static void make_default();
-    static void setup(jobject p_net_utils);
+    static void setup(jobject p_wifi_multicast_lock);
 
     virtual void close();
 


### PR DESCRIPTION
Currently, Android is still looking for the old engine library name and class names changed in #16 and crashes when it can't find them.

This PR fixes the name mismatches in the Java Native Interface (JNI). 