### PR TITLE
Replace distutils.dir_util.copy_tree with shutil.copytree

### DIFF
--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -555,9 +555,9 @@ def copy_mono_root_files(env, mono_root, mono_bcl):
 
 
 def copy_mono_etc_dir(mono_root, target_mono_config_dir, platform):
-    from distutils.dir_util import copy_tree
     from glob import glob
     from shutil import copy
+    from shutil import copytree
 
     if not os.path.isdir(target_mono_config_dir):
         os.makedirs(target_mono_config_dir)
@@ -577,17 +577,17 @@ def copy_mono_etc_dir(mono_root, target_mono_config_dir, platform):
         if not mono_etc_dir:
             raise RuntimeError("Mono installation etc directory not found")
 
-    copy_tree(
+    copytree(
         os.path.join(mono_etc_dir, "2.0"), os.path.join(target_mono_config_dir, "2.0")
     )
-    copy_tree(
+    copytree(
         os.path.join(mono_etc_dir, "4.0"), os.path.join(target_mono_config_dir, "4.0")
     )
-    copy_tree(
+    copytree(
         os.path.join(mono_etc_dir, "4.5"), os.path.join(target_mono_config_dir, "4.5")
     )
     if os.path.isdir(os.path.join(mono_etc_dir, "mconfig")):
-        copy_tree(
+        copytree(
             os.path.join(mono_etc_dir, "mconfig"),
             os.path.join(target_mono_config_dir, "mconfig"),
         )


### PR DESCRIPTION
Python has, for a long time, recommended using `setuptools` instead of `distutils` [[1](https://docs.python.org/3.9/library/distutils.html)]. In Python 3.10, `distutils` was deprecated [[2](https://peps.python.org/pep-0632/)]. In Python 3.12, it was removed [[3](https://docs.python.org/3/whatsnew/3.12.html)]. However, the Mono module is still using `distutils`.

This PR uses `setuptools`' `shutil` instead of `distutils`. Specifically, it replaces `distutils.dir_util.copy_tree` with [`shutil.copytree`](https://docs.python.org/3/library/shutil.html#shutil.copytree).

[1] https://docs.python.org/3.9/library/distutils.html
[2] https://peps.python.org/pep-0632/
[3] https://docs.python.org/3/whatsnew/3.12.html