### PR TITLE
Fix may be used unitialized in Physics Space

### DIFF
--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -136,9 +136,9 @@ bool PhysicsDirectSpaceStateSW::intersect_ray(
 
     bool collided = false;
     Vector3 res_point, res_normal;
-    int res_shape;
-    const CollisionObjectSW* res_obj;
-    real_t min_d = 1e10;
+    int res_shape                    = 0;
+    const CollisionObjectSW* res_obj = nullptr;
+    real_t min_d                     = 1e10;
 
     for (int i = 0; i < amount; i++) {
         if (!_can_collide_with(
@@ -196,7 +196,7 @@ bool PhysicsDirectSpaceStateSW::intersect_ray(
         }
     }
 
-    if (!collided) {
+    if (!collided || res_obj == nullptr) {
         return false;
     }
 

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -201,9 +201,9 @@ bool Physics2DDirectSpaceStateSW::intersect_ray(
 
     bool collided = false;
     Vector2 res_point, res_normal;
-    int res_shape;
-    const CollisionObject2DSW* res_obj;
-    real_t min_d = 1e10;
+    int res_shape                      = 0;
+    const CollisionObject2DSW* res_obj = nullptr;
+    real_t min_d                       = 1e10;
 
     for (int i = 0; i < amount; i++) {
         if (!_can_collide_with(
@@ -265,7 +265,7 @@ bool Physics2DDirectSpaceStateSW::intersect_ray(
         }
     }
 
-    if (!collided) {
+    if (!collided || res_obj == nullptr) {
         return false;
     }
 


### PR DESCRIPTION
The compiler is detecting that `res_shape` and `res_obj` may be used uninitialized in Physics' space's `interset_ray()` method:
```
In file included from ./thirdparty/misc/pcg.h:7,
                 from ./core/math/random_pcg.h:11,
                 from ./core/math/math_funcs.h:11,
                 from servers/physics_2d/broad_phase_2d_sw.h:10,
                 from servers/physics_2d/collision_object_2d_sw.h:10,
                 from servers/physics_2d/area_2d_sw.h:10,
                 from servers/physics_2d/space_2d_sw.h:10,
                 from servers/physics_2d/space_2d_sw.cpp:7:
In member function 'const Variant& CollisionObject2DSW::get_shape_metadata(int) const',
    inlined from 'virtual bool Physics2DDirectSpaceStateSW::intersect_ray(const Vector2&, const Vector2&, Physics2DDirectSpaceState::RayResult&, const Set<RID>&, uint32_t, bool, bool)' at servers/physics_2d/space_2d_sw.cpp:277:23:
./core/typedefs.h:300:37: error: 'res_shape' may be used uninitialized [-Werror=maybe-uninitialized]
  300 | #define unlikely(x) __builtin_expect(!!(x), 0)
      |                     ~~~~~~~~~~~~~~~~^~~~~~~~~~
./core/error_macros.h:264:9: note: in expansion of macro 'unlikely'
  264 |     if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                    \
      |         ^~~~~~~~
servers/physics_2d/collision_object_2d_sw.h:155:9: note: in expansion of macro 'CRASH_BAD_INDEX'
  155 |         CRASH_BAD_INDEX(p_index, shapes.size());
      |         ^~~~~~~~~~~~~~~
servers/physics_2d/space_2d_sw.cpp: In member function 'virtual bool Physics2DDirectSpaceStateSW::intersect_ray(const Vector2&, const Vector2&, Physics2DDirectSpaceState::RayResult&, const Set<RID>&, uint32_t, bool, bool)':
servers/physics_2d/space_2d_sw.cpp:204:9: note: 'res_shape' was declared here
  204 |     int res_shape;
      |         ^~~~~~~~~
In member function 'RID CollisionObject2DSW::get_self() const',
    inlined from 'virtual bool Physics2DDirectSpaceStateSW::intersect_ray(const Vector2&, const Vector2&, Physics2DDirectSpaceState::RayResult&, const Set<RID>&, uint32_t, bool, bool)' at servers/physics_2d/space_2d_sw.cpp:279:42:
servers/physics_2d/collision_object_2d_sw.h:93:16: error: 'res_obj' may be used uninitialized [-Werror=maybe-uninitialized]
   93 |         return self;
      |                ^~~~
servers/physics_2d/space_2d_sw.cpp: In member function 'virtual bool Physics2DDirectSpaceStateSW::intersect_ray(const Vector2&, const Vector2&, Physics2DDirectSpaceState::RayResult&, const Set<RID>&, uint32_t, bool, bool)':
servers/physics_2d/space_2d_sw.cpp:205:32: note: 'res_obj' was declared here
  205 |     const CollisionObject2DSW* res_obj;
      |                                ^~~~~~~
```
The `res_shape` and `res_obj` variables in Physics space's `intersect_ray()` method will never be used uninitialized, because they are assigned when setting `collided = true`:
https://github.com/RebelToolbox/RebelEngine/blob/d096042d72ac76ff7c0a557d9b423c5fc0aa6b88/servers/physics/space_sw.cpp#L192-L194
and only used if `collided` is `true`:
https://github.com/RebelToolbox/RebelEngine/blob/d096042d72ac76ff7c0a557d9b423c5fc0aa6b88/servers/physics/space_sw.cpp#L199-L201
This PR assigns default values and ensures that the `res_obj` is not a `nullptr` before trying to use it in both 2D and 3D space. 

