### PR TITLE
Update broken and permanently redirected links

### DIFF
--- a/docs/DynamicFont.xml
+++ b/docs/DynamicFont.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
     </brief_description>
     <description>
         DynamicFont renders vector font files dynamically at runtime instead of using a prerendered texture atlas like [BitmapFont]. This trades the faster loading time of [BitmapFont]s for the ability to change font parameters like size and spacing during runtime. [DynamicFontData] is used for referencing the font file paths. DynamicFont also supports defining one or more fallback fonts, which will be used when displaying a character not supported by the main font.
-        DynamicFont uses the [url=https://www.freetype.org/]FreeType[/url] library for rasterization. Supported formats are TrueType ([code].ttf[/code]), OpenType ([code].otf[/code]) and Web Open Font Format 1 ([code].woff[/code]). Web Open Font Format 2 ([code].woff2[/code]) is [i]not[/i] supported.
+        DynamicFont uses the [url=https://freetype.org/]FreeType[/url] library for rasterization. Supported formats are TrueType ([code].ttf[/code]), OpenType ([code].otf[/code]) and Web Open Font Format 1 ([code].woff[/code]). Web Open Font Format 2 ([code].woff2[/code]) is [i]not[/i] supported.
         [codeblock]
         var dynamic_font = DynamicFont.new()
         dynamic_font.font_data = load("res://BarlowCondensed-Bold.ttf")

--- a/docs/Image.xml
+++ b/docs/Image.xml
@@ -532,27 +532,27 @@ SPDX-License-Identifier: MIT
             [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC1]Ericsson Texture Compression format 1[/url], also referred to as "ETC1", and is part of the OpenGL ES graphics standard. This format cannot store an alpha channel.
         </constant>
         <constant name="FORMAT_ETC2_R11" value="30" enum="Format">
-            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC]Ericsson Texture Compression format 2[/url] ([code]R11_EAC[/code] variant), which provides one channel of unsigned data.
+            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#EAC]Ericsson Texture Compression format 2[/url] ([code]R11_EAC[/code] variant), which provides one channel of unsigned data.
         </constant>
         <constant name="FORMAT_ETC2_R11S" value="31" enum="Format">
-            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC]Ericsson Texture Compression format 2[/url] ([code]SIGNED_R11_EAC[/code] variant), which provides one channel of signed data.
+            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#EAC]Ericsson Texture Compression format 2[/url] ([code]SIGNED_R11_EAC[/code] variant), which provides one channel of signed data.
         </constant>
         <constant name="FORMAT_ETC2_RG11" value="32" enum="Format">
-            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC]Ericsson Texture Compression format 2[/url] ([code]RG11_EAC[/code] variant), which provides two channels of unsigned data.
+            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#EAC]Ericsson Texture Compression format 2[/url] ([code]RG11_EAC[/code] variant), which provides two channels of unsigned data.
         </constant>
         <constant name="FORMAT_ETC2_RG11S" value="33" enum="Format">
-            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC]Ericsson Texture Compression format 2[/url] ([code]SIGNED_RG11_EAC[/code] variant), which provides two channels of signed data.
+            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#EAC]Ericsson Texture Compression format 2[/url] ([code]SIGNED_RG11_EAC[/code] variant), which provides two channels of signed data.
         </constant>
         <constant name="FORMAT_ETC2_RGB8" value="34" enum="Format">
-            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC]Ericsson Texture Compression format 2[/url] ([code]RGB8[/code] variant), which is a follow-up of ETC1 and compresses RGB888 data.
+            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2]Ericsson Texture Compression format 2[/url] ([code]RGB8[/code] variant), which is a follow-up of ETC1 and compresses RGB888 data.
             [b]Note:[/b] When creating an [ImageTexture], an sRGB to linear color space conversion is performed.
         </constant>
         <constant name="FORMAT_ETC2_RGBA8" value="35" enum="Format">
-            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC]Ericsson Texture Compression format 2[/url] ([code]RGBA8[/code]variant), which compresses RGBA8888 data with full alpha support.
+            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2]Ericsson Texture Compression format 2[/url] ([code]RGBA8[/code]variant), which compresses RGBA8888 data with full alpha support.
             [b]Note:[/b] When creating an [ImageTexture], an sRGB to linear color space conversion is performed.
         </constant>
         <constant name="FORMAT_ETC2_RGB8A1" value="36" enum="Format">
-            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC]Ericsson Texture Compression format 2[/url] ([code]RGB8_PUNCHTHROUGH_ALPHA1[/code] variant), which compresses RGBA data to make alpha either fully transparent or fully opaque.
+            [url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2]Ericsson Texture Compression format 2[/url] ([code]RGB8_PUNCHTHROUGH_ALPHA1[/code] variant), which compresses RGBA data to make alpha either fully transparent or fully opaque.
             [b]Note:[/b] When creating an [ImageTexture], an sRGB to linear color space conversion is performed.
         </constant>
         <constant name="FORMAT_MAX" value="37" enum="Format">


### PR DESCRIPTION
Further to #89, this PR updates broken fragments in external links. Specifically, the https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC links in `Image.xml` have been split into two fragments:
- https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2 and
- https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#EAC

It also includes an update to the permanently redirected link to https://freetype.org/ in `DynamicFont.xml`.