### PR TITLE
Remove 32 bit builds from iOS

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -180,18 +180,6 @@ jobs:
             build-options: platform=iphone production=yes tools=no target=release_debug
             rebel-executable: librebel.iphone.opt.debug.arm64.a
 
-          - name: iOS Engine Library arm 32 bit
-            os: macos-latest
-            artifact: ios-engine-library-arm
-            build-options: platform=iphone production=yes tools=no target=release arch=arm
-            rebel-executable: librebel.iphone.opt.arm.a
-
-          - name: iOS Engine Library arm 32 bit Debug
-            os: macos-latest
-            artifact: ios-engine-library-arm-debug
-            build-options: platform=iphone production=yes tools=no target=release_debug arch=arm
-            rebel-executable: librebel.iphone.opt.debug.arm.a
-
           - name: iOS Engine Library x86 64 bit Simulator
             os: macos-latest
             artifact: ios-engine-library-x86-64
@@ -421,27 +409,13 @@ jobs:
           path: bin/
           merge-multiple: true
 
-      - name: Create Universal binaries
-        run: |
-          # For each build type, run lipo to create a universal binary.
-          for build in                \
-            librebel.iphone.opt       \
-            librebel.iphone.opt.debug
-          do
-            lipo -create           \
-            bin/$build.arm.a       \
-            bin/$build.arm64.a     \
-            -output                \
-            bin/$build.universal.a
-          done
-
       - name: Create iOS Template
         run: |
           # Add universal binaries to iOS Tempate.
           cp -r tools/dist/ios_xcode .
-          cp bin/librebel.iphone.opt.universal.a                                              \
+          cp bin/librebel.iphone.opt.arm64.a                                                  \
           ios_xcode/libgodot.iphone.release.xcframework/ios-arm64/librebel.a
-          cp bin/librebel.iphone.opt.debug.universal.a                                        \
+          cp bin/librebel.iphone.opt.debug.arm64.a                                            \
           ios_xcode/libgodot.iphone.debug.xcframework/ios-arm64/librebel.a
           cp bin/librebel.iphone.opt.x86_64.simulator.a                                       \
           ios_xcode/libgodot.iphone.release.xcframework/ios-arm64_x86_64-simulator/librebel.a

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup build dependencies
         uses: ./.github/actions/build-dependencies
 
-      - name: Build (armv7)
+      - name: Build (arm64)
         uses: ./.github/actions/build
         with:
           sconsflags: ${{ env.SCONSFLAGS }}


### PR DESCRIPTION
This PR removes 32 bit builds from Rebel's iOS platform.

Starting with Xcode 14, the ability to build a single binary with both 32-bit and 64-bit code has been removed. Xcode 14 will only build 64-bit apps. iOS 10, which was released in 2016, was the last version of iOS to run 32-bit apps. As of iOS 11, all 32-bit apps installed on device will not launch.[[1](https://developer.apple.com/news/upcoming-requirements/?id=06062022a)]

Xcode 15 was released in September 2023.

Trying to build Rebel for iOS armv7 with Xcode 15 results in:
```
  /Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk/usr/include/simd/matrix.h:1105:25: error: use of undeclared identifier 'vzip1q_f32'; did you mean 'vzipq_f32'? [2]
       simd_float4 __r01 = vzip1q_f32(__x0, __x1);
                           ^
  /Applications/Xcode_15.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/15.0.0/include/arm_neon.h:32079:20: note: 'vzipq_f32' declared here [2]
   __ai float32x4x2_t vzipq_f32(float32x4_t __p0, float32x4_t __p1) {
                      ^
```

In fact, trying to build any Objective-C++ for armv7 now results in:
```
The armv7 architecture is deprecated. You should update your ARCHS build setting to remove the armv7 architecture.
```

[1] https://developer.apple.com/news/upcoming-requirements/?id=06062022a