### PR TITLE
Fix Windows header include order

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -14,30 +14,30 @@
 #include <stdio.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// Windows system includes come after <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #ifndef UWP_ENABLED
 #include <iphlpapi.h>
-#endif
-#else // UNIX
-#include <netdb.h>
+#endif // UWP_ENABLED
+#else  // ! WINDOWS_ENABLED
 #ifdef ANDROID_ENABLED
 // We could drop this file once we up our API level to 24,
 // where the NDK's ifaddrs.h supports to needed getifaddrs.
 #include "thirdparty/misc/ifaddrs-android.h"
-#else
-#ifdef __FreeBSD__
-#include <sys/types.h>
-#endif
+#else // ! ANDROID_ENABLED
 #include <ifaddrs.h>
-#endif
+#endif // ! ANDROID_ENABLED
 #include <arpa/inet.h>
+#include <netdb.h>
 #include <sys/socket.h>
 #ifdef __FreeBSD__
 #include <netinet/in.h>
-#endif
-#include <net/if.h> // Order is important on OpenBSD, leave as last
-#endif
+#include <sys/types.h>
+#endif // __FreeBSD__
+// Order is important on OpenBSD, leave as last
+#include <net/if.h>
+#endif // ! WINDOWS_ENABLED
 
 static IP_Address _sockaddr2ip(struct sockaddr* p_addr) {
     IP_Address ip;

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -13,10 +13,11 @@
 #include "core/os/thread.h"
 #include "servers/audio_server.h"
 
-#include <audioclient.h>
-#include <mmdeviceapi.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// Windows system includes come after <windows.h>
+#include <audioclient.h>
+#include <mmdeviceapi.h>
 
 class AudioDriverWASAPI : public AudioDriver {
     class AudioDeviceWASAPI {

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -11,15 +11,16 @@
 #include "core/os/os.h"
 #include "core/print_string.h"
 
-#include <share.h> // _SH_DENYNO
-#include <shlwapi.h>
-#define WIN32_LEAN_AND_MEAN
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <tchar.h>
 #include <wchar.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// Windows system includes come after <windows.h>
+#include <share.h> // _SH_DENYNO
+#include <shlwapi.h>
+#include <tchar.h>
 
 #ifdef _MSC_VER
 #define S_ISREG(m) ((m) & _S_IFREG)

--- a/drivers/winmidi/midi_driver_winmidi.h
+++ b/drivers/winmidi/midi_driver_winmidi.h
@@ -15,11 +15,8 @@
 #include <stdio.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
-#ifdef WIN32_LEAN_AND_MEAN
-// Manually include <mmsystem.h> after <windows.h> if using WIN32_LEAN_AND_MEAN
+// Windows system includes come after <windows.h>
 #include <mmsystem.h>
-#endif // WIN32_LEAN_AND_MEAN
 
 class MIDIDriverWinMidi : public MIDIDriver {
     Vector<HMIDIIN> connected_sources;

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -11,9 +11,10 @@
 #include "core/os/thread.h"
 #include "servers/audio_server.h"
 
-#include <mmsystem.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// Windows system includes come after <windows.h>
+#include <mmsystem.h>
 #include <wrl/client.h>
 #include <xaudio2.h>
 

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -11,19 +11,21 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 
+#include <stdlib.h>
+
 #ifdef WINDOWS_ENABLED
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
-#define ENV_PATH_SEP ";"
-#else
+#else // ! WINDOWS_ENABLED
 #include <limits.h>
 #include <unistd.h>
+#endif // WINDOWS_ENABLED
 
+#ifdef WINDOWS_ENABLED
+#define ENV_PATH_SEP ";"
+#else // ! WINDOWS_ENABLED
 #define ENV_PATH_SEP ":"
-#endif
-
-#include <stdlib.h>
+#endif // WINDOWS_ENABLED
 
 namespace path
 {

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -21,10 +21,11 @@
 #include "servers/visual_server.h"
 
 #include <fcntl.h>
-#include <io.h>
 #include <stdio.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// Windows system includes come after <windows.h>
+#include <io.h>
 
 class OS_UWP : public OS {
 public:

--- a/platform/windows/key_mapping_windows.h
+++ b/platform/windows/key_mapping_windows.h
@@ -11,6 +11,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// Windows system includes come after <windows.h>
 #include <winuser.h>
 
 class KeyMappingWindows {

--- a/platform/windows/lang_table.h
+++ b/platform/windows/lang_table.h
@@ -7,8 +7,6 @@
 #ifndef LANG_TABLE_H
 #define LANG_TABLE_H
 
-// #include <windows.h>
-
 struct _WinLocale {
     const char* locale;
     int main_lang;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -25,14 +25,16 @@
 #include "drivers/xaudio2/audio_driver_xaudio2.h"
 #endif
 
-#include <dwmapi.h>
 #include <fcntl.h>
-#include <io.h>
-#include <shellapi.h>
 #include <stdio.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// Windows system includes come after <windows.h>
+#include <dwmapi.h>
+#include <io.h>
+#include <shellapi.h>
 #include <windowsx.h>
+
 // WinTab API
 #define WT_PACKET     0x7FF0
 #define WT_PROXIMITY  0x7FF5


### PR DESCRIPTION
Header files should not depend on the order that they are included. Specifically, header files should not depend on other header files being included first. Unfortunately, on Windows, the order that Windows system header files are included is important. For example, `winsock2.h` will raise a warning if it is not included before `windows.h`:
```
winsock2.h|15|warning: #warning Please include winsock2.h before windows.h
```

The problem is, even if we include `winsock2.h` before `windows.h` in the header file where `winsock2.h` is included, it doesn't guarantee that `windows.h` has not been included by another header file earlier. The solution is not to include `winsock2.h` before every time we include `windows.h`, because `winsock2.h` may not be needed there. Furthermore, this problem is not limited to `winsock2.h`. For example, in e557849ba0ac6b6e08cc291fe0f88d61f3d19f96, `mmsystem.h` needed to be included **after** `windows.h`.

The solution requires understanding why `winsock2.h` needs to be included before `windows.h`, and `mmsystem.h` needs to be included after `windows.h`. `windows.h` is often included when developing on Windows, because it defines many macros that Windows code uses. Unfortunately, presumably to make it simpler for beginner developers, `windows.h` also includes a number of other Windows system header files; even if they are not required or wanted. One of these system header files is `winsock.h` and another is `mmsystem.h`. `winsock2.h` wants to be included before `winsock.h`. `mmsystem.h` only wants to be included if it's not included with `windows.h`.

To avoid, `winsock.h`, `mmsystem.h` and other unnecessary Windows system headers being included whenever `windows.h` is included, `WIN32_LEAN_AND_MEAN` can be defined before `windows.h` is included for the first time. To ensure `WIN32_LEAN_AND_MEAN` is defined the first time `windows.h` is included, it must be defined before every time `windows.h` is included. Unfortunately, since many other Windows system header files may also include `windows.h`, we need to define `WIN32_LEAN_AND_MEAN` before every Windows system header file is included. Furthermore, since Rebel's coding style (#19) ensures that header files are included in alphabetical order, which would place `windows.h` below most other system header files, we need to ensure that enforcing Rebel's code style does not place other Windows system header files before `#define WIN32_LEAN_AND_MEAN` and `#include <windows.h>`.

This PR ensures that:
- `#define WIN32_LEAN_AND_MEAN` is placed before every `#include <windows.h>`
- If other Windows system files are included:
  - `#define WIN32_LEAN_AND_MEAN` and `#include <windows.h>` are placed before other Windows system files
  - A comment (`// Windows system includes come after <windows.h>`) is placed before other Windows system files to break the include block and the alphabetic header file ordering, and explains the deliberate change from alphabetic ordering of includes.
