### PR TITLE
Change Android ndk_platform option to android_ndk_api

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -20,19 +20,22 @@ def get_opts():
     from SCons.Variables import BoolVariable, EnumVariable
 
     return [
-        ("ANDROID_SDK_ROOT", "Path to the Android SDK", get_env_android_sdk_root()),
-        (
-            "ndk_platform",
-            'Target platform (android-<api>, e.g. "android-19")',
-            "android-19",
-        ),
         EnumVariable(
             "android_arch",
             "Target architecture",
             "arm64v8",
             ("armv7", "arm64v8", "x86", "x86_64"),
         ),
-        BoolVariable("android_neon", "Enable NEON support (armv7 only)", True),
+        (
+            "android_ndk_api",
+            "Android NDK API level (minimum SDK supported)",
+            21,
+        ),
+        BoolVariable(
+            "android_neon",
+            "Set to False to disable NEON support (armv7 only)",
+            True,
+        ),
     ]
 
 
@@ -41,12 +44,8 @@ def get_env_android_sdk_root():
     return os.environ.get("ANDROID_SDK_ROOT", -1)
 
 
-def get_min_sdk_version(platform):
-    return int(platform.split("-")[1])
-
-
-def get_android_ndk_root(env):
-    return env["ANDROID_SDK_ROOT"] + "/ndk/" + get_ndk_version()
+def get_android_ndk_root():
+    return get_env_android_sdk_root() + "/ndk/" + get_ndk_version()
 
 
 def get_ndk_version():
@@ -60,48 +59,49 @@ def get_flags():
     ]
 
 
-# Check if Android NDK version is installed
-# If not, install it.
-def install_ndk_if_needed(env):
+def install_ndk_if_needed():
     print("Checking for Android NDK...")
-    sdk_root = env["ANDROID_SDK_ROOT"]
-    if not os.path.exists(get_android_ndk_root(env)):
+    if not os.path.exists(get_android_ndk_root()):
         extension = ".bat" if os.name == "nt" else ""
-        sdkmanager = sdk_root + "/cmdline-tools/latest/bin/sdkmanager" + extension
+        sdkmanager = (
+            get_env_android_sdk_root()
+            + "/cmdline-tools/latest/bin/sdkmanager"
+            + extension
+        )
         if os.path.exists(sdkmanager):
             # Install the Android NDK
             print("Installing Android NDK...")
             ndk_download_args = "ndk;" + get_ndk_version()
             subprocess.check_call([sdkmanager, ndk_download_args])
         else:
-            print("Cannot find " + sdkmanager)
+            print("ERROR: Cannot find " + sdkmanager)
             print(
-                "Please ensure ANDROID_SDK_ROOT is correct and cmdline-tools are installed, or install NDK version "
-                + get_ndk_version()
-                + " manually."
+                "Please ensure ANDROID_SDK_ROOT is correct and cmdline-tools are installed."
+            )
+            print(
+                "Alternatively, install NDK version " + get_ndk_version() + " manually."
             )
             sys.exit()
-    env["ANDROID_NDK_ROOT"] = get_android_ndk_root(env)
 
 
 def configure(env):
-    install_ndk_if_needed(env)
-    ndk_root = env["ANDROID_NDK_ROOT"]
+    install_ndk_if_needed()
+    ndk_api_level = int(env["android_ndk_api"])
+    if ndk_api_level < 21:
+        print("WARNING: Minimum Android NDK API level is 21")
+        ndk_api_level = 21
+    print("Building for minimum Android SDK API level " + str(ndk_api_level))
+    if ndk_api_level >= 24:
+        env.Append(CPPDEFINES=["_FILE_OFFSET_BITS", 64])
 
     # Architecture
-
     if env["android_arch"] not in ["armv7", "arm64v8", "x86", "x86_64"]:
-        env["android_arch"] = "arm64v8"
-
+        print("ERROR: Unrecognised android arch: " + env["android_arch"])
+        sys.exit()
     neon_text = ""
     if env["android_arch"] == "armv7" and env["android_neon"]:
-        neon_text = " (with NEON)"
-    print("Building for Android (" + env["android_arch"] + ")" + neon_text)
-
-    if get_min_sdk_version(env["ndk_platform"]) < 21:
-        print("WARNING: Minimum Android NDK API level is 21")
-        print("Setting ndk_platform=android-21")
-        env["ndk_platform"] = "android-21"
+        neon_text = " with NEON"
+    print("Building for Android (" + env["android_arch"] + neon_text + ")")
 
     if env["android_arch"] == "armv7":
         triple = "arm-linux-androideabi"
@@ -122,23 +122,31 @@ def configure(env):
         triple = "x86_64-linux-android"
         target_triple = triple
         env.extra_suffix = ".x86_64" + env.extra_suffix
+    target_triple = target_triple + str(ndk_api_level)
+    env.Append(CCFLAGS=["-target", target_triple])
+    env.Append(ASFLAGS=["-target", target_triple])
+    env.Append(LINKFLAGS=["-target", target_triple])
 
-    target_option = [
-        "-target",
-        target_triple + str(get_min_sdk_version(env["ndk_platform"])),
-    ]
-    env.Append(CCFLAGS=target_option)
-    env.Append(ASFLAGS=target_option)
-    env.Append(LINKFLAGS=target_option)
+    env["neon_enabled"] = False
+    if env["android_arch"] == "armv7":
+        if env["android_neon"]:
+            env["neon_enabled"] = True
+            env.Append(CCFLAGS=["-mfpu=neon"])
+        else:
+            env.Append(CCFLAGS=["-mfpu=vfpv3-d16"])
+    elif env["android_arch"] == "arm64v8":
+        env.Append(CCFLAGS=["-mfix-cortex-a53-835769"])
+    elif env["android_arch"] == "x86":
+        # For x86 targets prior to Android Nougat (API 24),
+        # -mstackrealign is needed to properly align stacks for global constructors.
+        env.Append(CCFLAGS=["-mstackrealign"])
 
     # Build type
-
     if env["target"].startswith("release"):
-        if env["optimize"] == "speed":  # optimize for speed (default)
+        if env["optimize"] == "speed":
             env.Append(CCFLAGS=["-O2", "-fomit-frame-pointer"])
-        elif env["optimize"] == "size":  # optimize for size
+        elif env["optimize"] == "size":
             env.Append(CCFLAGS=["-Oz"])
-
         env.Append(CPPDEFINES=["NDEBUG"])
         env.Append(CCFLAGS=["-ftree-vectorize"])
     elif env["target"] == "debug":
@@ -148,7 +156,7 @@ def configure(env):
         env.Append(CPPFLAGS=["-UNDEBUG"])
 
     # Compiler configuration
-
+    env.Prepend(CPPPATH=["#platform/android"])
     env["SHLIBSUFFIX"] = ".so"
 
     if env["PLATFORM"] == "win32":
@@ -164,6 +172,7 @@ def configure(env):
         else:
             host_subpath = "windows"
 
+    ndk_root = get_android_ndk_root()
     toolchain_path = ndk_root + "/toolchains/llvm/prebuilt/" + host_subpath
     compiler_path = toolchain_path + "/bin"
     libc_shared_path = toolchain_path + "/sysroot/usr/lib/" + triple
@@ -183,34 +192,44 @@ def configure(env):
         env.Append(CPPDEFINES=["NO_SAFE_CAST"])
 
     env.Append(
-        CCFLAGS="-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing".split()
+        CPPDEFINES=[
+            "NO_STATVFS",
+            "GLES_ENABLED",
+            "ANDROID_ENABLED",
+            "UNIX_ENABLED",
+            "NO_FCNTL",
+        ]
     )
-    env.Append(CPPDEFINES=["NO_STATVFS", "GLES_ENABLED"])
 
-    if get_min_sdk_version(env["ndk_platform"]) >= 24:
-        env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
-
-    env["neon_enabled"] = False
-    if env["android_arch"] == "x86":
-        # For x86 targets prior to Android Nougat (API 24),
-        # -mstackrealign is needed to properly align stacks for global constructors.
-        env.Append(CCFLAGS=["-mstackrealign"])
-    elif env["android_arch"] == "armv7":
-        if env["android_neon"]:
-            env["neon_enabled"] = True
-            env.Append(CCFLAGS=["-mfpu=neon"])
-        else:
-            env.Append(CCFLAGS=["-mfpu=vfpv3-d16"])
-    elif env["android_arch"] == "arm64v8":
-        env.Append(CCFLAGS=["-mfix-cortex-a53-835769"])
-
-    # Link flags
-
-    env.Append(LINKFLAGS="-Wl,--gc-sections -Wl,--no-undefined -Wl,-z,now".split())
-    env.Append(LINKFLAGS="-Wl,-soname,librebel_android.so")
-
-    env.Prepend(CPPPATH=["#platform/android"])
-    env.Append(CPPDEFINES=["ANDROID_ENABLED", "UNIX_ENABLED", "NO_FCNTL"])
     env.Append(
-        LIBS=["OpenSLES", "EGL", "GLESv3", "GLESv2", "android", "log", "z", "dl"]
+        CCFLAGS=[
+            "-fpic",
+            "-ffunction-sections",
+            "-funwind-tables",
+            "-fstack-protector-strong",
+            "-fvisibility=hidden",
+            "-fno-strict-aliasing",
+        ]
+    )
+
+    env.Append(
+        LINKFLAGS=[
+            "-Wl,--gc-sections",
+            "-Wl,--no-undefined",
+            "-Wl,-z,now",
+            "-Wl,-soname,librebel_android.so",
+        ]
+    )
+
+    env.Append(
+        LIBS=[
+            "OpenSLES",
+            "EGL",
+            "GLESv3",
+            "GLESv2",
+            "android",
+            "log",
+            "z",
+            "dl",
+        ]
     )


### PR DESCRIPTION
Currently, the Android build has an `ndk_platform` option to specify the minimum Android API that the build should support. Not only is the option name confusing (it affects the Android API not the NDK platform) it requires the inclusion of the word "android" in the value.

This PR changes the name of the option to the more descriptive `android_ndk_api`, it also uses an integer for the minimum API level supported.

In addition, this PR also removes the ignored `ANDROID_SDK_ROOT` SCons option and includes a general clean up of `android/detect.py`.