### PR TITLE
Automate web platform tool updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "00:00"
+    labels:
+      - "PR Type: Maintenance"
+    pull-request-branch-name:
+      separator: "-"
+
+  - package-ecosystem: "npm"
+    directory: "/platforms/web/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "01:00"
+    labels:
+      - "PR Type: Maintenance"
+    pull-request-branch-name:
+      separator: "-"
+    groups:
+      version-updates:
+          patterns:
+             - "*"
+          update-types:
+            - "minor"
+            - "patch"


### PR DESCRIPTION
Although not critical, #173 highlighted that the [npm modules](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) used for testing the Javascript formatting and Javascript documentation creation used by the web platform do need to be kept up to date.

This PR automates that update process. It also includes the automatic updating of the GitHub actions used.

**Note:** It does not include the automated update of the third-party libraries used by Rebel Engine and Rebel Editor.