### PR TITLE
Remove dependence on VERSION_STATUS environmental variable

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -83,17 +83,7 @@ def update_version(module_version_string=""):
     f.write("#define VERSION_MAJOR " + str(version.major) + "\n")
     f.write("#define VERSION_MINOR " + str(version.minor) + "\n")
     f.write("#define VERSION_PATCH " + str(version.patch) + "\n")
-    # For dev snapshots (alpha, beta, RC, etc.) we do not commit status change to Git,
-    # so this define provides a way to override it without having to modify the source.
-    godot_status = str(version.status)
-    if os.getenv("GODOT_VERSION_STATUS") != None:
-        godot_status = str(os.getenv("GODOT_VERSION_STATUS"))
-        print(
-            "Using version status '{}', overriding the original '{}'.".format(
-                godot_status, str(version.status)
-            )
-        )
-    f.write('#define VERSION_STATUS "' + godot_status + '"\n')
+    f.write('#define VERSION_STATUS "' + str(version.status) + '"\n')
     f.write('#define VERSION_BUILD "' + str(build_name) + '"\n')
     f.write(
         '#define VERSION_MODULE_CONFIG "'

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -29,10 +29,7 @@ def get_build_version():
     v = "%d.%d" % (version.major, version.minor)
     if version.patch > 0:
         v += ".%d" % version.patch
-    status = version.status
-    if os.getenv("GODOT_VERSION_STATUS") != None:
-        status = str(os.getenv("GODOT_VERSION_STATUS"))
-    v += ".%s.%s" % (status, name)
+    v += ".%s.%s" % (version.status, name)
     return v
 
 


### PR DESCRIPTION
Currently, there is support for overriding the version status using an environmental variable. However, this unnecessarily obfuscates the status of a Rebel version.

This PR removes the ability to override the version status and a build's dependence of the external variable used. 