### PR TITLE
Remove 32-bit Linux builds from Rebel export templates

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -56,18 +56,6 @@ jobs:
             build-options: production=yes tools=no target=release_debug
             rebel-executable: rebel.linux.opt.debug.64
 
-          - name: Linux Engine 32 bit
-            os: ubuntu-latest
-            artifact: linux-engine-x86-32
-            build-options: production=yes tools=no target=release bits=32
-            rebel-executable: rebel.linux.opt.32
-
-          - name: Linux Engine 32 bit Debug
-            os: ubuntu-latest
-            artifact: linux-engine-x86-32-debug
-            build-options: production=yes tools=no target=release_debug bits=32
-            rebel-executable: rebel.linux.opt.debug.32
-
           # Rebel Engine Windows builds
           - name: Windows Engine 64 bit
             os: windows-latest
@@ -489,8 +477,6 @@ jobs:
           # Move Linux templates.
           mv artifacts/rebel.linux.opt.64 templates/linux_64_release
           mv artifacts/rebel.linux.opt.debug.64 templates/linux_64_debug
-          mv artifacts/rebel.linux.opt.32 templates/linux_32_release
-          mv artifacts/rebel.linux.opt.debug.32 templates/linux_32_debug
           # Move Windows templates.
           mv artifacts/rebel.windows.opt.64.msvc.exe templates/windows_64_release.exe
           mv artifacts/rebel.windows.opt.debug.64.msvc.exe templates/windows_64_debug.exe

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -219,7 +219,7 @@ jobs:
 
     steps:
       - name: Build Rebel
-        uses: RebelToolbox/RebelBuildAction@v2
+        uses: RebelToolbox/RebelBuildAction@v3
         with:
           artifact: ${{ matrix.artifact }}
           build-options: ${{ matrix.build-options }}


### PR DESCRIPTION
Our nightly releases are failing, because Github is migrating `ubuntu-latest` to `ubuntu-24.04` [[1](https://github.com/actions/runner-images/issues/10636)].

AMD announced AMD64 (the first 64-bit architecture that could also run 32-bit code) in 1999, and it released its first 64-bit processor in April 2003 [[2](https://en.wikipedia.org/wiki/X86-64#AMD64)]. Linux began removing support for 32-bit processors in 2012 [[3](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=743aa456c1834f76982af44e8b71d1a0b2a82e21)]. Ubuntu 18.04 LTS (released in April 2018) was the last version that supported 32-bits. Ubuntu 18.04 was a long-term support version that was supported for five years, but that support ended in May 2023 [[4](https://en.wikipedia.org/wiki/Ubuntu_version_history)]. Fedora removed support for 32-bits in Fedora 31 [[5](https://fedoraproject.org/wiki/Changes/Stop_Building_i686_Kernels)], and support for Fedora 30 ended in May 2020 [[6](https://en.wikipedia.org/wiki/Fedora_Linux_release_history)]. Although our 32-bit builds still worked on Ubuntu 22.04 LTS (released in April 2022 and will be supported until April 2027), they no longer work on Ubuntu 24.04 LTS, which was released earlier this year. There are other Linux distributions that still provide 32-bit versions [[7](https://itsfoss.com/32-bit-linux-distributions/)]. However, it makes sense to accept that Linux 32-bit support has ended.

Rebel Build Action [v3](https://github.com/RebelToolbox/RebelBuildAction/commit/8f17934ef6f4a99a85c4adeb6e3e7396245ca301) removed support for Linux 32-bit builds. This PR upgrades Rebel Build Action, used to create our releases, to v3 and removes support for Linux 32-bit builds from our nightly releases.

1. [https://github.com/actions/runner-images/issues/10636](https://github.com/actions/runner-images/issues/10636)
2. [https://en.wikipedia.org/wiki/X86-64#AMD64](https://en.wikipedia.org/wiki/X86-64#AMD64)
3. [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=743aa456c1834f76982af44e8b71d1a0b2a82e21](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=743aa456c1834f76982af44e8b71d1a0b2a82e21)
4. [https://en.wikipedia.org/wiki/Ubuntu_version_history](https://en.wikipedia.org/wiki/Ubuntu_version_history)
5. [https://fedoraproject.org/wiki/Changes/Stop_Building_i686_Kernels](https://fedoraproject.org/wiki/Changes/Stop_Building_i686_Kernels)
6. [https://en.wikipedia.org/wiki/Fedora_Linux_release_history](https://en.wikipedia.org/wiki/Fedora_Linux_release_history)
7. [https://itsfoss.com/32-bit-linux-distributions/](https://itsfoss.com/32-bit-linux-distributions/)