### PR TITLE
Update .gitignore to exclude C# compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ platforms/android/project/*/.cxx/
 platforms/android/project/*/libs/
 platforms/android/project/**/jniLibs/
 
+# CSharp generated
+obj/
+
 # Python generated
 __pycache__/
 


### PR DESCRIPTION
#116 removed a lot of unnecessary excludes from `.gitignore`. However, it also removed the `/obj` folders, which are created by C# builds.

To avoid C# build files being included in commits, this PR adds the C# build files folder to `.gitignore`.