### PR TITLE
Make tile data size a constant

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1517,14 +1517,15 @@ void TileMap::_set_tile_data(const PoolVector<int>& p_data) {
     int c                   = p_data.size();
     PoolVector<int>::Read r = p_data.read();
 
-    int offset = (format == FORMAT_2) ? 3 : 2;
+    const int data_size = (format == FORMAT_2) ? 12 : 8;
+    const int offset    = (format == FORMAT_2) ? 3 : 2;
     ERR_FAIL_COND_MSG(c % offset != 0, "Corrupted tile data.");
 
     clear();
     for (int i = 0; i < c; i += offset) {
         const uint8_t* ptr = (const uint8_t*)&r[i];
         uint8_t local[12];
-        for (int j = 0; j < ((format == FORMAT_2) ? 12 : 8); j++) {
+        for (int j = 0; j < data_size; j++) {
             local[j] = ptr[j];
         }
 


### PR DESCRIPTION
Currently, [`gcc`](https://gcc.gnu.org/) is raising an index overflow warning:
```
scene/2d/tile_map.cpp: In member function 'void TileMap::_set_tile_data(const PoolVector<int>&)':
scene/2d/tile_map.cpp:1528:22: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
 1528 |             local[j] = ptr[j];
      |             ~~~~~~~~~^~~~~~~~
scene/2d/tile_map.cpp:1526:17: note: at offset 12 into destination object 'local' of size 12
 1526 |         uint8_t local[12];
      |                 ^~~~~
```
This is a false warning. The index will never be 12, because the loop limit will be less than 12 or 8:
https://github.com/RebelToolbox/RebelEngine/blob/d310162b2d0f93dc1b3cfb15bc0c1b20e56fbf13/scene/2d/tile_map.cpp#L1527-L1529
However, to avoid confusion and prevent the limit being calculated every time, this PR makes the limit (the data size) a constant.