### PR TITLE
Create release configuration file

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    authors:
+      - github-actions
+  categories:
+    - title: Exciting New Features ✨
+      labels:
+        - "PR Type: New Feature"
+    - title: Bug Fixes 🐛
+      labels:
+        - "PR Type: Bug Fix"
+    - title: Enhancements 🚀
+      labels:
+        - "PR Type: Enhancement"
+    - title: Maintenance Updates 🔧
+      labels:
+        - "PR Type: Maintenance"
+    - title: Breaking Changes ⚠️
+      labels:
+        - "PR Type: Breaking Change"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Updates a release's notes to:
- Group PRs by category for each of the `PR Type: *` [labels](https://github.com/RebelToolbox/RebelEngine/labels).
- Removes the `github-actions` bot from the list of new contributors. 