### PR TITLE
Ensure Android Java and Kotlin compile to the same version

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -2,8 +2,6 @@
 //
 // Do not remove/modify comments ending with BEGIN/END, they are used to inject
 // addon-specific configuration.
-apply from: 'config.gradle'
-
 buildscript {
     apply from: 'config.gradle'
 
@@ -21,7 +19,12 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+apply from: 'config.gradle'
 
 allprojects {
     repositories {
@@ -82,6 +85,10 @@ android {
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = versions.javaVersion
     }
 
     assetPacks = [":assetPacks:installTime"]

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -4,8 +4,9 @@ ext.versions = [
     minSdk             : 19, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
     targetSdk          : 34, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '30.0.3',
-    kotlinVersion      : '1.6.10',
+    kotlinVersion      : '1.6.21',
     fragmentVersion    : '1.3.6',
+    nexusPublishVersion: '1.1.0',
     javaVersion        : 11,
     ndkVersion         : '23.2.8568313' // Also update 'platform/android/detect.py#get_ndk_version' when this is updated.
 
@@ -14,7 +15,7 @@ ext.versions = [
 ext.libraries = [
     androidGradlePlugin: "com.android.tools.build:gradle:$versions.androidGradlePlugin",
     kotlinGradlePlugin : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinVersion",
-    kotlinStdLib       : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlinVersion",
+    kotlinStdLib       : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlinVersion",
     androidxFragment   : "androidx.fragment:fragment:$versions.fragmentVersion",
 ]
 

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -1,2 +1,15 @@
 // These settings apply when creating a custom build in the Rebel Editor.
+pluginManagement {
+    apply from: 'config.gradle'
+
+    plugins {
+        id 'com.android.application' version versions.androidGradlePlugin
+        id 'org.jetbrains.kotlin.android' version versions.kotlinVersion
+    }
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
+
 include ':assetPacks:installTime'

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -1,7 +1,3 @@
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
-apply from: 'app/config.gradle'
-apply from: 'scripts/publish-root.gradle'
-
 buildscript {
     apply from: 'app/config.gradle'
 
@@ -16,6 +12,13 @@ buildscript {
         classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
     }
 }
+
+plugins {
+    id 'io.github.gradle-nexus.publish-plugin'
+}
+
+apply from: 'app/config.gradle'
+apply from: 'scripts/publish-root.gradle'
 
 allprojects {
     repositories {

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
 
 ext {
     PUBLISH_VERSION = getPublishVersion()
@@ -33,6 +35,10 @@ android {
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = versions.javaVersion
     }
 
     lintOptions {

--- a/platform/android/java/nativeSrcsConfigs/build.gradle
+++ b/platform/android/java/nativeSrcsConfigs/build.gradle
@@ -1,6 +1,7 @@
 // Non functional android library used to provide Android Studio editor support to the project.
 plugins {
     id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
@@ -15,6 +16,10 @@ android {
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = versions.javaVersion
     }
 
     packagingOptions {

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -1,4 +1,19 @@
 // Configure the root project.
+pluginManagement {
+    apply from: 'app/config.gradle'
+
+    plugins {
+        id 'com.android.application' version versions.androidGradlePlugin
+        id 'com.android.library' version versions.androidGradlePlugin
+        id 'org.jetbrains.kotlin.android' version versions.kotlinVersion
+        id 'io.github.gradle-nexus.publish-plugin' version versions.nexusPublishVersion
+    }
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
+
 rootProject.name = "Rebel"
 
 include ':app'


### PR DESCRIPTION
Rebel version of godotengine/godot#61580 (and godotengine/godot#61579).

Currently there is a mismatch between the Java and Kotlin classes compilation version targets. Java classes are being compiled using Java version 11, but the Kotlin classes are being compiled to be compatible with Java version 1.8.

This PR ensures that Java and Kotlin classes are compiled to the same Java version: 11.