### PR TITLE
Add a default copy constructor to CharProxy

### DIFF
--- a/core/ustring.h
+++ b/core/ustring.h
@@ -26,6 +26,8 @@ class CharProxy {
         _cowdata(cowdata) {}
 
 public:
+    CharProxy(const CharProxy<T>& p_other) = default;
+
     _FORCE_INLINE_ operator T() const {
         if (unlikely(_index == _cowdata.size())) {
             return _null;


### PR DESCRIPTION
When there is copy assignment operator defined, relying on the definition of an implicit copy constructor is deprecated. Currently  `CharProxy<T>` has a copy assignment operator defined, but no copy constructor:
https://github.com/RebelToolbox/RebelEngine/blob/d310162b2d0f93dc1b3cfb15bc0c1b20e56fbf13/core/ustring.h#L45-L47
This PR tells the compiler to use the default copy constructor.