### PR TITLE
Fix Android Rebel rebranding

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -4003,7 +4003,7 @@ Error EditorExportPlatformAndroid::export_project_helper(
             if (version != VERSION_FULL_CONFIG) {
                 EditorNode::get_singleton()->show_warning(vformat(
                     TTR("Android build version mismatch:\n   Template "
-                        "installed: %s\n   Godot Version: %s\nPlease reinstall "
+                        "installed: %s\n   Rebel Version: %s\nPlease reinstall "
                         "Android build template from 'Project' menu."),
                     version,
                     VERSION_FULL_CONFIG

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -290,7 +290,7 @@ String _get_instrumentation_tag(const Ref<EditorExportPreset>& p_preset) {
     String manifest_instrumentation_text = vformat(
         "    <instrumentation\n"
         "        tools:node=\"replace\"\n"
-        "        android:name=\".GodotInstrumentation\"\n"
+        "        android:name=\".RebelInstrumentation\"\n"
         "        android:icon=\"@mipmap/icon\"\n"
         "        android:label=\"@string/project_name_string\"\n"
         "        android:targetPackage=\"%s\" />\n",

--- a/platform/android/java/lib/patches/com.google.android.vending.expansion.downloader.patch
+++ b/platform/android/java/lib/patches/com.google.android.vending.expansion.downloader.patch
@@ -269,7 +269,7 @@ index b2e0e7af0..c114b8a64 100644
 +            // -- REBEL start --
 +            //wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, Constants.TAG);
 +            //wakeLock.acquire();
-+            wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "org.godot.game:wakelock");
++            wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "com.rebeltoolbox.rebelengine:wakelock");
 +            wakeLock.acquire(20 * 60 * 1000L /*20 minutes*/);
 +            // -- REBEL end --
  

--- a/platform/android/java/lib/src/com/google/android/vending/expansion/downloader/impl/DownloadThread.java
+++ b/platform/android/java/lib/src/com/google/android/vending/expansion/downloader/impl/DownloadThread.java
@@ -149,7 +149,7 @@ public class DownloadThread {
             // -- REBEL start --
             //wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, Constants.TAG);
             //wakeLock.acquire();
-            wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "org.godot.game:wakelock");
+            wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "com.rebeltoolbox.rebelengine:wakelock");
             wakeLock.acquire(20 * 60 * 1000L /*20 minutes*/);
             // -- REBEL end --
 

--- a/platform/android/java/nativeSrcsConfigs/AndroidManifest.xml
+++ b/platform/android/java/nativeSrcsConfigs/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.godotengine.godot" />
+<manifest package="com.rebeltoolbox.rebelengine" />

--- a/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
+++ b/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
@@ -1,19 +1,19 @@
 # Non functional cmake build file used to provide Android Studio editor support to the project.
 cmake_minimum_required(VERSION 3.6)
-project(godot)
+project(RebelEngine)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(GODOT_ROOT_DIR ../../../..)
+set(ROOT_DIR ../../../..)
 
 # Get sources
-file(GLOB_RECURSE SOURCES ${GODOT_ROOT_DIR}/*.c**)
-file(GLOB_RECURSE HEADERS ${GODOT_ROOT_DIR}/*.h**)
+file(GLOB_RECURSE SOURCES ${ROOT_DIR}/*.c**)
+file(GLOB_RECURSE HEADERS ${ROOT_DIR}/*.h**)
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 target_include_directories(${PROJECT_NAME}
         SYSTEM PUBLIC
-        ${GODOT_ROOT_DIR}
-        ${GODOT_ROOT_DIR}/modules/gdnative/include)
+        ${ROOT_DIR}
+        ${ROOT_DIR}/modules/gdnative/include)

--- a/platform/android/jni_utils.cpp
+++ b/platform/android/jni_utils.cpp
@@ -320,7 +320,7 @@ Variant _jobject_to_variant(JNIEnv* env, jobject obj) {
     };
 
     if (name == "java.util.HashMap"
-        || name == "org.godotengine.godot.Dictionary") {
+        || name == "com.rebeltoolbox.rebelengine.Dictionary") {
         Dictionary ret;
         jclass oclass = c;
         jmethodID get_keys =
@@ -354,18 +354,18 @@ Variant::Type get_jni_type(const String& p_type) {
         const char* name;
         Variant::Type type;
     } _type_to_vtype[] = {
-        {"void",                             Variant::NIL              },
-        {"boolean",                          Variant::BOOL             },
-        {"int",                              Variant::INT              },
-        {"float",                            Variant::REAL             },
-        {"double",                           Variant::REAL             },
-        {"java.lang.String",                 Variant::STRING           },
-        {"[I",                               Variant::POOL_INT_ARRAY   },
-        {"[B",                               Variant::POOL_BYTE_ARRAY  },
-        {"[F",                               Variant::POOL_REAL_ARRAY  },
-        {"[Ljava.lang.String;",              Variant::POOL_STRING_ARRAY},
-        {"org.godotengine.godot.Dictionary", Variant::DICTIONARY       },
-        {NULL,                               Variant::NIL              }
+        {"void",                                    Variant::NIL              },
+        {"boolean",                                 Variant::BOOL             },
+        {"int",                                     Variant::INT              },
+        {"float",                                   Variant::REAL             },
+        {"double",                                  Variant::REAL             },
+        {"java.lang.String",                        Variant::STRING           },
+        {"[I",                                      Variant::POOL_INT_ARRAY   },
+        {"[B",                                      Variant::POOL_BYTE_ARRAY  },
+        {"[F",                                      Variant::POOL_REAL_ARRAY  },
+        {"[Ljava.lang.String;",                     Variant::POOL_STRING_ARRAY},
+        {"com.rebeltoolbox.rebelengine.Dictionary", Variant::DICTIONARY       },
+        {NULL,                                      Variant::NIL              }
     };
 
     int idx = 0;

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -46,7 +46,7 @@ public:
     virtual void logv(const char* p_format, va_list p_list, bool p_err) {
         __android_log_vprint(
             p_err ? ANDROID_LOG_ERROR : ANDROID_LOG_INFO,
-            "godot",
+            "RebelEngine",
             p_format,
             p_list
         );


### PR DESCRIPTION
In addition to #42, there are a few other inconsistencies following #16:
- Android custom build doesn't use `RebelInstrumentation`
- A `Variant` containing a Rebel `Dictionary` is not working on Android
- The Android Studio build of Rebel hasn't been updated to use Rebel branding
- Android logging hasn't hasn't been updated to use Rebel branding
- The Android custom build template version mismatch message hasn't been updated to use Rebel branding  
 
This PR addresses these issues.