### PR TITLE
Update clang-format's pre-commit hook's minimum version to 16

### DIFF
--- a/tools/hooks/pre-commit-clang-format
+++ b/tools/hooks/pre-commit-clang-format
@@ -14,8 +14,8 @@ exclude_directories="thirdparty platform/android/project/engine/src/main/java/co
 exclude_file_patterns="\-so_wrap\."
 
 # To get consistent formatting, use the same clang-format version as CI.
-recommended_clang_format_major_min="14"
-recommended_clang_format_major_max="17"
+required_clang_format_major_version="16"
+recommended_clang_format_major_version="17"
 
 # Determine the major version of clang-format being used.
 # The returned string can be inconsistent depending on where clang-format comes from.
@@ -25,15 +25,22 @@ recommended_clang_format_major_max="17"
 clang_format_version="$(clang-format --version | sed "s/[^0-9\.]*\([0-9\.]*\).*/\1/")"
 clang_format_major_version="$(echo "$clang_format_version" | cut -d. -f1)"
 
-if [[ "$clang_format_major_version" -lt "$recommended_clang_format_major_min" ]]; then
+if [[ "$clang_format_major_version" -lt "$required_clang_format_major_version" ]]; then
+    echo "Error: Your version of clang-format is $clang_format_version."
+    echo "The minimum required version of clang-format is $required_clang_format_major_version."
+    echo "Please upgrade clang-format to ensure formatting is applied correctly."
+    exit 1
+fi
+
+if [[ "$clang_format_major_version" -lt "$recommended_clang_format_major_version" ]]; then
     echo "Warning: Your version of clang-format is $clang_format_version."
-    echo "The minimum recommended version of clang-format is $recommended_clang_format_major_min."
+    echo "The recommended version of clang-format is $recommended_clang_format_major_version."
     echo "Consider upgrading clang-format as formatting may not be applied correctly."
 fi
 
-if [[ "$clang_format_major_version" -gt "$recommended_clang_format_major_max" ]]; then
+if [[ "$clang_format_major_version" -gt "$recommended_clang_format_major_version" ]]; then
     echo "Warning: Your version of clang-format is $clang_format_version."
-    echo "The maximum recommended version of clang-format is $recommended_clang_format_major_max."
+    echo "The maximum tested version of clang-format is $recommended_clang_format_major_version."
     echo "Consider downgrading clang-format as formatting may not be applied correctly."
 fi
 


### PR DESCRIPTION
In #19, we used [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) to apply Rebel's coding style. Our [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) help contributors to automatically apply Rebel's coding style. Currently, the `pre-commit-clang-format` hook checks the version of `clang-format` installed and warns if it is not between versions 14 and 17. However, Rebel's coding style uses `clang-format` functionality added in version 16, which was [released](https://discourse.llvm.org/t/llvm-16-0-0-release/69326) in March 2023. So, if the contributor is using an earlier version of `clang-format`, `clang-format` will fail.

This PR updates the minimum version required to 16. It will also cause the pre-commit hook to fail, which prevents earlier versions of `clang-format` failing and deleting files. It also warns if the version doesn't match the version used by CI checks: currently 17, which was released in September 2023 and includes fixes present in version 16.