### PR TITLE
Test Android builds on all platforms

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -12,19 +12,14 @@ concurrency:
 
 jobs:
   android-template:
-    runs-on: "ubuntu-20.04"
-
-    name: Template (target=release, tools=no)
+    runs-on: ${{ matrix.os }}
+    name: Template - ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
-
-      # Azure repositories are not reliable, we need to prevent azure giving us packages.
-      - name: Make apt sources.list use the default Ubuntu repositories
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f tools/ci/sources.list /etc/apt/sources.list
-          sudo apt-get update
 
       - name: Set up Java 17
         uses: actions/setup-java@v4
@@ -56,6 +51,7 @@ jobs:
           tools: false
 
       - name: Create Android templates
+        shell: bash
         run: |
           cd platform/android/java
           ./gradlew createAndroidTemplates
@@ -64,3 +60,5 @@ jobs:
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
+        with:
+          name: ${{ github.job }}-${{ matrix.os }}


### PR DESCRIPTION
To ensure updates to the Android platform build on any operating system (Linux, Windows and macOS) this PR updates the Android Builds Tests to include builds on Windows and macOS.