### PR TITLE
Remove workflow dependency on external software sources

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -52,11 +52,7 @@ jobs:
       - name: Linux dependencies
         shell: bash
         run: |
-          # Azure repositories are not reliable, we need to prevent azure giving us packages.
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f tools/ci/sources.list /etc/apt/sources.list
           sudo apt-get update
-          # The actual dependencies
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
               libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev \
               libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip

--- a/.github/workflows/server_builds.yml
+++ b/.github/workflows/server_builds.yml
@@ -34,11 +34,7 @@ jobs:
       - name: Linux dependencies
         shell: bash
         run: |
-          # Azure repositories are not reliable, we need to prevent azure giving us packages.
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f tools/ci/sources.list /etc/apt/sources.list
           sudo apt-get update
-          # The actual dependencies
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
               libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev \
               libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip

--- a/tools/ci/sources.list
+++ b/tools/ci/sources.list
@@ -1,4 +1,0 @@
-deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse


### PR DESCRIPTION
Currently the Linux build workflow does not use the Github software sources and relies on hard-coded sources. However, this results in the incorrect software sources being used when a different Github runner version is used.

This PR removes the dependency on hard-coded sources and allows the Github runner to define the correct software sources and be responsible for their reliability.  