### PR TITLE
Assign a default value of zero to MipMaps Size GL names

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1470,8 +1470,8 @@ public:
 
         struct MipMaps {
             struct Size {
-                GLuint fbo;
-                GLuint color;
+                GLuint fbo   = 0;
+                GLuint color = 0;
                 int width;
                 int height;
             };

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1609,7 +1609,7 @@ public:
         struct Effects {
             struct MipMaps {
                 struct Size {
-                    GLuint fbo;
+                    GLuint fbo = 0;
                     int width;
                     int height;
                 };


### PR DESCRIPTION
Currently, the compiler is warning that GL names in the GLES2 and GLES3 Rasterizer Storage's Render Target's Mip Maps' Size `struct` may be used uninitialized.
Although they are assinged before they are used, this PR assigns them a default value of 0.
