### PR TITLE
Remove clang-format off from Windows audio driver

### DIFF
--- a/platform/windows/windows_audio_driver.cpp
+++ b/platform/windows/windows_audio_driver.cpp
@@ -14,10 +14,11 @@
 #ifndef PKEY_Device_FriendlyName
 
 #undef DEFINE_PROPERTYKEY
-/* clang-format off */
-#define DEFINE_PROPERTYKEY(id, a, b, c, d, e, f, g, h, i, j, k, l) \
-	const PROPERTYKEY id = { { a, b, c, { d, e, f, g, h, i, j, k, } }, l };
-/* clang-format on */
+#define DEFINE_PROPERTYKEY(id, a, b, c, d, e, f, g, h, i, j, k, l)             \
+    const PROPERTYKEY id = {                                                   \
+        {a, b, c, {d, e, f, g, h, i, j, k}},                                   \
+        l                                                                      \
+    };
 
 DEFINE_PROPERTYKEY(
     PKEY_Device_FriendlyName,


### PR DESCRIPTION
[`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) code formatting was turned off in the Windows audio driver, because the formatting was odd. However, by removing a hanging comma (after the `k`), the formatting works as expected.

This PR removes the comma and allows `clang-format` to format the code correctly.