### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+<p style="text-align: center;">
   <img src="rebel-engine.png" alt="Rebel Engine"/>
 </p>
 
@@ -12,7 +12,7 @@ Rebel Engine is based on [Godot Engine](https://godotengine.org), but developed 
 
   * Focus on the needs of the game developer before the engine developer
   * Fix bugs before writing new code
-  * Write maintainable code that follows [C++ Core Guidlines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)
+  * Write maintainable code that follows [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)
   * Reduce existing [technical debt](https://en.wikipedia.org/wiki/Technical_debt)
 
 Rebel Engine was forked from [Godot 3.4.5](https://github.com/godotengine/godot/tree/3.4.5-stable) in 2023. This version was chosen as the basis for Rebel Engine, because it was a stable and reliable version used to develop many published games.
@@ -25,7 +25,7 @@ Rebel Engine is Free and Open Source Software; released under the [MIT license](
 
 Rebel Toolbox user documentation, including the Rebel Engine API documentation, is available at https://docs.rebeltoolbox.com.
 
-Rebel Toolbox documenation is maintained via the [Rebel Documentation](https://github.com/RebelToolbox/RebelDocumentation) repository.
+Rebel Toolbox documentation is maintained via the [Rebel Documentation](https://github.com/RebelToolbox/RebelDocumentation) repository.
 The Rebel Engine API documentation is maintained here via XML files in the [`docs`](https://github.com/RebelToolbox/RebelEngine/tree/main/docs) folder.
 
 Rebel Toolbox translations are maintained via our [Weblate project](https://hosted.weblate.org/engage/rebel-toolbox/).


### PR DESCRIPTION
Fixes two typos in the main `README.md` and replaces [obsolete](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/center) `align="center"` element with `text-align: center` style.