### PR TITLE
Enable Bullet DEBUG on debug builds

### DIFF
--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -206,6 +206,8 @@ if env["builtin_bullet"]:
     env_bullet.Prepend(CPPPATH=[thirdparty_dir])
 
     env_bullet.Append(CPPDEFINES=["BT_USE_OLD_DAMPING_METHOD", "BT_THREADSAFE"])
+    if env["target"] == "debug" or env["target"] == "release_debug":
+        env_bullet.Append(CPPDEFINES=["DEBUG"])
 
     env_thirdparty = env_bullet.Clone()
     env_thirdparty.disable_warnings()


### PR DESCRIPTION
Enables Bullet DEBUG in debug mode.

Rebel version of godotengine/godot#34236
Fixes godotengine/godot#25301
