### PR TITLE
Refactor List operator[] to prevent compiler warnings

### DIFF
--- a/core/list.h
+++ b/core/list.h
@@ -438,15 +438,11 @@ public:
 
         Element* I = front();
         int c      = 0;
-        while (I) {
-            if (c == p_index) {
-                return I->get();
-            }
+        while (c < p_index) {
             I = I->next();
             c++;
         }
-
-        CRASH_NOW(); // bug!!
+        return I->get();
     }
 
     const T& operator[](int p_index) const {
@@ -454,15 +450,11 @@ public:
 
         const Element* I = front();
         int c            = 0;
-        while (I) {
-            if (c == p_index) {
-                return I->get();
-            }
+        while (c < p_index) {
             I = I->next();
             c++;
         }
-
-        CRASH_NOW(); // bug!!
+        return I->get();
     }
 
     void move_to_back(Element* p_I) {


### PR DESCRIPTION
Prevents GCC compiler throwing: control reaches end of non-void function.
Prevents Visual Studio throwing C4715: not all control paths return a value:
```
RebelEngine\RebelEngine\core\list.h(450) : warning C4715: 'List<long,DefaultAllocator>::operator[]': not all control paths return a value
```
Rebel version of https://github.com/godotengine/godot/pull/36097
