### PR TITLE
Use align="center" to centre the Rebel Engine image in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p style="text-align: center;">
+<p align="center">
   <img src="rebel-engine.png" alt="Rebel Engine"/>
 </p>
 


### PR DESCRIPTION
[Markdown syntax](https://www.markdownguide.org/basic-syntax/) doesn't support alignment. However, the GitHub parser does support the inclusion of some HTML elements. Images can be centred by placing them in a paragraph that uses the obsolete `align="center"` element. It's a hack, but it appears to be the only way that works [[1](https://stackoverflow.com/questions/12090472/how-do-i-center-an-image-in-the-readme-md-file-on-github#12118349)].

[1] https://stackoverflow.com/questions/12090472/how-do-i-center-an-image-in-the-readme-md-file-on-github#12118349