### PR TITLE
Refactor ProjectSettings

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -19,7 +19,12 @@
 
 #include <zlib.h>
 
-const String ProjectSettings::PROJECT_DATA_DIR_NAME_SUFFIX = "import";
+bool operator<(const Setting& left, const Setting& right) {
+    if (left.position == right.position) {
+        return left.name < right.name;
+    }
+    return left.position < right.position;
+}
 
 ProjectSettings* ProjectSettings::singleton = nullptr;
 
@@ -27,1270 +32,8 @@ ProjectSettings* ProjectSettings::get_singleton() {
     return singleton;
 }
 
-String ProjectSettings::get_project_data_dir_name() const {
-    return project_data_dir_name;
-}
-
-String ProjectSettings::get_project_data_path() const {
-    return "res://" + get_project_data_dir_name();
-}
-
-String ProjectSettings::get_resource_path() const {
-    return resource_path;
-};
-
-String ProjectSettings::localize_path(const String& p_path) const {
-    if (resource_path.empty() || p_path.begins_with("res://")
-        || p_path.begins_with("user://")
-        || (p_path.is_abs_path() && !p_path.begins_with(resource_path))) {
-        return p_path.simplify_path();
-    }
-
-    DirAccess* dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-
-    String path = p_path.replace("\\", "/").simplify_path();
-
-    if (dir->change_dir(path) == OK) {
-        String cwd = dir->get_current_dir();
-        cwd        = cwd.replace("\\", "/");
-
-        memdelete(dir);
-
-        // Ensure that we end with a '/'.
-        // This is important to ensure that we do not wrongly localize the
-        // resource path in an absolute path that just happens to contain this
-        // string but points to a different folder (e.g. "/my/project" as
-        // resource_path would be contained in
-        // "/my/project_data", even though the latter is not part of res://.
-        // `plus_file("")` is an easy way to ensure we have a trailing '/'.
-        const String res_path = resource_path.plus_file("");
-
-        // DirAccess::get_current_dir() is not guaranteed to return a path that
-        // with a trailing '/', so we must make sure we have it as well in order
-        // to compare with 'res_path'.
-        cwd = cwd.plus_file("");
-
-        if (!cwd.begins_with(res_path)) {
-            return p_path;
-        };
-
-        return cwd.replace_first(res_path, "res://");
-    } else {
-        memdelete(dir);
-
-        int sep = path.find_last("/");
-        if (sep == -1) {
-            return "res://" + path;
-        };
-
-        String parent = path.substr(0, sep);
-
-        String plocal = localize_path(parent);
-        if (plocal == "") {
-            return "";
-        };
-        // Only strip the starting '/' from 'path' if its parent ('plocal') ends
-        // with '/'
-        if (plocal[plocal.length() - 1] == '/') {
-            sep += 1;
-        }
-        return plocal + path.substr(sep, path.size() - sep);
-    };
-}
-
-void ProjectSettings::set_initial_value(
-    const String& p_name,
-    const Variant& p_value
-) {
-    ERR_FAIL_COND_MSG(
-        !props.has(p_name),
-        "Request for nonexistent project setting: " + p_name + "."
-    );
-    props[p_name].initial = p_value;
-}
-
-void ProjectSettings::set_restart_if_changed(
-    const String& p_name,
-    bool p_restart
-) {
-    ERR_FAIL_COND_MSG(
-        !props.has(p_name),
-        "Request for nonexistent project setting: " + p_name + "."
-    );
-    props[p_name].restart_if_changed = p_restart;
-}
-
-void ProjectSettings::set_ignore_value_in_docs(
-    const String& p_name,
-    bool p_ignore
-) {
-    ERR_FAIL_COND_MSG(
-        !props.has(p_name),
-        "Request for nonexistent project setting: " + p_name + "."
-    );
-#ifdef DEBUG_METHODS_ENABLED
-    props[p_name].ignore_value_in_docs = p_ignore;
-#endif
-}
-
-bool ProjectSettings::get_ignore_value_in_docs(const String& p_name) const {
-    ERR_FAIL_COND_V_MSG(
-        !props.has(p_name),
-        false,
-        "Request for nonexistent project setting: " + p_name + "."
-    );
-#ifdef DEBUG_METHODS_ENABLED
-    return props[p_name].ignore_value_in_docs;
-#else
-    return false;
-#endif
-}
-
-String ProjectSettings::globalize_path(const String& p_path) const {
-    if (p_path.begins_with("res://")) {
-        if (resource_path != "") {
-            return p_path.replace("res:/", resource_path);
-        };
-        return p_path.replace("res://", "");
-    } else if (p_path.begins_with("user://")) {
-        String data_dir = OS::get_singleton()->get_user_data_dir();
-        if (data_dir != "") {
-            return p_path.replace("user:/", data_dir);
-        };
-        return p_path.replace("user://", "");
-    }
-
-    return p_path;
-}
-
-bool ProjectSettings::_set(const StringName& p_name, const Variant& p_value) {
-    _THREAD_SAFE_METHOD_
-
-    if (p_value.get_type() == Variant::NIL) {
-        props.erase(p_name);
-    } else {
-        if (p_name == CoreStringNames::get_singleton()->_custom_features) {
-            Vector<String> custom_feature_array = String(p_value).split(",");
-            for (int i = 0; i < custom_feature_array.size(); i++) {
-                custom_features.insert(custom_feature_array[i]);
-            }
-            return true;
-        }
-
-        if (!disable_feature_overrides) {
-            int dot = p_name.operator String().find(".");
-            if (dot != -1) {
-                Vector<String> s = p_name.operator String().split(".");
-
-                bool override_valid = false;
-                for (int i = 1; i < s.size(); i++) {
-                    String feature = s[i].strip_edges();
-                    if (OS::get_singleton()->has_feature(feature)
-                        || custom_features.has(feature)) {
-                        override_valid = true;
-                        break;
-                    }
-                }
-
-                if (override_valid) {
-                    feature_overrides[s[0]] = p_name;
-                }
-            }
-        }
-
-        if (props.has(p_name)) {
-            if (!props[p_name].overridden) {
-                props[p_name].variant = p_value;
-            }
-
-        } else {
-            props[p_name] = VariantContainer(p_value, last_order++);
-        }
-    }
-
-    return true;
-}
-
-bool ProjectSettings::_get(const StringName& p_name, Variant& r_ret) const {
-    _THREAD_SAFE_METHOD_
-
-    StringName name = p_name;
-    if (!disable_feature_overrides && feature_overrides.has(name)) {
-        name = feature_overrides[name];
-    }
-    if (!props.has(name)) {
-        WARN_PRINT("Property not found: " + String(name));
-        return false;
-    }
-    r_ret = props[name].variant;
-    return true;
-}
-
-struct _VCSort {
-    String name;
-    Variant::Type type;
-    int order;
-    int flags;
-
-    bool operator<(const _VCSort& p_vcs) const {
-        return order == p_vcs.order ? name < p_vcs.name : order < p_vcs.order;
-    }
-};
-
-void ProjectSettings::_get_property_list(List<PropertyInfo>* p_list) const {
-    _THREAD_SAFE_METHOD_
-
-    Set<_VCSort> vclist;
-
-    for (Map<StringName, VariantContainer>::Element* E = props.front(); E;
-         E                                             = E->next()) {
-        const VariantContainer* v = &E->get();
-
-        if (v->hide_from_editor) {
-            continue;
-        }
-
-        _VCSort vc;
-        vc.name  = E->key();
-        vc.order = v->order;
-        vc.type  = v->variant.get_type();
-        if (vc.name.begins_with("input/") || vc.name.begins_with("import/")
-            || vc.name.begins_with("export/") || vc.name.begins_with("/remap")
-            || vc.name.begins_with("/locale")
-            || vc.name.begins_with("/autoload")) {
-            vc.flags = PROPERTY_USAGE_STORAGE;
-        } else {
-            vc.flags = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
-        }
-
-        if (v->restart_if_changed) {
-            vc.flags |= PROPERTY_USAGE_RESTART_IF_CHANGED;
-        }
-        vclist.insert(vc);
-    }
-
-    for (Set<_VCSort>::Element* E = vclist.front(); E; E = E->next()) {
-        String prop_info_name = E->get().name;
-        int dot               = prop_info_name.find(".");
-        if (dot != -1) {
-            prop_info_name = prop_info_name.substr(0, dot);
-        }
-
-        if (custom_prop_info.has(prop_info_name)) {
-            PropertyInfo pi = custom_prop_info[prop_info_name];
-            pi.name         = E->get().name;
-            pi.usage        = E->get().flags;
-            p_list->push_back(pi);
-        } else {
-            p_list->push_back(PropertyInfo(
-                E->get().type,
-                E->get().name,
-                PROPERTY_HINT_NONE,
-                "",
-                E->get().flags
-            ));
-        }
-    }
-}
-
-bool ProjectSettings::_load_resource_pack(
-    const String& p_pack,
-    bool p_replace_files,
-    int p_offset
-) {
-    if (PackedData::get_singleton()->is_disabled()) {
-        return false;
-    }
-
-    bool ok =
-        PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset)
-        == OK;
-
-    if (!ok) {
-        return false;
-    }
-
-    // if data.pck is found, all directory access will be from here
-    DirAccess::make_default<DirAccessPack>(DirAccess::ACCESS_RESOURCES);
-    using_datapack = true;
-
-    return true;
-}
-
-void ProjectSettings::_convert_to_last_version(int p_from_version) {
-    if (p_from_version <= 3) {
-        // Converts the actions from array to dictionary (array of events to
-        // dictionary with deadzone + events)
-        for (Map<StringName, ProjectSettings::VariantContainer>::Element* E =
-                 props.front();
-             E;
-             E = E->next()) {
-            Variant value = E->get().variant;
-            if (String(E->key()).begins_with("input/")
-                && value.get_type() == Variant::ARRAY) {
-                Array array = value;
-                Dictionary action;
-                action["deadzone"] = Variant(0.5f);
-                action["events"]   = array;
-                E->get().variant   = action;
-            }
-        }
-    }
-}
-
-/*
- * This method is responsible for loading a project.rebel file and/or data file
- * using the following merit order:
- *  - If using NetworkClient, try to lookup project file or fail.
- *  - If --main-pack was passed by the user (`p_main_pack`), load it or fail.
- *  - Search for project PCKs automatically. For each step we try loading a
- * potential PCK, and if it doesn't work, we proceed to the next step. If any
- * step succeeds, we try loading the project settings, and abort if it fails.
- * Steps: o Bundled PCK in the executable. o [macOS only] PCK with same basename
- * as the binary in the .app resource dir. o PCK with same basename as the
- * binary in the binary's directory. We handle both changing the extension to
- * '.pck' (e.g. 'win_game.exe' -> 'win_game.pck') and appending '.pck' to the
- * binary name (e.g. 'linux_game' -> 'linux_game.pck'). o PCK with the same
- * basename as the binary in the current working directory. Same as above for
- * the two possible PCK file names.
- *  - On relevant platforms (Android/iOS), lookup project file in OS resource
- * path. If found, load it or fail.
- *  - Lookup project file in passed `p_path` (--path passed by the user), i.e.
- * we are running from source code. If not found and `p_upwards` is true
- * (--upwards passed by the user), look for project files in parent folders up
- * to the system root (used to run a game from command line while in a
- * subfolder). If a project file is found, load it or fail. If nothing was
- * found, error out.
- */
-Error ProjectSettings::_setup(
-    const String& p_path,
-    const String& p_main_pack,
-    bool p_upwards
-) {
-    // If looking for files in a network client, use it directly
-
-    if (FileAccessNetworkClient::get_singleton()) {
-        Error err = _load_settings_text_or_binary(
-            "res://project.rebel",
-            "res://project.binary"
-        );
-        if (err == OK) {
-            // Optional, we don't mind if it fails
-            _load_settings_text("res://override.cfg");
-        }
-        return err;
-    }
-
-    // Attempt with a user-defined main pack first
-
-    if (p_main_pack != "") {
-        bool ok = _load_resource_pack(p_main_pack);
-        ERR_FAIL_COND_V_MSG(
-            !ok,
-            ERR_CANT_OPEN,
-            "Cannot open resource pack '" + p_main_pack + "'."
-        );
-
-        Error err = _load_settings_text_or_binary(
-            "res://project.rebel",
-            "res://project.binary"
-        );
-        if (err == OK) {
-            // Load override from location of the main pack
-            // Optional, we don't mind if it fails
-            _load_settings_text(
-                p_main_pack.get_base_dir().plus_file("override.cfg")
-            );
-        }
-        return err;
-    }
-
-    String exec_path = OS::get_singleton()->get_executable_path();
-
-    if (exec_path != "") {
-        // We do several tests sequentially until one succeeds to find a PCK,
-        // and if so we attempt loading it at the end.
-
-        // Attempt with PCK bundled into executable.
-        bool found = _load_resource_pack(exec_path);
-
-        // Attempt with exec_name.pck.
-        // (This is the usual case when distributing a Rebel game.)
-        String exec_dir      = exec_path.get_base_dir();
-        String exec_filename = exec_path.get_file();
-        String exec_basename = exec_filename.get_basename();
-
-        // Based on the OS, it can be the exec path + '.pck' (Linux w/o
-        // extension, macOS in .app bundle) or the exec path's basename + '.pck'
-        // (Windows). We need to test both possibilities as extensions for Linux
-        // binaries are optional (so both 'mygame.bin' and 'mygame' should be
-        // able to find 'mygame.pck').
-
-#ifdef MACOS_ENABLED
-        if (!found) {
-            // Attempt to load PCK from macOS .app bundle resources.
-            found = _load_resource_pack(OS::get_singleton()
-                                            ->get_bundle_resource_dir()
-                                            .plus_file(exec_basename + ".pck"))
-                 || _load_resource_pack(OS::get_singleton()
-                                            ->get_bundle_resource_dir()
-                                            .plus_file(exec_filename + ".pck"));
-        }
-#endif
-
-        if (!found) {
-            // Try to load data pack at the location of the executable.
-            // As mentioned above, we have two potential names to attempt.
-            found =
-                _load_resource_pack(exec_dir.plus_file(exec_basename + ".pck"))
-                || _load_resource_pack(
-                    exec_dir.plus_file(exec_filename + ".pck")
-                );
-        }
-
-        if (!found) {
-            // If we couldn't find them next to the executable, we attempt
-            // the current working directory. Same story, two tests.
-            found = _load_resource_pack(exec_basename + ".pck")
-                 || _load_resource_pack(exec_filename + ".pck");
-        }
-
-        // If we opened our package, try and load our project.
-        if (found) {
-            Error err = _load_settings_text_or_binary(
-                "res://project.rebel",
-                "res://project.binary"
-            );
-            if (err == OK) {
-                // Load override from location of the executable.
-                // Optional, we don't mind if it fails.
-                _load_settings_text(
-                    exec_path.get_base_dir().plus_file("override.cfg")
-                );
-            }
-            return err;
-        }
-    }
-
-    // Try to use the filesystem for files, according to OS.
-    // (Only Android -when reading from pck- and iOS use this.)
-
-    if (OS::get_singleton()->get_resource_dir() != "") {
-        // OS will call ProjectSettings->get_resource_path which will be empty
-        // if not overridden! If the OS would rather use a specific location,
-        // then it will not be empty.
-        resource_path =
-            OS::get_singleton()->get_resource_dir().replace("\\", "/");
-        if (resource_path != ""
-            && resource_path[resource_path.length() - 1] == '/') {
-            resource_path = resource_path.substr(
-                0,
-                resource_path.length() - 1
-            ); // Chop end.
-        }
-
-        Error err = _load_settings_text_or_binary(
-            "res://project.rebel",
-            "res://project.binary"
-        );
-        if (err == OK) {
-            // Optional, we don't mind if it fails.
-            _load_settings_text("res://override.cfg");
-        }
-        return err;
-    }
-
-    // Nothing was found, try to find a project file in provided path (`p_path`)
-    // or, if requested (`p_upwards`) in parent directories.
-
-    DirAccess* d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-    ERR_FAIL_COND_V_MSG(
-        !d,
-        ERR_CANT_CREATE,
-        "Cannot create DirAccess for path '" + p_path + "'."
-    );
-    d->change_dir(p_path);
-
-    String current_dir = d->get_current_dir();
-    String candidate   = current_dir;
-    bool found         = false;
-    Error err;
-
-    while (true) {
-        err = _load_settings_text_or_binary(
-            current_dir.plus_file("project.rebel"),
-            current_dir.plus_file("project.binary")
-        );
-        if (err == OK) {
-            // Optional, we don't mind if it fails.
-            _load_settings_text(current_dir.plus_file("override.cfg"));
-            candidate = current_dir;
-            found     = true;
-            break;
-        }
-
-        if (p_upwards) {
-            // Try to load settings ascending through parent directories
-            d->change_dir("..");
-            if (d->get_current_dir() == current_dir) {
-                break; // not doing anything useful
-            }
-            current_dir = d->get_current_dir();
-        } else {
-            break;
-        }
-    }
-
-    resource_path = candidate;
-    resource_path = resource_path.replace(
-        "\\",
-        "/"
-    ); // Windows path to Unix path just in case.
-    memdelete(d);
-
-    if (!found) {
-        return err;
-    }
-
-    if (resource_path.length()
-        && resource_path[resource_path.length() - 1] == '/') {
-        resource_path =
-            resource_path.substr(0, resource_path.length() - 1); // Chop end.
-    }
-
-    return OK;
-}
-
-Error ProjectSettings::setup(
-    const String& p_path,
-    const String& p_main_pack,
-    bool p_upwards
-) {
-    Error err = _setup(p_path, p_main_pack, p_upwards);
-    if (err == OK) {
-        String custom_settings =
-            GLOBAL_DEF("application/config/project_settings_override", "");
-        if (custom_settings != "") {
-            _load_settings_text(custom_settings);
-        }
-    }
-
-    // Updating the default value after the project settings have loaded.
-    bool use_hidden_directory =
-        GLOBAL_GET("application/config/use_hidden_project_data_directory");
-    project_data_dir_name =
-        (use_hidden_directory ? "." : "") + PROJECT_DATA_DIR_NAME_SUFFIX;
-
-    // Using GLOBAL_GET on every block for compressing can be slow, so assigning
-    // here.
-    Compression::zstd_long_distance_matching =
-        GLOBAL_GET("compression/formats/zstd/long_distance_matching");
-    Compression::zstd_level =
-        GLOBAL_GET("compression/formats/zstd/compression_level");
-    Compression::zstd_window_log_size =
-        GLOBAL_GET("compression/formats/zstd/window_log_size");
-
-    Compression::zlib_level =
-        GLOBAL_GET("compression/formats/zlib/compression_level");
-
-    Compression::gzip_level =
-        GLOBAL_GET("compression/formats/gzip/compression_level");
-
-    return err;
-}
-
-bool ProjectSettings::has_setting(String p_var) const {
-    _THREAD_SAFE_METHOD_
-
-    return props.has(p_var);
-}
-
-void ProjectSettings::set_registering_order(bool p_enable) {
-    registering_order = p_enable;
-}
-
-Error ProjectSettings::_load_settings_binary(const String& p_path) {
-    Error err;
-    FileAccess* f = FileAccess::open(p_path, FileAccess::READ, &err);
-    if (err != OK) {
-        return err;
-    }
-
-    uint8_t hdr[4];
-    f->get_buffer(hdr, 4);
-    if (hdr[0] != 'E' || hdr[1] != 'C' || hdr[2] != 'F' || hdr[3] != 'G') {
-        memdelete(f);
-        ERR_FAIL_V_MSG(
-            ERR_FILE_CORRUPT,
-            "Corrupted header in binary project.binary (not ECFG)."
-        );
-    }
-
-    uint32_t count = f->get_32();
-
-    for (uint32_t i = 0; i < count; i++) {
-        uint32_t slen = f->get_32();
-        CharString cs;
-        cs.resize(slen + 1);
-        cs[slen] = 0;
-        f->get_buffer((uint8_t*)cs.ptr(), slen);
-        String key;
-        key.parse_utf8(cs.ptr());
-
-        uint32_t vlen = f->get_32();
-        Vector<uint8_t> d;
-        d.resize(vlen);
-        f->get_buffer(d.ptrw(), vlen);
-        Variant value;
-        err = decode_variant(value, d.ptr(), d.size(), nullptr, true);
-        ERR_CONTINUE_MSG(err != OK, "Error decoding property: " + key + ".");
-        set(key, value);
-    }
-
-    f->close();
-    memdelete(f);
-    return OK;
-}
-
-Error ProjectSettings::_load_settings_text(const String& p_path) {
-    Error err;
-    FileAccess* f = FileAccess::open(p_path, FileAccess::READ, &err);
-
-    if (!f) {
-        // FIXME: Above 'err' error code is ERR_FILE_CANT_OPEN if the file is
-        // missing This needs to be streamlined if we want decent error
-        // reporting
-        return ERR_FILE_NOT_FOUND;
-    }
-
-    VariantParser::StreamFile stream;
-    stream.f = f;
-
-    String assign;
-    Variant value;
-    VariantParser::Tag next_tag;
-
-    int lines = 0;
-    String error_text;
-    String section;
-    int config_version = 0;
-
-    while (true) {
-        assign = Variant();
-        next_tag.fields.clear();
-        next_tag.name = String();
-
-        err = VariantParser::parse_tag_assign_eof(
-            &stream,
-            lines,
-            error_text,
-            next_tag,
-            assign,
-            value,
-            nullptr,
-            true
-        );
-        if (err == ERR_FILE_EOF) {
-            memdelete(f);
-            // If we're loading a project.rebel from source code, we can operate
-            // some ProjectSettings conversions if need be.
-            _convert_to_last_version(config_version);
-            last_save_time = FileAccess::get_modified_time(
-                get_resource_path().plus_file("project.rebel")
-            );
-            return OK;
-        } else if (err != OK) {
-            ERR_PRINT(
-                "Error parsing " + p_path + " at line " + itos(lines) + ": "
-                + error_text + " File might be corrupted."
-            );
-            memdelete(f);
-            return err;
-        }
-
-        if (assign != String()) {
-            if (section == String() && assign == "config_version") {
-                config_version = value;
-                if (config_version > CONFIG_VERSION) {
-                    memdelete(f);
-                    ERR_FAIL_V_MSG(
-                        ERR_FILE_CANT_OPEN,
-                        vformat(
-                            "Can't open project at '%s', its `config_version` "
-                            "(%d) is from a more recent and incompatible "
-                            "version of the engine. Expected config version: "
-                            "%d.",
-                            p_path,
-                            config_version,
-                            CONFIG_VERSION
-                        )
-                    );
-                }
-            } else {
-                if (section == String()) {
-                    set(assign, value);
-                } else {
-                    set(section + "/" + assign, value);
-                }
-            }
-        } else if (next_tag.name != String()) {
-            section = next_tag.name;
-        }
-    }
-}
-
-Error ProjectSettings::_load_settings_text_or_binary(
-    const String& p_text_path,
-    const String& p_bin_path
-) {
-    // Attempt first to load the binary project.rebel file.
-    Error err = _load_settings_binary(p_bin_path);
-    if (err == OK) {
-        return OK;
-    } else if (err != ERR_FILE_NOT_FOUND) {
-        // If the file exists but can't be loaded, we want to know it.
-        ERR_PRINT(
-            "Couldn't load file '" + p_bin_path + "', error code " + itos(err)
-            + "."
-        );
-    }
-
-    // Fallback to text-based project.rebel file if binary was not found.
-    err = _load_settings_text(p_text_path);
-    if (err == OK) {
-        return OK;
-    } else if (err != ERR_FILE_NOT_FOUND) {
-        ERR_PRINT(
-            "Couldn't load file '" + p_text_path + "', error code " + itos(err)
-            + "."
-        );
-    }
-
-    return err;
-}
-
-int ProjectSettings::get_order(const String& p_name) const {
-    ERR_FAIL_COND_V_MSG(
-        !props.has(p_name),
-        -1,
-        "Request for nonexistent project setting: " + p_name + "."
-    );
-    return props[p_name].order;
-}
-
-void ProjectSettings::set_order(const String& p_name, int p_order) {
-    ERR_FAIL_COND_MSG(
-        !props.has(p_name),
-        "Request for nonexistent project setting: " + p_name + "."
-    );
-    props[p_name].order = p_order;
-}
-
-void ProjectSettings::set_builtin_order(const String& p_name) {
-    ERR_FAIL_COND_MSG(
-        !props.has(p_name),
-        "Request for nonexistent project setting: " + p_name + "."
-    );
-    if (props[p_name].order >= NO_BUILTIN_ORDER_BASE) {
-        props[p_name].order = last_builtin_order++;
-    }
-}
-
-void ProjectSettings::clear(const String& p_name) {
-    ERR_FAIL_COND_MSG(
-        !props.has(p_name),
-        "Request for nonexistent project setting: " + p_name + "."
-    );
-    props.erase(p_name);
-}
-
-Error ProjectSettings::save() {
-    Error error = save_custom(get_resource_path().plus_file("project.rebel"));
-    if (error == OK) {
-        last_save_time = FileAccess::get_modified_time(
-            get_resource_path().plus_file("project.rebel")
-        );
-    }
-    return error;
-}
-
-Error ProjectSettings::_save_settings_binary(
-    const String& p_file,
-    const Map<String, List<String>>& props,
-    const CustomMap& p_custom,
-    const String& p_custom_features
-) {
-    Error err;
-    FileAccess* file = FileAccess::open(p_file, FileAccess::WRITE, &err);
-    ERR_FAIL_COND_V_MSG(
-        err != OK,
-        err,
-        "Couldn't save project.binary at " + p_file + "."
-    );
-
-    uint8_t hdr[4] = {'E', 'C', 'F', 'G'};
-    file->store_buffer(hdr, 4);
-
-    int count = 0;
-
-    for (Map<String, List<String>>::Element* E = props.front(); E;
-         E                                     = E->next()) {
-        for (List<String>::Element* F = E->get().front(); F; F = F->next()) {
-            count++;
-        }
-    }
-
-    if (p_custom_features != String()) {
-        file->store_32(count + 1);
-        // store how many properties are saved, add one for custom featuers,
-        // which must always go first
-        String key = CoreStringNames::get_singleton()->_custom_features;
-        file->store_pascal_string(key);
-
-        int len;
-        err = encode_variant(p_custom_features, nullptr, len, false);
-        if (err != OK) {
-            memdelete(file);
-            ERR_FAIL_V(err);
-        }
-
-        Vector<uint8_t> buff;
-        buff.resize(len);
-
-        err = encode_variant(p_custom_features, buff.ptrw(), len, false);
-        if (err != OK) {
-            memdelete(file);
-            ERR_FAIL_V(err);
-        }
-        file->store_32(len);
-        file->store_buffer(buff.ptr(), buff.size());
-
-    } else {
-        file->store_32(count); // store how many properties are saved
-    }
-
-    for (Map<String, List<String>>::Element* E = props.front(); E;
-         E                                     = E->next()) {
-        for (List<String>::Element* F = E->get().front(); F; F = F->next()) {
-            String key = F->get();
-            if (E->key() != "") {
-                key = E->key() + "/" + key;
-            }
-            Variant value;
-            if (p_custom.has(key)) {
-                value = p_custom[key];
-            } else {
-                value = get(key);
-            }
-
-            file->store_pascal_string(key);
-
-            int len;
-            err = encode_variant(value, nullptr, len, true);
-            if (err != OK) {
-                memdelete(file);
-            }
-            ERR_FAIL_COND_V_MSG(
-                err != OK,
-                ERR_INVALID_DATA,
-                "Error when trying to encode Variant."
-            );
-
-            Vector<uint8_t> buff;
-            buff.resize(len);
-
-            err = encode_variant(value, buff.ptrw(), len, true);
-            if (err != OK) {
-                memdelete(file);
-            }
-            ERR_FAIL_COND_V_MSG(
-                err != OK,
-                ERR_INVALID_DATA,
-                "Error when trying to encode Variant."
-            );
-            file->store_32(len);
-            file->store_buffer(buff.ptr(), buff.size());
-        }
-    }
-
-    file->close();
-    memdelete(file);
-
-    return OK;
-}
-
-Error ProjectSettings::_save_settings_text(
-    const String& p_file,
-    const Map<String, List<String>>& props,
-    const CustomMap& p_custom,
-    const String& p_custom_features
-) {
-    Error err;
-    FileAccess* file = FileAccess::open(p_file, FileAccess::WRITE, &err);
-
-    ERR_FAIL_COND_V_MSG(
-        err != OK,
-        err,
-        "Couldn't save project.rebel - " + p_file + "."
-    );
-
-    file->store_line("; Engine configuration file.");
-    file->store_line("; It's best edited using the editor UI and not directly,"
-    );
-    file->store_line("; since the parameters that go here are not all obvious."
-    );
-    file->store_line(";");
-    file->store_line("; Format:");
-    file->store_line(";   [section] ; section goes between []");
-    file->store_line(";   param=value ; assign values to parameters");
-    file->store_line("");
-
-    file->store_string("config_version=" + itos(CONFIG_VERSION) + "\n");
-    if (p_custom_features != String()) {
-        file->store_string("custom_features=\"" + p_custom_features + "\"\n");
-    }
-    file->store_string("\n");
-
-    for (Map<String, List<String>>::Element* E = props.front(); E;
-         E                                     = E->next()) {
-        if (E != props.front()) {
-            file->store_string("\n");
-        }
-
-        if (E->key() != "") {
-            file->store_string("[" + E->key() + "]\n\n");
-        }
-        for (List<String>::Element* F = E->get().front(); F; F = F->next()) {
-            String key = F->get();
-            if (E->key() != "") {
-                key = E->key() + "/" + key;
-            }
-            Variant value;
-            if (p_custom.has(key)) {
-                value = p_custom[key];
-            } else {
-                value = get(key);
-            }
-
-            String vstr;
-            VariantWriter::write_to_string(value, vstr);
-            file->store_string(
-                F->get().property_name_encode() + "=" + vstr + "\n"
-            );
-        }
-    }
-
-    file->close();
-    memdelete(file);
-
-    return OK;
-}
-
-Error ProjectSettings::_save_custom_bnd(const String& p_file
-) { // add other params as dictionary and array?
-
-    return save_custom(p_file);
-};
-
-Error ProjectSettings::save_custom(
-    const String& p_path,
-    const CustomMap& p_custom,
-    const Vector<String>& p_custom_features,
-    bool p_merge_with_current
-) {
-    ERR_FAIL_COND_V_MSG(
-        p_path == "",
-        ERR_INVALID_PARAMETER,
-        "Project settings save path cannot be empty."
-    );
-
-    Set<_VCSort> vclist;
-
-    if (p_merge_with_current) {
-        for (Map<StringName, VariantContainer>::Element* G = props.front(); G;
-             G                                             = G->next()) {
-            const VariantContainer* v = &G->get();
-
-            if (v->hide_from_editor) {
-                continue;
-            }
-
-            if (p_custom.has(G->key())) {
-                continue;
-            }
-
-            _VCSort vc;
-            vc.name  = G->key(); //*k;
-            vc.order = v->order;
-            vc.type  = v->variant.get_type();
-            vc.flags = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
-            if (v->variant == v->initial) {
-                continue;
-            }
-
-            vclist.insert(vc);
-        }
-    }
-
-    for (const Map<String, Variant>::Element* E = p_custom.front(); E;
-         E                                      = E->next()) {
-        // Lookup global prop to store in the same order
-        Map<StringName, VariantContainer>::Element* global_prop =
-            props.find(E->key());
-
-        _VCSort vc;
-        vc.name  = E->key();
-        vc.order = global_prop ? global_prop->get().order : 0xFFFFFFF;
-        vc.type  = E->get().get_type();
-        vc.flags = PROPERTY_USAGE_STORAGE;
-        vclist.insert(vc);
-    }
-
-    Map<String, List<String>> props;
-
-    for (Set<_VCSort>::Element* E = vclist.front(); E; E = E->next()) {
-        String category = E->get().name;
-        String name     = E->get().name;
-
-        int div = category.find("/");
-
-        if (div < 0) {
-            category = "";
-        } else {
-            category = category.substr(0, div);
-            name     = name.substr(div + 1, name.size());
-        }
-        props[category].push_back(name);
-    }
-
-    String custom_features;
-
-    for (int i = 0; i < p_custom_features.size(); i++) {
-        if (i > 0) {
-            custom_features += ",";
-        }
-
-        String f         = p_custom_features[i].strip_edges().replace("\"", "");
-        custom_features += f;
-    }
-
-    if (p_path.ends_with(".rebel") || p_path.ends_with("override.cfg")) {
-        return _save_settings_text(p_path, props, p_custom, custom_features);
-    } else if (p_path.ends_with(".binary")) {
-        return _save_settings_binary(p_path, props, p_custom, custom_features);
-    } else {
-        ERR_FAIL_V_MSG(
-            ERR_FILE_UNRECOGNIZED,
-            "Unknown config file format: " + p_path + "."
-        );
-    }
-    return ERR_FILE_UNRECOGNIZED;
-}
-
-Variant _GLOBAL_DEF_ALIAS(
-    const String& p_var,
-    const String& p_old_name,
-    const Variant& p_default,
-    bool p_restart_if_changed
-) {
-    // if the new name setting isn't present, try the old one
-    if (!ProjectSettings::get_singleton()->has_setting(p_var)) {
-        if (ProjectSettings::get_singleton()->has_setting(p_old_name)) {
-            // if the old setting is present, get the value and set it in the
-            // new setting
-            Variant value = ProjectSettings::get_singleton()->get(p_old_name);
-            ProjectSettings::get_singleton()->set(p_var, value);
-        }
-    }
-
-    return _GLOBAL_DEF(p_var, p_default, p_restart_if_changed);
-}
-
-Variant _GLOBAL_DEF(
-    const String& p_var,
-    const Variant& p_default,
-    bool p_restart_if_changed,
-    bool p_ignore_value_in_docs
-) {
-    Variant ret;
-    if (!ProjectSettings::get_singleton()->has_setting(p_var)) {
-        ProjectSettings::get_singleton()->set(p_var, p_default);
-    }
-    ret = ProjectSettings::get_singleton()->get(p_var);
-
-    ProjectSettings::get_singleton()->set_initial_value(p_var, p_default);
-    ProjectSettings::get_singleton()->set_builtin_order(p_var);
-    ProjectSettings::get_singleton()->set_restart_if_changed(
-        p_var,
-        p_restart_if_changed
-    );
-    ProjectSettings::get_singleton()->set_ignore_value_in_docs(
-        p_var,
-        p_ignore_value_in_docs
-    );
-    return ret;
-}
-
-Vector<String> ProjectSettings::get_optimizer_presets() const {
-    List<PropertyInfo> pi;
-    ProjectSettings::get_singleton()->get_property_list(&pi);
-    Vector<String> names;
-
-    for (List<PropertyInfo>::Element* E = pi.front(); E; E = E->next()) {
-        if (!E->get().name.begins_with("optimizer_presets/")) {
-            continue;
-        }
-        names.push_back(E->get().name.get_slicec('/', 1));
-    }
-
-    names.sort();
-
-    return names;
-}
-
-void ProjectSettings::_add_property_info_bind(const Dictionary& p_info) {
-    ERR_FAIL_COND(!p_info.has("name"));
-    ERR_FAIL_COND(!p_info.has("type"));
-
-    PropertyInfo pinfo;
-    pinfo.name = p_info["name"];
-    ERR_FAIL_COND(!props.has(pinfo.name));
-    pinfo.type = Variant::Type(p_info["type"].operator int());
-    ERR_FAIL_INDEX(pinfo.type, Variant::VARIANT_MAX);
-
-    if (p_info.has("hint")) {
-        pinfo.hint = PropertyHint(p_info["hint"].operator int());
-    }
-    if (p_info.has("hint_string")) {
-        pinfo.hint_string = p_info["hint_string"];
-    }
-
-    set_custom_property_info(pinfo.name, pinfo);
-}
-
-void ProjectSettings::set_custom_property_info(
-    const String& p_prop,
-    const PropertyInfo& p_info
-) {
-    ERR_FAIL_COND(!props.has(p_prop));
-    custom_prop_info[p_prop]      = p_info;
-    custom_prop_info[p_prop].name = p_prop;
-}
-
-const Map<StringName, PropertyInfo>& ProjectSettings::get_custom_property_info(
-) const {
-    return custom_prop_info;
-}
-
-void ProjectSettings::set_disable_feature_overrides(bool p_disable) {
-    disable_feature_overrides = p_disable;
-}
-
-bool ProjectSettings::is_using_datapack() const {
-    return using_datapack;
-}
-
-bool ProjectSettings::property_can_revert(const String& p_name) {
-    if (!props.has(p_name)) {
-        return false;
-    }
-
-    return props[p_name].initial != props[p_name].variant;
-}
-
-Variant ProjectSettings::property_get_revert(const String& p_name) {
-    if (!props.has(p_name)) {
-        return Variant();
-    }
-
-    return props[p_name].initial;
-}
-
-void ProjectSettings::set_setting(
-    const String& p_setting,
-    const Variant& p_value
-) {
-    set(p_setting, p_value);
-}
-
-Variant ProjectSettings::get_setting(const String& p_setting) const {
-    return get(p_setting);
-}
-
-bool ProjectSettings::has_custom_feature(const String& p_feature) const {
-    return custom_features.has(p_feature);
-}
-
-void ProjectSettings::_bind_methods() {
-    ClassDB::bind_method(
-        D_METHOD("has_setting", "name"),
-        &ProjectSettings::has_setting
-    );
-    ClassDB::bind_method(
-        D_METHOD("set_setting", "name", "value"),
-        &ProjectSettings::set_setting
-    );
-    ClassDB::bind_method(
-        D_METHOD("get_setting", "name"),
-        &ProjectSettings::get_setting
-    );
-    ClassDB::bind_method(
-        D_METHOD("set_order", "name", "position"),
-        &ProjectSettings::set_order
-    );
-    ClassDB::bind_method(
-        D_METHOD("get_order", "name"),
-        &ProjectSettings::get_order
-    );
-    ClassDB::bind_method(
-        D_METHOD("set_initial_value", "name", "value"),
-        &ProjectSettings::set_initial_value
-    );
-    ClassDB::bind_method(
-        D_METHOD("add_property_info", "hint"),
-        &ProjectSettings::_add_property_info_bind
-    );
-    ClassDB::bind_method(D_METHOD("clear", "name"), &ProjectSettings::clear);
-    ClassDB::bind_method(
-        D_METHOD("localize_path", "path"),
-        &ProjectSettings::localize_path
-    );
-    ClassDB::bind_method(
-        D_METHOD("globalize_path", "path"),
-        &ProjectSettings::globalize_path
-    );
-    ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-    ClassDB::bind_method(
-        D_METHOD("load_resource_pack", "pack", "replace_files", "offset"),
-        &ProjectSettings::_load_resource_pack,
-        DEFVAL(true),
-        DEFVAL(0)
-    );
-    ClassDB::bind_method(
-        D_METHOD("property_can_revert", "name"),
-        &ProjectSettings::property_can_revert
-    );
-    ClassDB::bind_method(
-        D_METHOD("property_get_revert", "name"),
-        &ProjectSettings::property_get_revert
-    );
-
-    ClassDB::bind_method(
-        D_METHOD("save_custom", "file"),
-        &ProjectSettings::_save_custom_bnd
-    );
-}
-
 ProjectSettings::ProjectSettings() {
-    // Initialization of engine variables should be done in the setup() method,
-    // so that the values can be overridden from project.rebel or
-    // project.binary.
-
-    singleton                 = this;
-    last_order                = NO_BUILTIN_ORDER_BASE;
-    last_builtin_order        = 0;
-    disable_feature_overrides = false;
-    registering_order         = true;
+    singleton = this;
 
     Array events;
     Dictionary action;
@@ -1299,13 +42,13 @@ ProjectSettings::ProjectSettings() {
 
     GLOBAL_DEF("application/config/name", "");
     GLOBAL_DEF("application/config/description", "");
-    custom_prop_info["application/config/description"] = PropertyInfo(
+    custom_property_info["application/config/description"] = PropertyInfo(
         Variant::STRING,
         "application/config/description",
         PROPERTY_HINT_MULTILINE_TEXT
     );
     GLOBAL_DEF("application/run/main_scene", "");
-    custom_prop_info["application/run/main_scene"] = PropertyInfo(
+    custom_property_info["application/run/main_scene"] = PropertyInfo(
         Variant::STRING,
         "application/run/main_scene",
         PROPERTY_HINT_FILE,
@@ -1321,7 +64,7 @@ ProjectSettings::ProjectSettings() {
     GLOBAL_DEF("application/config/custom_user_dir_name", "");
     GLOBAL_DEF("application/config/project_settings_override", "");
     GLOBAL_DEF("audio/default_bus_layout", "res://default_bus_layout.tres");
-    custom_prop_info["audio/default_bus_layout"] = PropertyInfo(
+    custom_property_info["audio/default_bus_layout"] = PropertyInfo(
         Variant::STRING,
         "audio/default_bus_layout",
         PROPERTY_HINT_FILE,
@@ -1339,13 +82,13 @@ ProjectSettings::ProjectSettings() {
     GLOBAL_DEF("editor/main_run_args", "");
 
     GLOBAL_DEF("editor/search_in_file_extensions", extensions);
-    custom_prop_info["editor/search_in_file_extensions"] = PropertyInfo(
+    custom_property_info["editor/search_in_file_extensions"] = PropertyInfo(
         Variant::POOL_STRING_ARRAY,
         "editor/search_in_file_extensions"
     );
 
     GLOBAL_DEF("editor/script_templates_search_path", "res://script_templates");
-    custom_prop_info["editor/script_templates_search_path"] = PropertyInfo(
+    custom_property_info["editor/script_templates_search_path"] = PropertyInfo(
         Variant::STRING,
         "editor/script_templates_search_path",
         PROPERTY_HINT_DIR
@@ -1509,26 +252,26 @@ ProjectSettings::ProjectSettings() {
     GLOBAL_DEF("input/ui_end", action);
     input_presets.push_back("input/ui_end");
 
-    custom_prop_info["display/window/handheld/orientation"] = PropertyInfo(
+    custom_property_info["display/window/handheld/orientation"] = PropertyInfo(
         Variant::STRING,
         "display/window/handheld/orientation",
         PROPERTY_HINT_ENUM,
         "landscape,portrait,reverse_landscape,reverse_portrait,sensor_"
         "landscape,sensor_portrait,sensor"
     );
-    custom_prop_info["rendering/threads/thread_model"] = PropertyInfo(
+    custom_property_info["rendering/threads/thread_model"] = PropertyInfo(
         Variant::INT,
         "rendering/threads/thread_model",
         PROPERTY_HINT_ENUM,
         "Single-Unsafe,Single-Safe,Multi-Threaded"
     );
-    custom_prop_info["physics/2d/thread_model"] = PropertyInfo(
+    custom_property_info["physics/2d/thread_model"] = PropertyInfo(
         Variant::INT,
         "physics/2d/thread_model",
         PROPERTY_HINT_ENUM,
         "Single-Unsafe,Single-Safe,Multi-Threaded"
     );
-    custom_prop_info
+    custom_property_info
         ["rendering/quality/intended_usage/framebuffer_allocation"] =
             PropertyInfo(
                 Variant::INT,
@@ -1538,7 +281,7 @@ ProjectSettings::ProjectSettings() {
             );
 
     GLOBAL_DEF("rendering/quality/filters/sharpen_intensity", 0.0);
-    custom_prop_info["rendering/quality/filters/sharpen_intensity"] =
+    custom_property_info["rendering/quality/filters/sharpen_intensity"] =
         PropertyInfo(
             Variant::REAL,
             "rendering/quality/filters/sharpen_intensity",
@@ -1547,18 +290,19 @@ ProjectSettings::ProjectSettings() {
         );
 
     GLOBAL_DEF("debug/settings/profiler/max_functions", 16384);
-    custom_prop_info["debug/settings/profiler/max_functions"] = PropertyInfo(
-        Variant::INT,
-        "debug/settings/profiler/max_functions",
-        PROPERTY_HINT_RANGE,
-        "128,65535,1"
-    );
+    custom_property_info["debug/settings/profiler/max_functions"] =
+        PropertyInfo(
+            Variant::INT,
+            "debug/settings/profiler/max_functions",
+            PROPERTY_HINT_RANGE,
+            "128,65535,1"
+        );
 
     GLOBAL_DEF(
         "compression/formats/zstd/long_distance_matching",
         Compression::zstd_long_distance_matching
     );
-    custom_prop_info["compression/formats/zstd/long_distance_matching"] =
+    custom_property_info["compression/formats/zstd/long_distance_matching"] =
         PropertyInfo(
             Variant::BOOL,
             "compression/formats/zstd/long_distance_matching"
@@ -1567,7 +311,7 @@ ProjectSettings::ProjectSettings() {
         "compression/formats/zstd/compression_level",
         Compression::zstd_level
     );
-    custom_prop_info["compression/formats/zstd/compression_level"] =
+    custom_property_info["compression/formats/zstd/compression_level"] =
         PropertyInfo(
             Variant::INT,
             "compression/formats/zstd/compression_level",
@@ -1578,18 +322,19 @@ ProjectSettings::ProjectSettings() {
         "compression/formats/zstd/window_log_size",
         Compression::zstd_window_log_size
     );
-    custom_prop_info["compression/formats/zstd/window_log_size"] = PropertyInfo(
-        Variant::INT,
-        "compression/formats/zstd/window_log_size",
-        PROPERTY_HINT_RANGE,
-        "10,30,1"
-    );
+    custom_property_info["compression/formats/zstd/window_log_size"] =
+        PropertyInfo(
+            Variant::INT,
+            "compression/formats/zstd/window_log_size",
+            PROPERTY_HINT_RANGE,
+            "10,30,1"
+        );
 
     GLOBAL_DEF(
         "compression/formats/zlib/compression_level",
         Compression::zlib_level
     );
-    custom_prop_info["compression/formats/zlib/compression_level"] =
+    custom_property_info["compression/formats/zlib/compression_level"] =
         PropertyInfo(
             Variant::INT,
             "compression/formats/zlib/compression_level",
@@ -1601,7 +346,7 @@ ProjectSettings::ProjectSettings() {
         "compression/formats/gzip/compression_level",
         Compression::gzip_level
     );
-    custom_prop_info["compression/formats/gzip/compression_level"] =
+    custom_property_info["compression/formats/gzip/compression_level"] =
         PropertyInfo(
             Variant::INT,
             "compression/formats/gzip/compression_level",
@@ -1609,13 +354,1059 @@ ProjectSettings::ProjectSettings() {
             "-1,9,1"
         );
 
-    // Would ideally be defined in an Android-specific file, but then it doesn't
-    // appear in the docs
     GLOBAL_DEF("android/modules", "");
-
-    using_datapack = false;
 }
 
 ProjectSettings::~ProjectSettings() {
     singleton = nullptr;
+}
+
+bool ProjectSettings::has_setting(const String& name) const {
+    _THREAD_SAFE_METHOD_
+    return settings.has(name);
+}
+
+Variant ProjectSettings::get_setting(const String& name) const {
+    return get(name);
+}
+
+void ProjectSettings::set_setting(const String& name, const Variant& value) {
+    set(name, value);
+}
+
+int ProjectSettings::get_order(const String& name) const {
+    ERR_FAIL_COND_V_MSG(
+        !settings.has(name),
+        -1,
+        "Cannot get order of unknown project setting: " + name
+    );
+    return settings[name].position;
+}
+
+void ProjectSettings::set_order(const String& name, int position) {
+    ERR_FAIL_COND_MSG(
+        !settings.has(name),
+        "Cannot set order of unknown project setting: " + name
+    );
+    settings[name].position = position;
+}
+
+void ProjectSettings::set_builtin_order(const String& name) {
+    ERR_FAIL_COND_MSG(
+        !settings.has(name),
+        "Cannot set builtin order of unknown project setting: " + name
+    );
+    if (settings[name].position >= CUSTOM_SETTINGS_START) {
+        settings[name].position = builtin_position++;
+    }
+}
+
+bool ProjectSettings::get_ignore_value_in_docs(const String& name) const {
+    ERR_FAIL_COND_V_MSG(
+        !settings.has(name),
+        false,
+        "Cannot get ignore value in docs of unknown project setting: " + name
+    );
+#ifdef DEBUG_METHODS_ENABLED
+    return settings[name].ignore_value_in_docs;
+#else
+    return false;
+#endif
+}
+
+void ProjectSettings::set_ignore_value_in_docs(
+    const String& name,
+    bool ignore_in_docs
+) {
+    ERR_FAIL_COND_MSG(
+        !settings.has(name),
+        "Cannot set ignore value in docs of unknown project setting: " + name
+    );
+#ifdef DEBUG_METHODS_ENABLED
+    settings[name].ignore_value_in_docs = ignore_in_docs;
+#endif
+}
+
+Variant ProjectSettings::property_get_revert(const String& name) const {
+    ERR_FAIL_COND_V_MSG(
+        !settings.has(name),
+        Variant(),
+        "Cannot get revert value of unknown project setting: " + name
+    );
+    return settings[name].initial_value;
+}
+
+bool ProjectSettings::property_can_revert(const String& name) {
+    ERR_FAIL_COND_V_MSG(
+        !settings.has(name),
+        false,
+        "Cannot determine if we can revert unknown project setting: " + name
+    );
+    return settings[name].initial_value != settings[name].current_value;
+}
+
+String ProjectSettings::get_project_data_dir_name() const {
+    return project_data_dir_name;
+}
+
+String ProjectSettings::get_project_data_path() const {
+    return "res://" + project_data_dir_name;
+}
+
+String ProjectSettings::get_resource_path() const {
+    return resource_path;
+};
+
+const Map<StringName, PropertyInfo>& ProjectSettings::get_custom_property_info(
+) const {
+    return custom_property_info;
+}
+
+uint64_t ProjectSettings::get_last_saved_time() const {
+    return last_save_time;
+}
+
+List<String> ProjectSettings::get_input_presets() const {
+    return input_presets;
+}
+
+Vector<String> ProjectSettings::get_optimizer_presets() const {
+    List<PropertyInfo> property_info_list;
+    ProjectSettings::get_singleton()->get_property_list(&property_info_list);
+    Vector<String> optimizer_presets;
+    for (auto E = property_info_list.front(); E; E = E->next()) {
+        if (!E->get().name.begins_with("optimizer_presets/")) {
+            continue;
+        }
+        optimizer_presets.push_back(E->get().name.get_slicec('/', 1));
+    }
+    optimizer_presets.sort();
+    return optimizer_presets;
+}
+
+bool ProjectSettings::is_using_datapack() const {
+    return using_datapack;
+}
+
+bool ProjectSettings::has_custom_feature(const String& feature) const {
+    return custom_features.has(feature);
+}
+
+void ProjectSettings::clear(const String& name) {
+    ERR_FAIL_COND_MSG(
+        !settings.has(name),
+        "Cannot clear unknown project setting: " + name
+    );
+    settings.erase(name);
+}
+
+void ProjectSettings::set_initial_value(
+    const String& name,
+    const Variant& value
+) {
+    ERR_FAIL_COND_MSG(
+        !settings.has(name),
+        "Cannot set initial value of unknown project setting: " + name
+    );
+    settings[name].initial_value = value;
+}
+
+void ProjectSettings::set_restart_if_changed(
+    const String& name,
+    bool restart_required
+) {
+    ERR_FAIL_COND_MSG(
+        !settings.has(name),
+        "Cannot set restart required of unknown project setting: " + name
+    );
+    settings[name].restart_if_changed = restart_required;
+}
+
+void ProjectSettings::set_disable_feature_overrides(bool disable) {
+    disable_feature_overrides = disable;
+}
+
+void ProjectSettings::set_custom_property_info(
+    const String& name,
+    const PropertyInfo& property_info
+) {
+    ERR_FAIL_COND_MSG(
+        !settings.has(name),
+        "Cannot set custom property info of unknown project setting: " + name
+    );
+    custom_property_info[name]      = property_info;
+    custom_property_info[name].name = name;
+}
+
+String ProjectSettings::globalize_path(const String& local_path) const {
+    if (local_path.begins_with("res://")) {
+        if (resource_path != "") {
+            return local_path.replace("res:/", resource_path);
+        };
+        return local_path.replace("res://", "");
+    } else if (local_path.begins_with("user://")) {
+        String data_dir = OS::get_singleton()->get_user_data_dir();
+        if (data_dir != "") {
+            return local_path.replace("user:/", data_dir);
+        };
+        return local_path.replace("user://", "");
+    }
+    return local_path;
+}
+
+String ProjectSettings::localize_path(const String& global_path) const {
+    if (resource_path.empty() || global_path.begins_with("res://")
+        || global_path.begins_with("user://")
+        || (global_path.is_abs_path() && !global_path.begins_with(resource_path)
+        )) {
+        return global_path.simplify_path();
+    }
+
+    DirAccess* dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+    String simple_path    = global_path.replace("\\", "/").simplify_path();
+    if (dir_access->change_dir(simple_path) == OK) {
+        String current_dir = dir_access->get_current_dir();
+        current_dir        = current_dir.replace("\\", "/");
+        memdelete(dir_access);
+
+        // Ensure paths end with a '/'.
+        const String res_path = resource_path.plus_file("");
+        current_dir           = current_dir.plus_file("");
+
+        if (current_dir.begins_with(res_path)) {
+            return current_dir.replace_first(res_path, "res://");
+        };
+        return global_path;
+    } else {
+        memdelete(dir_access);
+        // Global path does not exist.
+        int last_dir_index = simple_path.find_last("/");
+        if (last_dir_index == -1) {
+            return "res://" + simple_path;
+        };
+
+        String parent_dir           = simple_path.substr(0, last_dir_index);
+        String localized_parent_dir = localize_path(parent_dir);
+        if (localized_parent_dir == "") {
+            return "";
+        };
+        // Strip first '/' from 'simple_path' if 'parent_dir' ends with '/'.
+        if (localized_parent_dir[localized_parent_dir.length() - 1] == '/') {
+            last_dir_index += 1;
+        }
+        return localized_parent_dir + simple_path.substr(last_dir_index);
+    }
+}
+
+Error ProjectSettings::setup(
+    const String& path,
+    const String& main_pack,
+    bool try_parent_dirs
+) {
+    Error error = _setup(path, main_pack, try_parent_dirs);
+    if (error == OK) {
+        String custom_settings =
+            GLOBAL_DEF("application/config/project_settings_override", "");
+        if (custom_settings != "") {
+            _load_text_settings(custom_settings);
+        }
+    }
+
+    // Assign global variables dependent on project settings.
+    if (GLOBAL_GET("application/config/use_hidden_project_data_directory")) {
+        project_data_dir_name = "." + project_data_dir_name;
+    }
+
+    Compression::zstd_long_distance_matching =
+        GLOBAL_GET("compression/formats/zstd/long_distance_matching");
+    Compression::zstd_level =
+        GLOBAL_GET("compression/formats/zstd/compression_level");
+    Compression::zstd_window_log_size =
+        GLOBAL_GET("compression/formats/zstd/window_log_size");
+    Compression::zlib_level =
+        GLOBAL_GET("compression/formats/zlib/compression_level");
+    Compression::gzip_level =
+        GLOBAL_GET("compression/formats/gzip/compression_level");
+
+    return error;
+}
+
+Error ProjectSettings::save() {
+    Error error = save_custom(resource_path.plus_file("project.rebel"));
+    if (error == OK) {
+        last_save_time = FileAccess::get_modified_time(
+            resource_path.plus_file("project.rebel")
+        );
+    }
+    return error;
+}
+
+Error ProjectSettings::save_custom(
+    const String& settings_file,
+    const CustomSettings& custom_settings,
+    const Vector<String>& custom_features,
+    bool merge_with_current
+) {
+    ERR_FAIL_COND_V_MSG(
+        !(settings_file.ends_with(".rebel")
+          || settings_file.ends_with(".binary")
+          || settings_file.ends_with("override.cfg")),
+        ERR_FILE_UNRECOGNIZED,
+        "Unrecognized project settings file: " + settings_file
+    );
+
+    Set<Setting> settings_to_save;
+
+    if (merge_with_current) {
+        for (auto G = settings.front(); G; G = G->next()) {
+            const String& setting_name = G->key();
+            if (custom_settings.has(setting_name)) {
+                continue;
+            }
+
+            Setting setting = G->get();
+            if (setting.current_value == setting.initial_value) {
+                continue;
+            }
+            if (setting.hide_from_editor) {
+                continue;
+            }
+            setting.flags = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
+            settings_to_save.insert(setting);
+        }
+    }
+
+    for (auto E = custom_settings.front(); E; E = E->next()) {
+        const String& setting_name = E->key();
+        const Variant& value       = E->get();
+        Setting setting(setting_name, value, 0xFFFFFF);
+        auto F = settings.find(setting_name);
+        if (F) {
+            setting.position = F->get().position;
+        }
+        setting.flags = PROPERTY_USAGE_STORAGE;
+        settings_to_save.insert(setting);
+    }
+
+    Map<String, List<String>> grouped_settings;
+
+    for (auto E = settings_to_save.front(); E; E = E->next()) {
+        String section;
+        String setting_name = E->get().name;
+
+        int div = setting_name.find("/");
+        if (div > 0) {
+            section      = setting_name.substr(0, div);
+            setting_name = setting_name.substr(div + 1);
+        }
+        grouped_settings[section].push_back(setting_name);
+    }
+
+    String features;
+    for (int i = 0; i < custom_features.size(); i++) {
+        if (i > 0) {
+            features += ",";
+        }
+        String feature  = custom_features[i].strip_edges().replace("\"", "");
+        features       += feature;
+    }
+
+    if (settings_file.ends_with(".binary")) {
+        return _save_binary_settings(
+            settings_file,
+            grouped_settings,
+            custom_settings,
+            features
+        );
+    } else {
+        return _save_text_settings(
+            settings_file,
+            grouped_settings,
+            custom_settings,
+            features
+        );
+    }
+}
+
+void ProjectSettings::_bind_methods() {
+    ClassDB::bind_method(
+        D_METHOD("add_property_info", "hint"),
+        &ProjectSettings::_add_property_info
+    );
+    ClassDB::bind_method(D_METHOD("clear", "name"), &ProjectSettings::clear);
+    ClassDB::bind_method(
+        D_METHOD("get_order", "name"),
+        &ProjectSettings::get_order
+    );
+    ClassDB::bind_method(
+        D_METHOD("get_setting", "name"),
+        &ProjectSettings::get_setting
+    );
+    ClassDB::bind_method(
+        D_METHOD("globalize_path", "path"),
+        &ProjectSettings::globalize_path
+    );
+    ClassDB::bind_method(
+        D_METHOD("has_setting", "name"),
+        &ProjectSettings::has_setting
+    );
+    ClassDB::bind_method(
+        D_METHOD("load_resource_pack", "pack", "replace_files", "offset"),
+        &ProjectSettings::_load_resource_pack,
+        DEFVAL(true),
+        DEFVAL(0)
+    );
+    ClassDB::bind_method(
+        D_METHOD("localize_path", "path"),
+        &ProjectSettings::localize_path
+    );
+    ClassDB::bind_method(
+        D_METHOD("property_can_revert", "name"),
+        &ProjectSettings::property_can_revert
+    );
+    ClassDB::bind_method(
+        D_METHOD("property_get_revert", "name"),
+        &ProjectSettings::property_get_revert
+    );
+    ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
+    ClassDB::bind_method(
+        D_METHOD("save_custom", "file"),
+        &ProjectSettings::_save_custom_bnd
+    );
+    ClassDB::bind_method(
+        D_METHOD("set_initial_value", "name", "value"),
+        &ProjectSettings::set_initial_value
+    );
+    ClassDB::bind_method(
+        D_METHOD("set_order", "name", "position"),
+        &ProjectSettings::set_order
+    );
+    ClassDB::bind_method(
+        D_METHOD("set_setting", "name", "value"),
+        &ProjectSettings::set_setting
+    );
+}
+
+bool ProjectSettings::_get(const StringName& name, Variant& r_value) const {
+    _THREAD_SAFE_METHOD_
+
+    StringName override_name = name;
+    if (!disable_feature_overrides && feature_overrides.has(name)) {
+        override_name = feature_overrides[name];
+    }
+    ERR_FAIL_COND_V_MSG(
+        !settings.has(override_name),
+        false,
+        "Unknown project setting: " + override_name
+    );
+    r_value = settings[override_name].current_value;
+    return true;
+}
+
+bool ProjectSettings::_set(const StringName& name, const Variant& value) {
+    _THREAD_SAFE_METHOD_
+
+    if (value.get_type() == Variant::NIL) {
+        settings.erase(name);
+        return true;
+    }
+
+    if (name == CoreStringNames::get_singleton()->_custom_features) {
+        Vector<String> custom_feature_array = String(value).split(",");
+        for (int i = 0; i < custom_feature_array.size(); i++) {
+            custom_features.insert(custom_feature_array[i]);
+        }
+        return true;
+    }
+
+    if (!disable_feature_overrides) {
+        int dot = name.operator String().find(".");
+        if (dot != -1) {
+            Vector<String> parts = name.operator String().split(".");
+            for (int i = 1; i < parts.size(); i++) {
+                String feature = parts[i].strip_edges();
+                if (OS::get_singleton()->has_feature(feature)
+                    || custom_features.has(feature)) {
+                    feature_overrides[parts[0]] = name;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (settings.has(name)) {
+        settings[name].current_value = value;
+    } else {
+        settings[name] = Setting(name, value, custom_position++);
+    }
+    return true;
+}
+
+void ProjectSettings::_get_property_list(List<PropertyInfo>* r_list) const {
+    _THREAD_SAFE_METHOD_
+
+    for (auto E = settings.front(); E; E = E->next()) {
+        Setting setting = E->get();
+        if (setting.hide_from_editor) {
+            continue;
+        }
+
+        if (setting.name.begins_with("input/")
+            || setting.name.begins_with("import/")
+            || setting.name.begins_with("export/")
+            || setting.name.begins_with("/remap")
+            || setting.name.begins_with("/locale")
+            || setting.name.begins_with("/autoload")) {
+            setting.flags = PROPERTY_USAGE_STORAGE;
+        } else {
+            setting.flags = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
+        }
+        if (setting.restart_if_changed) {
+            setting.flags |= PROPERTY_USAGE_RESTART_IF_CHANGED;
+        }
+
+        String property_info_name = setting.name;
+        int dot                   = setting.name.find(".");
+        if (dot > 0) {
+            property_info_name = setting.name.substr(0, dot);
+        }
+
+        if (custom_property_info.has(property_info_name)) {
+            PropertyInfo pi = custom_property_info[property_info_name];
+            pi.name         = setting.name;
+            pi.usage        = setting.flags;
+            r_list->push_back(pi);
+        } else {
+            r_list->push_back(PropertyInfo(
+                setting.current_value.get_type(),
+                setting.name,
+                PROPERTY_HINT_NONE,
+                "",
+                setting.flags
+            ));
+        }
+    }
+}
+
+void ProjectSettings::_add_property_info(const Dictionary& dict_info) {
+    ERR_FAIL_COND_MSG(!dict_info.has("name"), "Dictionary has no key \"name\"");
+    ERR_FAIL_COND_MSG(!dict_info.has("type"), "Dictionary has no key \"type\"");
+
+    const String& name        = dict_info["name"];
+    const Variant::Type& type = Variant::Type(dict_info["type"].operator int());
+    ERR_FAIL_COND_MSG(!settings.has(name), "Unknown setting: " + name);
+    ERR_FAIL_INDEX_MSG(type, Variant::VARIANT_MAX, "Unknown Variant type");
+
+    PropertyHint hint = PROPERTY_HINT_NONE;
+    String hint_string;
+    if (dict_info.has("hint")) {
+        hint = PropertyHint(dict_info["hint"].operator int());
+    }
+    if (dict_info.has("hint_string")) {
+        hint_string = dict_info["hint_string"];
+    }
+
+    const PropertyInfo property_info(type, name, hint, hint_string);
+    set_custom_property_info(name, property_info);
+}
+
+void ProjectSettings::_upgrade_settings(int current_version) {
+    if (current_version <= 3) {
+        // Convert input actions from an array to a dictionary.
+        for (auto E = settings.front(); E; E = E->next()) {
+            Variant value = E->get().current_value;
+            if (String(E->key()).begins_with("input/")
+                && value.get_type() == Variant::ARRAY) {
+                Array array = value;
+                Dictionary action;
+                action["deadzone"]     = Variant(0.5f);
+                action["events"]       = array;
+                E->get().current_value = action;
+            }
+        }
+    }
+}
+
+Error ProjectSettings::_setup(
+    const String& path,
+    const String& main_pack,
+    bool try_parent_dirs
+) {
+    // If using a network client, only load the settings.
+    if (FileAccessNetworkClient::get_singleton()) {
+        return _load_settings();
+    }
+
+    // If defined, use the user defined main pack.
+    if (main_pack != "") {
+        ERR_FAIL_COND_V_MSG(
+            !_load_resource_pack(main_pack),
+            ERR_CANT_OPEN,
+            "Cannot open resource pack: " + main_pack
+        );
+        return _load_settings("res://", main_pack.get_base_dir());
+    }
+
+    const String executable    = OS::get_singleton()->get_executable_path();
+    const String exec_dir      = executable.get_base_dir();
+    const String exec_filename = executable.get_file();
+    const String exec_basename = exec_filename.get_basename();
+
+    // Try loading the resource pack from the executable.
+    // This is the usual case when distributing a Rebel game.
+    if (executable != "" && _load_resource_pack(executable)) {
+        return _load_settings("res://", exec_dir);
+    }
+
+#ifdef MACOS_ENABLED
+    // Try loading the resource pack from macOS .app bundle resources.
+    const String bundle_dir = OS::get_singleton()->get_bundle_resource_dir();
+    if (_load_resource_pack(bundle_dir.plus_file(exec_basename + ".pck"))
+        || _load_resource_pack(bundle_dir.plus_file(exec_filename + ".pck"))) {
+        return _load_settings("res://", exec_dir);
+    }
+#endif
+
+    // Try loading the resource pack from the executable or working directories.
+    if (_load_resource_pack(exec_dir.plus_file(exec_basename + ".pck"))
+        || _load_resource_pack(exec_dir.plus_file(exec_filename + ".pck"))
+        || _load_resource_pack(exec_basename + ".pck")
+        || _load_resource_pack(exec_filename + ".pck")) {
+        return _load_settings("res://", exec_dir);
+    }
+
+    // If the OS has a specified resource directory, use that.
+    const String os_resource_dir = OS::get_singleton()->get_resource_dir();
+    if (os_resource_dir != "") {
+        resource_path = os_resource_dir.replace("\\", "/");
+        // Trim trailing '/'.
+        if (resource_path[resource_path.length() - 1] == '/') {
+            resource_path = resource_path.substr(0, resource_path.length() - 1);
+        }
+        return _load_settings();
+    }
+
+    // Try the specified `path`, and, if requested, try parent directories.
+    DirAccess* dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+    ERR_FAIL_COND_V_MSG(
+        dir_access->change_dir(path) != OK,
+        ERR_CANT_CREATE,
+        "Cannot access " + path
+    );
+    String current_dir;
+    Error error;
+    bool found = false;
+    while (!found && current_dir != dir_access->get_current_dir()) {
+        current_dir = dir_access->get_current_dir();
+        error       = _load_settings(current_dir, current_dir);
+        if (error == OK) {
+            found = true;
+        }
+        if (try_parent_dirs) {
+            dir_access->change_dir("..");
+        }
+    }
+    memdelete(dir_access);
+
+    resource_path = current_dir;
+    resource_path = resource_path.replace("\\", "/");
+    // Trim trailing '/'.
+    if (resource_path.length()
+        && resource_path[resource_path.length() - 1] == '/') {
+        resource_path = resource_path.substr(0, resource_path.length() - 1);
+    }
+
+    return error;
+}
+
+bool ProjectSettings::_load_resource_pack(
+    const String& pack_file,
+    bool replace_files,
+    int offset
+) {
+    if (PackedData::get_singleton()->is_disabled()) {
+        return false;
+    }
+
+    Error error =
+        PackedData::get_singleton()->add_pack(pack_file, replace_files, offset);
+    if (error != OK) {
+        return false;
+    }
+
+    // If data.pck is found, all directory access will be from here.
+    DirAccess::make_default<DirAccessPack>(DirAccess::ACCESS_RESOURCES);
+    using_datapack = true;
+    return true;
+}
+
+Error ProjectSettings::_load_binary_settings(const String& settings_file) {
+    Error file_access_error;
+    FileAccess* file_access =
+        FileAccess::open(settings_file, FileAccess::READ, &file_access_error);
+    if (!file_access) {
+        return file_access_error;
+    }
+
+    uint8_t header[4];
+    file_access->get_buffer(header, 4);
+    if (header[0] != 'E' || header[1] != 'C' || header[2] != 'F'
+        || header[3] != 'G') {
+        memdelete(file_access);
+        ERR_FAIL_V_MSG(
+            ERR_FILE_CORRUPT,
+            "Corrupted header in binary project.binary (not ECFG)"
+        );
+    }
+
+    uint32_t length = file_access->get_32();
+    for (uint32_t i = 0; i < length; i++) {
+        uint32_t key_length = file_access->get_32();
+        CharString char_string;
+        char_string.resize(key_length + 1);
+        char_string[key_length] = 0;
+        file_access->get_buffer((uint8_t*)char_string.ptr(), key_length);
+        String key;
+        key.parse_utf8(char_string.ptr());
+
+        uint32_t value_length = file_access->get_32();
+        Vector<uint8_t> value_bytes;
+        value_bytes.resize(value_length);
+        file_access->get_buffer(value_bytes.ptrw(), value_length);
+        Variant value;
+        Error error = decode_variant(
+            value,
+            value_bytes.ptr(),
+            value_bytes.size(),
+            nullptr,
+            true
+        );
+        ERR_CONTINUE_MSG(error != OK, "Error decoding setting: " + key);
+        set(key, value);
+    }
+
+    file_access->close();
+    memdelete(file_access);
+    return OK;
+}
+
+Error ProjectSettings::_load_text_settings(const String& settings_file) {
+    Error file_access_error;
+    FileAccess* file_access =
+        FileAccess::open(settings_file, FileAccess::READ, &file_access_error);
+    if (!file_access) {
+        return file_access_error;
+    }
+
+    String section;
+    int config_version = 0;
+
+    VariantParser::StreamFile stream;
+    stream.f = file_access;
+    int line = 0;
+    String error_text;
+    Error error = OK;
+
+    while (error == OK) {
+        VariantParser::Tag tag;
+        String key;
+        Variant value;
+
+        error = VariantParser::parse_tag_assign_eof(
+            &stream,
+            line,
+            error_text,
+            tag,
+            key,
+            value,
+            nullptr,
+            true
+        );
+
+        if (key != String()) {
+            if (section == String() && key == "config_version") {
+                config_version = value;
+                if (config_version > CONFIG_VERSION) {
+                    error = ERR_FILE_UNRECOGNIZED;
+                }
+            } else {
+                if (section == String()) {
+                    set(key, value);
+                } else {
+                    set(section + "/" + key, value);
+                }
+            }
+        } else if (tag.name != String()) {
+            section = tag.name;
+        }
+    }
+    memdelete(file_access);
+
+    switch (error) {
+        case ERR_FILE_EOF: {
+            // Not an error: Settings file loaded successfully.
+            _upgrade_settings(config_version);
+            last_save_time = FileAccess::get_modified_time(
+                resource_path.plus_file("project.rebel")
+            );
+            error = OK;
+        } break;
+        case ERR_FILE_UNRECOGNIZED: {
+            ERR_PRINT(vformat(
+                "Unable to load project settings file '%s'.\n"
+                "It's `config_version` (%d) is from a more recent and "
+                "incompatible version of the engine.\n"
+                "Expected config version: %d or lower",
+                settings_file,
+                config_version,
+                CONFIG_VERSION
+            ));
+        } break;
+        default: {
+            ERR_PRINT(vformat(
+                "Error parsing settings file '%s' at line %d: %s",
+                settings_file,
+                line,
+                error_text
+            ));
+        }
+    }
+    return error;
+}
+
+Error ProjectSettings::_load_settings(
+    const String& settings_dir,
+    const String& override_dir
+) {
+    const String& binary_file   = settings_dir.plus_file("project.binary");
+    const String& text_file     = settings_dir.plus_file("project.rebel");
+    const String& override_file = override_dir.plus_file("override.cfg");
+
+    // First, try to load the binary settings file.
+    Error error = _load_binary_settings(binary_file);
+    if (error != OK && error != ERR_FILE_NOT_FOUND) {
+        // If the file exists but can't be loaded, print an error.
+        ERR_PRINT(vformat(
+            "Error(%d): Couldn't load file %s",
+            binary_file,
+            itos(error)
+        ));
+    }
+
+    // If binary settings file fails, try to load the text settings file.
+    if (error != OK) {
+        error = _load_text_settings(text_file);
+    }
+
+    // If settings were loaded, optionally load the override settings file.
+    if (error == OK) {
+        _load_text_settings(override_file);
+    }
+
+    return error;
+}
+
+Error ProjectSettings::_save_binary_settings(
+    const String& settings_file,
+    const Map<String, List<String>>& grouped_settings,
+    const CustomSettings& custom_settings,
+    const String& custom_features
+) {
+    Error error;
+    FileAccess* file =
+        FileAccess::open(settings_file, FileAccess::WRITE, &error);
+    ERR_FAIL_COND_V_MSG(
+        error != OK,
+        error,
+        "Cannot write project settings file: " + settings_file
+    );
+
+    uint8_t header[4] = {'E', 'C', 'F', 'G'};
+    file->store_buffer(header, 4);
+
+    // Store the number of sections; add one for custom features.
+    int section_count = 0;
+    if (custom_features != String()) {
+        section_count++;
+    }
+    for (auto E = grouped_settings.front(); E; E = E->next()) {
+        for (auto F = E->get().front(); F; F = F->next()) {
+            section_count++;
+        }
+    }
+    file->store_32(section_count);
+
+    if (custom_features != String()) {
+        String key = CoreStringNames::get_singleton()->_custom_features;
+        file->store_pascal_string(key);
+
+        int length;
+        error = encode_variant(custom_features, nullptr, length, false);
+        if (error != OK) {
+            memdelete(file);
+            ERR_FAIL_V(error);
+        }
+
+        Vector<uint8_t> buffer;
+        buffer.resize(length);
+        error = encode_variant(custom_features, buffer.ptrw(), length, false);
+        if (error != OK) {
+            memdelete(file);
+            ERR_FAIL_V_MSG(
+                error,
+                "Error when trying to encode: " + custom_features
+            );
+        }
+        file->store_32(length);
+        file->store_buffer(buffer.ptr(), buffer.size());
+    }
+
+    for (auto E = grouped_settings.front(); E; E = E->next()) {
+        const String section = E->key();
+        for (auto F = E->get().front(); F; F = F->next()) {
+            String key = F->get();
+            if (section != "") {
+                key = section + "/" + key;
+            }
+            Variant value;
+            if (custom_settings.has(key)) {
+                value = custom_settings[key];
+            } else {
+                value = get(key);
+            }
+
+            file->store_pascal_string(key);
+            int length;
+            error = encode_variant(value, nullptr, length, true);
+            if (error != OK) {
+                memdelete(file);
+                ERR_FAIL_V_MSG(error, "Error when trying to encode Variant");
+            }
+
+            Vector<uint8_t> buffer;
+            buffer.resize(length);
+
+            error = encode_variant(value, buffer.ptrw(), length, true);
+            if (error != OK) {
+                memdelete(file);
+                ERR_FAIL_V_MSG(error, "Error when trying to encode Variant");
+            }
+            file->store_32(length);
+            file->store_buffer(buffer.ptr(), buffer.size());
+        }
+    }
+
+    file->close();
+    memdelete(file);
+
+    return OK;
+}
+
+Error ProjectSettings::_save_text_settings(
+    const String& settings_file,
+    const Map<String, List<String>>& grouped_settings,
+    const CustomSettings& custom_settings,
+    const String& custom_features
+) {
+    Error error;
+    FileAccess* file_access =
+        FileAccess::open(settings_file, FileAccess::WRITE, &error);
+    ERR_FAIL_COND_V_MSG(
+        error != OK,
+        error,
+        "Cannot write project settings file: " + settings_file
+    );
+
+    String header =
+        "; Engine configuration file.\n"
+        "; It's best edited using the editor UI and not directly,\n"
+        "; since the parameters that go here are not all obvious.\n"
+        ";\n"
+        "; Format:\n"
+        ";   [section] ; section goes between []\n"
+        ";   param=value ; assign values to parameters\n";
+    file_access->store_line(header);
+
+    file_access->store_string("config_version=" + itos(CONFIG_VERSION) + "\n");
+
+    if (custom_features != String()) {
+        file_access->store_line("custom_features=\"" + custom_features + "\"");
+    }
+
+    for (auto E = grouped_settings.front(); E; E = E->next()) {
+        file_access->store_line("");
+
+        const String section = E->key();
+        if (section != "") {
+            file_access->store_line("[" + section + "]");
+            file_access->store_line("");
+        }
+
+        for (auto F = E->get().front(); F; F = F->next()) {
+            const String key = F->get();
+            String setting   = key;
+            if (section != "") {
+                setting = section + "/" + key;
+            }
+            Variant value;
+            if (custom_settings.has(setting)) {
+                value = custom_settings[setting];
+            } else {
+                value = get(setting);
+            }
+
+            String value_string;
+            VariantWriter::write_to_string(value, value_string);
+            file_access->store_line(
+                key.property_name_encode() + "=" + value_string
+            );
+        }
+    }
+
+    file_access->close();
+    memdelete(file_access);
+
+    return OK;
+}
+
+Error ProjectSettings::_save_custom_bnd(const String& settings_file) {
+    return save_custom(settings_file);
+};
+
+Variant _GLOBAL_DEF(
+    const String& name,
+    const Variant& default_value,
+    bool requires_restart,
+    bool ignore_in_docs
+) {
+    if (!ProjectSettings::get_singleton()->has_setting(name)) {
+        ProjectSettings::get_singleton()->set(name, default_value);
+    }
+    ProjectSettings::get_singleton()->set_initial_value(name, default_value);
+    ProjectSettings::get_singleton()->set_builtin_order(name);
+    ProjectSettings::get_singleton()->set_restart_if_changed(
+        name,
+        requires_restart
+    );
+    ProjectSettings::get_singleton()->set_ignore_value_in_docs(
+        name,
+        ignore_in_docs
+    );
+    return ProjectSettings::get_singleton()->get(name);
+}
+
+Variant _GLOBAL_DEF_ALIAS(
+    const String& name,
+    const String& old_name,
+    const Variant& default_value,
+    bool requires_restart
+) {
+    // If the new name doesn't exist, try using the value of the old name.
+    if (!ProjectSettings::get_singleton()->has_setting(name)) {
+        if (ProjectSettings::get_singleton()->has_setting(old_name)) {
+            Variant old_value = ProjectSettings::get_singleton()->get(old_name);
+            ProjectSettings::get_singleton()->set(name, old_value);
+        }
+    }
+    return _GLOBAL_DEF(name, default_value, requires_restart);
 }

--- a/docs/ProjectSettings.xml
+++ b/docs/ProjectSettings.xml
@@ -120,7 +120,7 @@ SPDX-License-Identifier: MIT
                 Returns [code]true[/code] if the specified property exists and its initial value differs from the current value.
             </description>
         </method>
-        <method name="property_get_revert">
+        <method name="property_get_revert" qualifiers="const">
             <return type="Variant" />
             <argument index="0" name="name" type="String" />
             <description>

--- a/editor/docs/docs_data.cpp
+++ b/editor/docs/docs_data.cpp
@@ -320,7 +320,7 @@ void DocsData::generate(bool p_basic_types) {
                 // taken from the current project's settings
                 if (E->get().name == "script"
                     || ProjectSettings::get_singleton()->get_order(E->get().name
-                       ) >= ProjectSettings::NO_BUILTIN_ORDER_BASE) {
+                       ) >= ProjectSettings::CUSTOM_SETTINGS_START) {
                     continue;
                 }
                 if (E->get().usage & PROPERTY_USAGE_EDITOR) {

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1033,7 +1033,7 @@ Error EditorExportPlatform::export_project_files(
 
     // save config!
 
-    Vector<String> custom_list;
+    Vector<String> custom_features;
 
     if (p_preset->get_custom_features() != String()) {
         Vector<String> tmp_custom_list =
@@ -1042,12 +1042,12 @@ Error EditorExportPlatform::export_project_files(
         for (int i = 0; i < tmp_custom_list.size(); i++) {
             String f = tmp_custom_list[i].strip_edges();
             if (f != String()) {
-                custom_list.push_back(f);
+                custom_features.push_back(f);
             }
         }
     }
 
-    ProjectSettings::CustomMap custom_map;
+    ProjectSettings::CustomSettings custom_settings;
     if (path_remaps.size()) {
         if (true) { // new remap mode, use always as it's friendlier with
                     // multiple .pck exports
@@ -1071,7 +1071,7 @@ Error EditorExportPlatform::export_project_files(
         } else {
             // old remap mode, will still work, but it's unused because it's not
             // multiple pck export friendly
-            custom_map["path_remap/remapped_paths"] = path_remaps;
+            custom_settings["path_remap/remapped_paths"] = path_remaps;
         }
     }
 
@@ -1102,7 +1102,7 @@ Error EditorExportPlatform::export_project_files(
             "tmp" + config_file
         );
     ProjectSettings::get_singleton()
-        ->save_custom(engine_cfb, custom_map, custom_list);
+        ->save_custom(engine_cfb, custom_settings, custom_features);
     Vector<uint8_t> data = FileAccess::get_file_as_array(engine_cfb);
     DirAccess::remove_file_or_error(engine_cfb);
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1131,7 +1131,7 @@ void ProjectSettingsEditor::_item_del() {
     }
 
     if (ProjectSettings::get_singleton()->get_order(property)
-        < ProjectSettings::NO_BUILTIN_ORDER_BASE) {
+        < ProjectSettings::CUSTOM_SETTINGS_START) {
         EditorNode::get_singleton()->show_warning(vformat(
             TTR("Setting '%s' is internal, and it can't be deleted."),
             property

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-#ifndef PROJECT_SETTINGS_H
-#define PROJECT_SETTINGS_H
+#ifndef PROJECT_SETTINGS_EDITOR_H
+#define PROJECT_SETTINGS_EDITOR_H
 
 #include "core/undo_redo.h"
 #include "editor/editor_autoload_settings.h"
@@ -199,4 +199,4 @@ public:
     ProjectSettingsEditor(EditorData* p_data);
 };
 
-#endif // PROJECT_SETTINGS_H
+#endif // PROJECT_SETTINGS_EDITOR_H

--- a/projects_manager/new_project_dialog.cpp
+++ b/projects_manager/new_project_dialog.cpp
@@ -21,7 +21,7 @@
 namespace {
 bool create_project(
     const String& project_folder,
-    const ProjectSettings::CustomMap& project_settings
+    const ProjectSettings::CustomSettings& project_settings
 ) {
     Error error = ProjectSettings::get_singleton()->save_custom(
         project_folder.plus_file("project.rebel"),
@@ -260,7 +260,7 @@ void NewProjectDialog::ok_pressed() {
         return;
     }
 
-    ProjectSettings::CustomMap project_settings;
+    ProjectSettings::CustomSettings project_settings;
     project_settings["application/config/name"] = project_name;
     if (renderer_button_group->get_pressed_button()->get_meta("driver_name")
         == "GLES3") {


### PR DESCRIPTION
To clean and simplify the code and make it easier to read and maintain in the future, this PR [refactors](https://en.wikipedia.org/wiki/Code_refactoring) the `ProjectSettings` class.

- Restructures files to make the public interface clearer
- Initialises variables in the header
- Renames variables, private methods, `typedefs`, etc. to better reflect their purpose
- Simplifies and merges internal `structs`
- Removes unused methods and variables
- Makes `const` methods `const`.
- Simplifies methods to make them easier to understand
- Makes error messages clearer and comments relevant
