### PR TITLE
Separate UDP packet reading and converting to integer

### DIFF
--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -88,12 +88,16 @@ Error PacketPeerUDP::get_packet(const uint8_t** r_buffer, int& r_buffer_size) {
         return ERR_UNAVAILABLE;
     }
 
-    uint32_t size = 0;
     uint8_t ipv6[16];
+    uint8_t packet_port_bytes[4]{};
+    uint8_t size_bytes[4]{};
+    uint32_t size = 0;
     rb.read(ipv6, 16, true);
     packet_ip.set_ipv6(ipv6);
-    rb.read((uint8_t*)&packet_port, 4, true);
-    rb.read((uint8_t*)&size, 4, true);
+    rb.read(packet_port_bytes, 4, true);
+    memcpy(&packet_port, packet_port_bytes, 4);
+    rb.read(size_bytes, 4, true);
+    memcpy(&size, size_bytes, 4);
     rb.read(packet_buffer, size, true);
     --queue_count;
     *r_buffer     = packet_buffer;


### PR DESCRIPTION
Currently, when retrieving a UDP peer packet, bytes are converted to integers by casting the integers to byte pointers that are then used as byte arrays to read the bytes representing the integers. The [gcc](https://gcc.gnu.org/) compiler [detects](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow) the attempt to write to memory adjacent to the pointer and not to the next element of the array and raises an overflow error.
```
./core/ring_buffer.h:44:30: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
   44 |                 p_buf[dst++] = read[pos + i];
      |                 ~~~~~~~~~~~~~^~~~~~~
```
This PR separates the reading of the bytes into an array of four bytes, and the conversion of those four bytes into an integer.