### PR TITLE
Fix may be used uninitialized warning in CSG module

### DIFF
--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -192,7 +192,7 @@ struct CSGBrushOperation {
         Plane plane;
         Transform to_2D;
         Transform to_3D;
-        float vertex_snap2;
+        float vertex_snap2 = 0.0f;
 
         inline int _get_point_idx(const Vector2& p_point);
         inline int _add_vertex(const Vertex2D& p_vertex);


### PR DESCRIPTION
The CSG module's `Build2DFaces` struct has a default constructor that is used to store faces that are not used.
https://github.com/RebelToolbox/RebelEngine/blob/32fd5c7725407024547fd96362c937e05b1341ef/modules/csg/csg.cpp#L1693-L1710
However, the compiler is warning that these objects have a variable that is then not initialised even though it is never used. This PR initialises the variable to zero.