### PR TITLE
Ignore temporary build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ obj/
 # Python generated
 __pycache__/
 
+# Temporary files
+*.tmp
 
 # 3. IDE and tool specific
 #    #####################


### PR DESCRIPTION
#116 removed a lot of unnecessary excludes from `.gitignore`. However, it also removed the `*.tmp` files, which are created by compilers.

To avoid temporary build files being included in commits, this PR adds `*.tmp` files to `.gitignore`.