### PR TITLE
Use an older version of Ubuntu for creating Linux builds

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -20,7 +20,7 @@ jobs:
         include:
           # Rebel Editor builds
           - name: Linux Editor
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: linux-editor
             build-options: production=yes target=release_debug
             rebel-executable: rebel.linux.opt.tools.64
@@ -45,13 +45,13 @@ jobs:
 
           # Rebel Engine Linux builds
           - name: Linux Engine 64 bit
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: linux-engine-x86-64
             build-options: production=yes tools=no target=release
             rebel-executable: rebel.linux.opt.64
 
           - name: Linux Engine 64 bit Debug
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: linux-engine-x86-64-debug
             build-options: production=yes tools=no target=release_debug
             rebel-executable: rebel.linux.opt.debug.64


### PR DESCRIPTION
Currently, when trying to run our nightly release on [Debian](https://www.debian.org/) based versions of Linux, we get an error:
```
/lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
```
On Linux, [`glibc`](https://www.gnu.org/software/libc/) provides the core libraries for the operating system. When building applications on Linux, the compiler binds the application to a particular version of `glibc`. In general, `glibc` is backwards compatible*[[1](https://abi-laboratory.pro/?view=timeline&l=glibc)]. So, running the application on a different Linux operating system will work if the operating system's version of `glibc` is the same or newer. This allows old applications to run on newer versions of Linux. However, trying to run an application built with a newer version of `glibc` on a older version of Linux will probably fail. To support older versions of Linux, the application needs to be built on an older version of Linux.

We are currently building our release builds on the `ubuntu-latest` Github runner, which uses Ubuntu 24.04, which uses `glibc` version 2.39[[2](https://launchpad.net/ubuntu/+source/glibc)]. Ubuntu 22.04 uses `glibc` version 2.35. Debian stable uses `glibc` version 2.36[[3](https://tracker.debian.org/pkg/glibc)]. To support users using Ubuntu 22.04 or Debian stable, we need to build Rebel using Ubuntu 22.04.

This PR changes the version of Ubuntu used to build Rebel to Ubuntu 22.04. This will bind Rebel to `glibc` version 2.35, which allow people using Ubuntu 22.04 Debian stable or any version of Linux using `glibc` version 2.35 or newer to run the Rebel Linux release builds.

* There are limits to the backwards compatibility[[1](https://abi-laboratory.pro/?view=timeline&l=glibc)].

References
[1] https://abi-laboratory.pro/?view=timeline&l=glibc.
[2] https://launchpad.net/ubuntu/+source/glibc
[3] https://tracker.debian.org/pkg/glibc