### PR TITLE
Treat warnings as errors in Linux build tests

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   BRANCH_NAME: main
-  SCONSFLAGS: verbose=yes warnings=all
+  SCONSFLAGS: verbose=yes warnings=all werror=yes
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux

--- a/.github/workflows/server_builds.yml
+++ b/.github/workflows/server_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   BRANCH_NAME: main
-  SCONSFLAGS: verbose=yes warnings=all debug_symbols=no module_mono_enabled=yes mono_static=yes mono_glue=no
+  SCONSFLAGS: verbose=yes warnings=all werror=yes debug_symbols=no module_mono_enabled=yes mono_static=yes mono_glue=no
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-server


### PR DESCRIPTION
#158 disabled treating all warnings as errors in jobs running on Ubuntu. This was a temporary workaround until all the bugs identified by the new version of the compiler had been addressed.
These bugs were addressed in: #154, #155, #156, #157, #159, #160, #161, #164, #166, #167 and #168. Therefore, this PR re-enables treating all warnings as errors in jobs running on Ubuntu.

**Note:** Some of the fixes are themselves workarounds until the code can be properly refactored to comply with [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines); specifically [Resource acquisition is initialization (RAII)](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization): Not initialising variables when objects are created was often the reason for these warnings.
