### PR TITLE
Fix spelling mistake in NavigationMesh.xml

### DIFF
--- a/docs/NavigationMesh.xml
+++ b/docs/NavigationMesh.xml
@@ -108,7 +108,7 @@ SPDX-License-Identifier: MIT
             The maximum distance the detail mesh surface should deviate from heightfield, in cell unit.
         </member>
         <member name="edge/max_error" type="float" setter="set_edge_max_error" getter="get_edge_max_error" default="1.3">
-            The maximum distance a simplfied contour's border edges should deviate the original raw contour.
+            The maximum distance a simplified contour's border edges should deviate from the original raw contour.
         </member>
         <member name="edge/max_length" type="float" setter="set_edge_max_length" getter="get_edge_max_length" default="12.0">
             The maximum allowed length for contour edges along the border of the mesh.


### PR DESCRIPTION
Not sure why this has been missed by [`codespell`](https://pypi.org/project/codespell/) until now, but this PR fixes a typo in [`NavigationMesh`](https://docs.rebeltoolbox.com/en/latest/api/class_navigationmesh.html)'s [`edge/max_error`](https://docs.rebeltoolbox.com/en/latest/api/class_navigationmesh.html#class-navigationmesh-property-edge-max-error) property (and fixes the grammar).