### PR TITLE
Fix broken and updated links in the Rebel Engine API documentation

### DIFF
--- a/docs/Engine.xml
+++ b/docs/Engine.xml
@@ -153,7 +153,7 @@ SPDX-License-Identifier: MIT
             else:
                 simulate_physics()
             [/codeblock]
-            See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/misc/running_code_in_the_editor.html]Running code in the editor[/url] in the documentation for more information.
+            See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/plugins/running_code_in_the_editor.html]Running code in the editor[/url] in the documentation for more information.
             [b]Note:[/b] To detect whether the script is run from an editor [i]build[/i] (e.g. when pressing [code]F5[/code]), use [method OS.has_feature] with the [code]"editor"[/code] argument instead. [code]OS.has_feature("editor")[/code] will evaluate to [code]true[/code] both when the code is running in the editor and when running the project from the editor, but it will evaluate to [code]false[/code] when the code is run from an exported project.
         </member>
         <member name="iterations_per_second" type="int" setter="set_iterations_per_second" getter="get_iterations_per_second" default="60">

--- a/docs/ExternalTexture.xml
+++ b/docs/ExternalTexture.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
         Enable OpenGL ES external texture extension.
     </brief_description>
     <description>
-        Enable support for the OpenGL ES external texture extension as defined by [url=https://www.khronos.org/registry/OpenGL/extensions/OES/OES_EGL_image_external.txt]OES_EGL_image_external[/url].
+        Enable support for the OpenGL ES external texture extension as defined by [url=https://registry.khronos.org/OpenGL/extensions/OES/OES_EGL_image_external.txt]OES_EGL_image_external[/url].
         [b]Note:[/b] This is only supported for Android platforms.
     </description>
     <tutorials>

--- a/docs/HTTPClient.xml
+++ b/docs/HTTPClient.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: MIT
         Hyper-text transfer protocol client (sometimes called "User Agent"). Used to make HTTP requests to download web content, upload files and other data or to communicate with various services, among other use cases. [b]See the [HTTPRequest] node for a higher-level alternative.[/b]
         [b]Note:[/b] This client only needs to connect to a host once (see [method connect_to_host]) to send multiple requests. Because of this, methods that take URLs usually take just the part after the host instead of the full URL, as the client is already connected to a host. See [method request] for a full example and to get started.
         A [HTTPClient] should be reused between multiple requests or to connect to different hosts instead of creating one client per request. Supports SSL and SSL server certificate verification. HTTP status codes in the 2xx range indicate success, 3xx redirection (i.e. "try again, but over here"), 4xx something was wrong with the request, and 5xx something went wrong on the server's side.
-        For more information on HTTP, see https://developer.mozilla.org/en-US/docs/Web/HTTP (or read RFC 2616 to get it straight from the source: https://tools.ietf.org/html/rfc2616).
+        For more information on HTTP, see https://developer.mozilla.org/en-US/docs/Web/HTTP (or read RFC 2616 to get it straight from the source: https://datatracker.ietf.org/doc/html/rfc2616).
         [b]Note:[/b] When performing HTTP requests from a project exported for the web, keep in mind the remote server may not allow requests from foreign origins due to [url=https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS]CORS[/url]. If you host the server in question, you should modify its backend to allow requests from foreign origins by adding the [code]Access-Control-Allow-Origin: *[/code] HTTP header.
         [b]Note:[/b] SSL/TLS support is currently limited to TLS 1.0, TLS 1.1, and TLS 1.2. Attempting to connect to a TLS 1.3-only server will return an error.
         [b]Warning:[/b] SSL/TLS certificate revocation and certificate pinning are currently not supported. Revoked certificates are accepted as long as they are otherwise valid. If this is a concern, you may want to use automatically managed certificates with a short validity period.
@@ -38,7 +38,7 @@ SPDX-License-Identifier: MIT
             <argument index="3" name="verify_host" type="bool" default="true" />
             <description>
                 Connects to a host. This needs to be done before any requests are sent.
-                The host should not have http:// prepended but will strip the protocol identifier if provided.
+                The host should not have [code]http://[/code] prepended but will strip the protocol identifier if provided.
                 If no [code]port[/code] is specified (or [code]-1[/code] is used), it is automatically set to 80 for HTTP and 443 for HTTPS (if [code]use_ssl[/code] is enabled).
                 [code]verify_host[/code] will check the SSL identity of the host if set to [code]true[/code].
             </description>

--- a/docs/Node.xml
+++ b/docs/Node.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
                     child_node.get_parent().remove_child(child_node)
                 add_child(child_node)
                 [/codeblock]
-                [b]Note:[/b] If you want a child to be persisted to a [PackedScene], you must set [member owner] in addition to calling [method add_child]. This is typically relevant for [url=https://docs.rebeltoolbox.com/en/latest/tutorials/misc/running_code_in_the_editor.html]tool scripts[/url] and [url=https://docs.rebeltoolbox.com/en/latest/tutorials/plugins/editor/index.html]editor plugins[/url]. If [method add_child] is called without setting [member owner], the newly added [Node] will not be visible in the scene tree, though it will be visible in the 2D/3D view.
+                [b]Note:[/b] If you want a child to be persisted to a [PackedScene], you must set [member owner] in addition to calling [method add_child]. This is typically relevant for [url=https://docs.rebeltoolbox.com/en/latest/tutorials/plugins/running_code_in_the_editor.html]tool scripts[/url] and [url=https://docs.rebeltoolbox.com/en/latest/tutorials/plugins/editor/index.html]editor plugins[/url]. If [method add_child] is called without setting [member owner], the newly added [Node] will not be visible in the scene tree, though it will be visible in the 2D/3D view.
             </description>
         </method>
         <method name="add_child_below_node">
@@ -714,7 +714,7 @@ SPDX-License-Identifier: MIT
         </member>
         <member name="owner" type="Node" setter="set_owner" getter="get_owner">
             The node owner. A node can have any other node as owner (as long as it is a valid parent, grandparent, etc. ascending in the tree). When saving a node (using [PackedScene]), all the nodes it owns will be saved with it. This allows for the creation of complex [SceneTree]s, with instancing and subinstancing.
-            [b]Note:[/b] If you want a child to be persisted to a [PackedScene], you must set [member owner] in addition to calling [method add_child]. This is typically relevant for [url=https://docs.rebeltoolbox.com/en/latest/tutorials/misc/running_code_in_the_editor.html]tool scripts[/url] and [url=https://docs.rebeltoolbox.com/en/latest/tutorials/plugins/editor/index.html]editor plugins[/url]. If [method add_child] is called without setting [member owner], the newly added [Node] will not be visible in the scene tree, though it will be visible in the 2D/3D view.
+            [b]Note:[/b] If you want a child to be persisted to a [PackedScene], you must set [member owner] in addition to calling [method add_child]. This is typically relevant for [url=https://docs.rebeltoolbox.com/en/latest/tutorials/plugins/running_code_in_the_editor.html]tool scripts[/url] and [url=https://docs.rebeltoolbox.com/en/latest/tutorials/plugins/editor/index.html]editor plugins[/url]. If [method add_child] is called without setting [member owner], the newly added [Node] will not be visible in the scene tree, though it will be visible in the 2D/3D view.
         </member>
         <member name="pause_mode" type="int" setter="set_pause_mode" getter="get_pause_mode" enum="Node.PauseMode" default="0">
             Pause mode. How the node will behave if the [SceneTree] is paused.

--- a/docs/OS.xml
+++ b/docs/OS.xml
@@ -924,7 +924,7 @@ SPDX-License-Identifier: MIT
                 Requests the OS to open a resource with the most appropriate program. For example:
                 - [code]OS.shell_open("C:\\Users\name\Downloads")[/code] on Windows opens the file explorer at the user's Downloads folder.
                 - [code]OS.shell_open("https://rebeltoolbox.com")[/code] opens the default web browser on the official Rebel Toolbox website.
-                - [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://blog.escapecreative.com/customizing-mailto-links/]Customizing [code]mailto:[/code] Links[/url] for a list of fields that can be added.
+                - [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://www.w3docs.com/snippets/html/how-to-create-mailto-links.html]Customizing [code]mailto:[/code] Links[/url] for a list of fields that can be added.
                 Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
                 [b]Note:[/b] This method is implemented on the Linux, macOS, Windows, Android, iOS and Web platforms.
             </description>

--- a/docs/ProjectSettings.xml
+++ b/docs/ProjectSettings.xml
@@ -1115,7 +1115,7 @@ SPDX-License-Identifier: MIT
         </member>
         <member name="physics/3d/physics_engine" type="String" setter="" getter="" default="&quot;DEFAULT&quot;">
             Sets which physics engine to use for 3D physics.
-            "DEFAULT" is currently the [url=https://bulletphysics.org]Bullet[/url] physics engine. The "Rebel Physics" engine is still supported as an alternative.
+            "DEFAULT" is currently the [url=https://pybullet.org/wordpress/]Bullet[/url] physics engine. The "Rebel Physics" engine is still supported as an alternative.
         </member>
         <member name="physics/common/enable_object_picking" type="bool" setter="" getter="" default="true">
             Enables [member Viewport.physics_object_picking] on the root viewport.

--- a/docs/RandomNumberGenerator.xml
+++ b/docs/RandomNumberGenerator.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
         A class for generating pseudo-random numbers.
     </brief_description>
     <description>
-        RandomNumberGenerator is a class for generating pseudo-random numbers. It currently uses [url=http://www.pcg-random.org/]PCG32[/url].
+        RandomNumberGenerator is a class for generating pseudo-random numbers. It currently uses [url=https://www.pcg-random.org/]PCG32[/url].
         [b]Note:[/b] The underlying algorithm is an implementation detail. As a result, it should not be depended upon for reproducible random streams across Rebel Engine versions.
         To generate a random float number (within a given range) based on a time-dependant seed:
         [codeblock]

--- a/modules/csg/docs/CSGBox.xml
+++ b/modules/csg/docs/CSGBox.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
     </methods>

--- a/modules/csg/docs/CSGCombiner.xml
+++ b/modules/csg/docs/CSGCombiner.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
     </methods>

--- a/modules/csg/docs/CSGCylinder.xml
+++ b/modules/csg/docs/CSGCylinder.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
     </methods>

--- a/modules/csg/docs/CSGMesh.xml
+++ b/modules/csg/docs/CSGMesh.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
     </methods>

--- a/modules/csg/docs/CSGPolygon.xml
+++ b/modules/csg/docs/CSGPolygon.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
     </methods>

--- a/modules/csg/docs/CSGPrimitive.xml
+++ b/modules/csg/docs/CSGPrimitive.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
     </methods>

--- a/modules/csg/docs/CSGShape.xml
+++ b/modules/csg/docs/CSGShape.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
         <method name="get_collision_layer_bit" qualifiers="const">

--- a/modules/csg/docs/CSGSphere.xml
+++ b/modules/csg/docs/CSGSphere.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
     </methods>

--- a/modules/csg/docs/CSGTorus.xml
+++ b/modules/csg/docs/CSGTorus.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         [b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
     </description>
     <tutorials>
-        <link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
+        <link title="Prototyping levels with CSG">https://docs.rebeltoolbox.com/en/latest/tutorials/3d/csg_tools.html</link>
     </tutorials>
     <methods>
     </methods>

--- a/modules/webxr/docs/WebXRInterface.xml
+++ b/modules/webxr/docs/WebXRInterface.xml
@@ -120,7 +120,7 @@ SPDX-License-Identifier: MIT
             <argument index="0" name="session_mode" type="String" />
             <description>
                 Checks if the given [code]session_mode[/code] is supported by the user's browser.
-                Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSessionMode]WebXR's XRSessionMode[/url], including: [code]"immersive-vr"[/code], [code]"immersive-ar"[/code], and [code]"inline"[/code].
+                Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSystem/requestSession]WebXR's XRSessionMode[/url], including: [code]"immersive-vr"[/code], [code]"immersive-ar"[/code], and [code]"inline"[/code].
                 This method returns nothing, instead it emits the [signal session_supported] signal with the result.
             </description>
         </method>
@@ -135,32 +135,32 @@ SPDX-License-Identifier: MIT
             A comma-seperated list of optional features used by [method ARVRInterface.initialize] when setting up the WebXR session.
             If a user's browser or device doesn't support one of the given features, initialization will continue, but you won't be able to use the requested feature.
             This doesn't have any effect on the interface when already initialized.
-            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
+            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSession/requestReferenceSpace]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
         </member>
         <member name="reference_space_type" type="String" setter="" getter="get_reference_space_type">
             The reference space type (from the list of requested types set in the [member requested_reference_space_types] property), that was ultimately used by [method ARVRInterface.initialize] when setting up the WebXR session.
-            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
+            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSession/requestReferenceSpace]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
         </member>
         <member name="requested_reference_space_types" type="String" setter="set_requested_reference_space_types" getter="get_requested_reference_space_types">
             A comma-seperated list of reference space types used by [method ARVRInterface.initialize] when setting up the WebXR session.
             The reference space types are requested in order, and the first on supported by the users device or browser will be used. The [member reference_space_type] property contains the reference space type that was ultimately used.
             This doesn't have any effect on the interface when already initialized.
-            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
+            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSession/requestReferenceSpace]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
         </member>
         <member name="required_features" type="String" setter="set_required_features" getter="get_required_features">
             A comma-seperated list of required features used by [method ARVRInterface.initialize] when setting up the WebXR session.
             If a user's browser or device doesn't support one of the given features, initialization will fail and [signal session_failed] will be emitted.
             This doesn't have any effect on the interface when already initialized.
-            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
+            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSession/requestReferenceSpace]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
         </member>
         <member name="session_mode" type="String" setter="set_session_mode" getter="get_session_mode">
             The session mode used by [method ARVRInterface.initialize] when setting up the WebXR session.
             This doesn't have any effect on the interface when already initialized.
-            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSessionMode]WebXR's XRSessionMode[/url], including: [code]"immersive-vr"[/code], [code]"immersive-ar"[/code], and [code]"inline"[/code].
+            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSystem/requestSession]WebXR's XRSessionMode[/url], including: [code]"immersive-vr"[/code], [code]"immersive-ar"[/code], and [code]"inline"[/code].
         </member>
         <member name="visibility_state" type="String" setter="" getter="get_visibility_state">
             Indicates if the WebXR session's imagery is visible to the user.
-            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRVisibilityState]WebXR's XRVisibilityState[/url], including [code]"hidden"[/code], [code]"visible"[/code], and [code]"visible-blurred"[/code].
+            Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSession/visibilityState]WebXR's XRVisibilityState[/url], including [code]"hidden"[/code], [code]"visible"[/code], and [code]"visible-blurred"[/code].
         </member>
     </members>
     <signals>


### PR DESCRIPTION
Fix broken internal Rebel Documentation links in:
- docs/Engine.xml
- docs/Node.xml
- modules/csg/docs/CSGBox.xml
- modules/csg/docs/CSGCombiner.xml
- modules/csg/docs/CSGCylinder.xml
- modules/csg/docs/CSGMesh.xml
- modules/csg/docs/CSGPolygon.xml
- modules/csg/docs/CSGPrimitive.xml
- modules/csg/docs/CSGShape.xml
- modules/csg/docs/CSGSphere.xml
- modules/csg/docs/CSGTorus.xml

Update external links in:
- docs/ExternalTexture.xml
- docs/HTTPClient.xml
- docs/OS.xml
- docs/ProjectSettings.xml
- docs/RandomNumberGenerator.xml
- modules/webxr/docs/WebXRInterface.xml

1. https://www.khronos.org/registry/ has been permanently redirected to https://registry.khronos.org/
2. https://tools.ietf.org/html/ has been permanently redirected to https://datatracker.ietf.org/doc/html/
3. https://bulletphysics.org has been permanently redirected to https://pybullet.org/wordpress/
4. http://www.pcg-random.org/ is permanently redirected to https://www.pcg-random.org/
5. https://developer.mozilla.org/en-US/docs/Web/API/ has permanent redirections:
   - XRReferenceSpaceType to XRSession/requestReferenceSpace
   - XRSessionMode to XRSystem/requestSession
   - XRVisibilityState to XRSession/visibilityState

Finally, in HTTPClient.xml, wrap `http://` in code blocks to prevent it being detected as a broken URL link.