### PR TITLE
Ensure that GLES Canvas batch pointer is never a nullptr

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -823,7 +823,7 @@ protected:
 public:
     Batch* _batch_request_new(bool p_blank = true) {
         Batch* batch = bdata.batches.request();
-        if (!batch) {
+        while (!batch) {
             // grow the batches
             bdata.batches.grow();
 
@@ -833,7 +833,6 @@ public:
 
             // this should always succeed after growing
             batch = bdata.batches.request();
-            RAST_DEBUG_ASSERT(batch);
         }
 
         if (p_blank) {


### PR DESCRIPTION
Currently, when requesting a new GLES Canvas Batch, a `nullptr` will be returned if the array is full. When a `nullptr` is returned, the Batch arrays are grown, and a new Batch is requested:
https://github.com/RebelToolbox/RebelEngine/blob/0ded4522c8273359146eee0d4dd8c537aff4ce09/drivers/gles_common/rasterizer_canvas_batcher.h#L825-L837
Since, after the array is grown, it can never be full, we can be certain that, when now requesting a new GLES Canvas Batch, a `nullptr` will never be returned. However, the compiler cannot be certain of this, and it complains that, if a `nullptr` is returned, we cannot use `memset` on it:
```
In function 'void* memset(void*, int, size_t)',
    inlined from 'RasterizerCanvasBatcher<T, T_STORAGE>::Batch* RasterizerCanvasBatcher<T, T_STORAGE>::_batch_request_new(bool) [with T = RasterizerCanvasGLES3; T_STORAGE = RasterizerStorageGLES3]' at ./drivers/gles_common/rasterizer_canvas_batcher.h:840:19,
    inlined from 'void RasterizerCanvasBatcher<T, T_STORAGE>::_prefill_default_batch(FillState&, int, const RasterizerCanvas::Item&) [with T = RasterizerCanvasGLES3; T_STORAGE = RasterizerStorageGLES3]' at ./drivers/gles_common/rasterizer_canvas_batcher.h:1090:63,
    inlined from 'void RasterizerCanvasBatcher<T, T_STORAGE>::_prefill_default_batch(FillState&, int, const RasterizerCanvas::Item&) [with T = RasterizerCanvasGLES3; T_STORAGE = RasterizerStorageGLES3]' at ./drivers/gles_common/rasterizer_canvas_batcher.h:1027:1:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:59:33: error: 'void* __builtin_memset(void*, int, long unsigned int)' offset [0, 29] is out of the bounds [0, 0] [-Werror=array-bounds=]
   59 |   return __builtin___memset_chk (__dest, __ch, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
   60 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Instead of trying to fix the code to ensure a `nullptr` is never returned, which would require considerable refactoring, and instead of telling the compiler we will crash Rebel Engine if a `nullptr` is returned after growing the array (which currently only happens in Rebel Editor and only in debug builds) this PR uses a `while` loop to convince the compiler that the pointer to the new Batch will never be a `nullptr`.