### PR TITLE
Fix control reaches end of non-void function warnings

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -385,6 +385,7 @@ RES ResourceLoader::_load(
 #endif
 
     ERR_FAIL_V_MSG(RES(), "No loader found for resource: " + p_path + ".");
+    return RES();
 }
 
 bool ResourceLoader::_add_to_loading_map(const String& p_path) {
@@ -653,6 +654,7 @@ Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(
         Ref<ResourceInteractiveLoader>(),
         "No loader found for resource: " + path + "."
     );
+    return Ref<ResourceInteractiveLoader>();
 }
 
 void ResourceLoader::add_resource_format_loader(

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -788,6 +788,7 @@ PoolStringArray OS::get_connected_midi_inputs() {
             OS::get_singleton()->get_name()
         )
     );
+    return list;
 }
 
 void OS::open_midi_inputs() {

--- a/core/packed_data_container.cpp
+++ b/core/packed_data_container.cpp
@@ -79,6 +79,7 @@ Variant PackedDataContainer::_iter_get_ofs(
     } else {
         ERR_FAIL_V(Variant());
     }
+    return Variant();
 }
 
 Variant PackedDataContainer::_get_at_ofs(

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1084,6 +1084,7 @@ Error ProjectSettings::save_custom(
             "Unknown config file format: " + p_path + "."
         );
     }
+    return ERR_FILE_UNRECOGNIZED;
 }
 
 Variant _GLOBAL_DEF_ALIAS(

--- a/platform/windows/windows_dir_access.cpp
+++ b/platform/windows/windows_dir_access.cpp
@@ -333,6 +333,7 @@ String WindowsDirAccess::get_filesystem_type() const {
     }
 
     ERR_FAIL_V("");
+    return String();
 }
 
 WindowsDirAccess::WindowsDirAccess() {


### PR DESCRIPTION
The [`mingw-w64`](https://www.mingw-w64.org/) compiler, raises warnings that `control reaches end of non-void function [-Wreturn-type]` in:
- `core/io/resource_loader.cpp` line 388, in static member function `static RES ResourceLoader::_load(const String&, const String&, const String&, bool, Error*)`
- `core/io/resource_loader.cpp` line 656, in static member function `static Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String&, const String&, bool, Error*)`
- `core/os/os.cpp` line 791, in member function `virtual PoolStringArray OS::get_connected_midi_inputs()`
- `core/packed_data_container.cpp` line 82, in member function `Variant PackedDataContainer::_iter_get_ofs(const Variant&, uint32_t)`
- `core/project_settings.cpp` line 1087, in member function `Error ProjectSettings::save_custom(const String&, const CustomMap&, const Vector<String>&, bool)`
-`platform/windows/windows_dir_access.cpp` line 336, in member function `virtual String WindowsDirAccess::get_filesystem_type() const`

It appears that the compiler doesn't recognise that the `ERR_FAIL_V` and `ERR_FAIL_V_MSG` macros `if (true)` condition implies that the `else` branch will never be reached:
https://github.com/RebelToolbox/RebelEngine/blob/5afd8c9104a9b9e616695b5ad93545e0afeb0632/core/error_macros.h#L701-L712
https://github.com/RebelToolbox/RebelEngine/blob/5afd8c9104a9b9e616695b5ad93545e0afeb0632/core/error_macros.h#L718-L728

To avoid these warnings, this PR adds additional returns that mirror the `if (true)` returns.