### PR TITLE
Fix may be used uninitialized warning in Audio Server

### DIFF
--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -225,7 +225,7 @@ private:
             Ref<AudioEffect> effect;
             bool enabled;
 #ifdef DEBUG_ENABLED
-            uint64_t prof_time;
+            uint64_t prof_time = 0;
 #endif
         };
 


### PR DESCRIPTION
The Audio Server's Bus Effect `struct` has a debugging variable `prof_time` that may be used uninitialised:
```
servers/audio_server.h:224:16: error: 'bfx.AudioServer::Bus::Effect::prof_time' may be used uninitialized [-Werror=maybe-uninitialized]
  224 |         struct Effect {
      |                ^~~~~~
servers/audio_server.cpp: In member function 'void AudioServer::set_bus_layout(const Ref<AudioBusLayout>&)':
servers/audio_server.cpp:1289:29: note: 'bfx' declared here
 1289 |                 Bus::Effect bfx;
      |                             ^~~
```
This PR assigns it a default value of `0`.