### PR TITLE
Update Android target SDK to 34

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -214,7 +214,7 @@ static const int DEFAULT_MIN_SDK_VERSION =
     19; // Should match the value in
         // 'platform/android/java/app/config.gradle#minSdk'
 static const int DEFAULT_TARGET_SDK_VERSION =
-    31; // Should match the value in
+    34; // Should match the value in
         // 'platform/android/java/app/config.gradle#targetSdk'
 const String SDK_VERSION_RANGE = vformat(
     "%s,%s,1,or_greater",
@@ -3168,12 +3168,6 @@ bool EditorExportPlatformAndroid::can_export(
     }
 
     // Check the min and target sdk version.
-
-    // They're only used for custom_build_enabled, but since we save their
-    // default values in the export preset, users would get an unexpected error
-    // when updating to a Godot version that has different values (GH-62465). So
-    // we don't make a blocking error, instead we just show a warning.
-
     int min_sdk_version = p_preset->get("version/min_sdk");
     if (min_sdk_version != DEFAULT_MIN_SDK_VERSION && !custom_build_enabled) {
         err += vformat(
@@ -3188,9 +3182,6 @@ bool EditorExportPlatformAndroid::can_export(
         err += "\n";
     }
 
-    // Here we also handle compatibility with Godot 3.4 to 3.4.4 where target
-    // SDK was 30. Version 3.4.5 updated it to 31 to match platform
-    // requirements, so make sure that users notice it.
     int target_sdk_version = p_preset->get("version/target_sdk");
     if (target_sdk_version != DEFAULT_TARGET_SDK_VERSION) {
         if (!custom_build_enabled) {
@@ -3204,12 +3195,13 @@ bool EditorExportPlatformAndroid::can_export(
                 DEFAULT_TARGET_SDK_VERSION
             );
             err += "\n";
-        } else if (target_sdk_version == 30) { // Compatibility with < 3.4.5.
+        } else if (target_sdk_version < DEFAULT_TARGET_SDK_VERSION) {
             err += vformat(
-                TTR("\"Target Sdk\" is set to 30, while the current default is "
-                    "\"%d\". This might be due to upgrading from a previous "
-                    "Godot release.\n>> Consider changing it to \"%d\" to stay "
-                    "up-to-date with platform requirements."),
+                TTR("\"Target Sdk\" is set to \"%d\", while the current "
+                    "default is \"%d\". This might be due to upgrading from a "
+                    "previous release.\n>> Consider changing it to \"%d\" to "
+                    "stay up-to-date with platform requirements."),
+                target_sdk_version,
                 DEFAULT_TARGET_SDK_VERSION,
                 DEFAULT_TARGET_SDK_VERSION
             );
@@ -3217,7 +3209,7 @@ bool EditorExportPlatformAndroid::can_export(
         } else if (target_sdk_version > DEFAULT_TARGET_SDK_VERSION) {
             err += vformat(
                 TTR("\"Target Sdk\" %d is higher than the default version %d. "
-                    "This may work, but wasn't tested and may be unstable."),
+                    "This may work, but isn't tested and may be unstable."),
                 target_sdk_version,
                 DEFAULT_TARGET_SDK_VERSION
             );

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,8 +1,8 @@
 ext.versions = [
     androidGradlePlugin: '7.0.3',
     compileSdk         : 30,
-    minSdk             : 19, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
-    targetSdk          : 31, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
+    minSdk             : 19, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
+    targetSdk          : 34, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '30.0.3',
     kotlinVersion      : '1.6.10',
     fragmentVersion    : '1.3.6',

--- a/platform/android/java/lib/AndroidManifest.xml
+++ b/platform/android/java/lib/AndroidManifest.xml
@@ -4,9 +4,6 @@
     android:versionCode="1"
     android:versionName="1.0">
 
-    <!-- Should match the mindSdk and targetSdk values in platform/android/java/app/config.gradle -->
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="31" />
-
     <application>
 
         <!-- Records the version of the library -->


### PR DESCRIPTION
Every year Google releases a new Android version and updates [Google Play's target API level requirements](https://developer.android.com/google/play/requirements/target-sdk).

In 2022, they released Android 13 (API level 33), and, since 31 August 2023, API level 33 has been the minimum requirement. In 2023, they released Android 14 (API level 34) and in August 2024, this will become the new minimum requirement. Therefore, to get ahead of the curve, we should update the default target API level to 34.

Although the minimum and target API levels can be changed when creating a custom Android build, the default and standard target API level is currently still 30! This PR updates the default and standard API level to 34 and updates the warning messages appropriately.

In addition, in the Rebel Engine library Android Manifest file, the `minSdkVersion` and `targetSdkVersion` values are no longer used: they are always overridden by the value specified in the Gradle build script. These are removed to avoid ambiguity and potential confusion.