### PR TITLE
Update create release to support updated Android builds

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -242,6 +242,10 @@ jobs:
     name: Create Android Templates
     needs: builds
     runs-on: ubuntu-latest
+    env:
+      ndk_version: 23.2.8568313
+      java_version: 17
+
     steps:
       - name: Checkout Rebel Engine
         uses: actions/checkout@v4
@@ -253,15 +257,19 @@ jobs:
           path: bin/
           merge-multiple: true
 
-      - name: Install Dependencies
+      - name: Configure Dependencies
         run: |
-          # Intall dependencies.
-          sudo apt-get update
-          sudo apt-get install -y \
-          scons
+          # Configure Dependencies
+          # Android NDK
+          echo "Installing Android NDK v$ndk_version"
           sdkmanager="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
-          $sdkmanager "ndk;23.2.8568313"
-          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/23.2.8568313" >> $GITHUB_ENV
+          $sdkmanager "ndk;$ndk_version"
+          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/$ndk_version" >> $GITHUB_ENV
+          # Java JDK
+          echo Android builds require Java version $java_version.
+          java_home_variable="JAVA_HOME_${java_version}_X64"
+          echo "Setting JAVA_HOME=${!java_home_variable}"
+          echo "JAVA_HOME=${!java_home_variable}" >> $GITHUB_ENV
 
       - name: Copy Android libraries to Java libs folders
         run: |
@@ -295,13 +303,13 @@ jobs:
             mkdir -p $target
             echo Copying $library into $build/$arch
             cp $library $target/librebel_android.so
-            echo Copying stl library int $build/$arch
+            echo Copying $stl_lib into $build/$arch
             cp $stl_lib $target/
           done
 
       - name: Create Android Templates
         run: |
-          #./gradlew createAndroidTemplates in platform/android/java
+          # Create Android Templates
           cd platform/android/java
           ./gradlew createAndroidTemplates
           cd ../../..


### PR DESCRIPTION
#55 upgraded the build tools used to create the Rebel Android templates, which included a requirement to upgrade Java to version 17. The servers used to create a Rebel release (including the Rebel's nightly release) currently use Java 11 as the default. This PR updates the create release workflow to change the version of Java used to 17. Similarly, it ensures that the `libc++` shared libraries are the ones that match the version of the NDK used (23.2.8568313). Both options have been set up as variables; so they can be more easily updated in future.

Finally, this PR also removes the installation of SCons when creating the templates; as #55 (f9586eef4a694383b2d57380cec57700140508ae) has removed this requirement. 