### PR TITLE
Fix spelling of _on_browse_button_pressed method

### DIFF
--- a/projects_manager/add_project_dialog.cpp
+++ b/projects_manager/add_project_dialog.cpp
@@ -41,7 +41,7 @@ AddProjectDialog::AddProjectDialog() {
 
     Button* browse_button = memnew(Button);
     browse_button->set_text(TTR("Browse"));
-    browse_button->connect("pressed", this, "_on_browse_buton_pressed");
+    browse_button->connect("pressed", this, "_on_browse_button_pressed");
     project_file_container->add_child(browse_button);
 
     error_message_label = memnew(Label);
@@ -79,8 +79,8 @@ void AddProjectDialog::show_dialog() {
 
 void AddProjectDialog::_bind_methods() {
     ClassDB::bind_method(
-        "_on_browse_buton_pressed",
-        &AddProjectDialog::_on_browse_buton_pressed
+        "_on_browse_button_pressed",
+        &AddProjectDialog::_on_browse_button_pressed
     );
     ClassDB::bind_method(
         "_on_file_selected",
@@ -131,7 +131,7 @@ void AddProjectDialog::_check_file(const String& p_file) {
     set_size(Size2(500, 0) * EDSCALE);
 }
 
-void AddProjectDialog::_on_browse_buton_pressed() {
+void AddProjectDialog::_on_browse_button_pressed() {
     file_dialog->set_current_dir(project_file_line_edit->get_text());
     file_dialog->set_mode(FileDialog::MODE_OPEN_FILE);
     file_dialog->clear_filters();

--- a/projects_manager/add_project_dialog.h
+++ b/projects_manager/add_project_dialog.h
@@ -36,7 +36,7 @@ private:
     TextureRect* project_file_error_icon;
 
     void _check_file(const String& p_file);
-    void _on_browse_buton_pressed();
+    void _on_browse_button_pressed();
     void _on_file_selected(const String& p_path);
     void _on_project_file_text_changed(const String& p_text);
 };


### PR DESCRIPTION
Fixes spelling of Projects Manager's `_on_browse_button_pressed` method.