### PR TITLE
Fix patch file created from black diff on Windows

### DIFF
--- a/tools/hooks/pre-commit-style-check
+++ b/tools/hooks/pre-commit-style-check
@@ -114,10 +114,12 @@ while read -r file; do
     "clang-format")
         "$application" ${options:+"$options"} "$file" | \
             diff -u "$file" - | \
-            sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch_file";;
+            sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" \
+            >> "$patch_file";;
     "black")
         "$application" ${options:+"$options"} --diff "$file" | \
-            sed -e "1s|--- |--- a/|" -e "2s|+++ |+++ b/|" >> "$patch_file";;
+            sed -e "1,2s|\\\\|/|g" -e "1s|--- |--- a/|" -e "2s|+++ |+++ b/|" \
+            >> "$patch_file";;
     *)
         echo "Unrecognised application: $application_name."
         echo "Please consider adding $application_name's method for creating diffs."


### PR DESCRIPTION
All code contributions are checked to ensure that they are consistent with Rebel's code styles. This is done automatically when changes are pushed to Github and a patch file with the changes required to make it consistent is created. This can be downloaded and applied to your changes using [Git apply](https://git-scm.com/docs/git-apply). To make it even easier for contributors, we have created [commit hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) that check the code style for consistency before a commit is created. The commit hooks create patch files that you are then prompted to automatically apply to make your changes consistent with the Rebel code styles.

We use [Black](https://black.readthedocs.io/en/stable/index.html) to apply a consistent Python code style. Black can create a [diff](https://duckduckgo.com/?t=ffab&q=git+diff&atb=v432-1&ia=web) that shows the changes required to make your code consistent with the Rebel code style. The diff for each file is converted to a single patch file that is used to apply the changes. Currently, on Windows, the patch file created by the Black Git hooks isn't working, because the diff created by Black uses the Windows directory separator `\`. These need to be converted to the POSIX directory separator `/` when creating a patch file.

This PR converts the Windows directory separator `\` to the POSIX directory separator `/` when combining the Black diff files to a patch file that can then be automatically applied in the code style check commit hook.
