### PR TITLE
Remove ProjectSettings clear(setting) bound method

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -492,12 +492,10 @@ bool ProjectSettings::has_custom_feature(const String& feature) const {
     return custom_features.has(feature);
 }
 
-void ProjectSettings::clear(const String& name) {
-    ERR_FAIL_COND_MSG(
-        !settings.has(name),
-        "Cannot clear unknown project setting: " + name
-    );
-    settings.erase(name);
+void ProjectSettings::clear() {
+    settings.clear();
+    custom_property_info.clear();
+    feature_overrides.clear();
 }
 
 void ProjectSettings::set_initial_value(
@@ -733,7 +731,6 @@ void ProjectSettings::_bind_methods() {
         D_METHOD("add_property_info", "hint"),
         &ProjectSettings::_add_property_info
     );
-    ClassDB::bind_method(D_METHOD("clear", "name"), &ProjectSettings::clear);
     ClassDB::bind_method(
         D_METHOD("get_order", "name"),
         &ProjectSettings::get_order

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -71,7 +71,7 @@ public:
     bool is_using_datapack() const;
     bool has_custom_feature(const String& feature) const;
 
-    void clear(const String& name);
+    void clear();
     void set_initial_value(const String& name, const Variant& value);
     void set_restart_if_changed(const String& name, bool restart_required);
     void set_disable_feature_overrides(bool disable);

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -290,37 +290,30 @@ void ScriptServer::get_global_class_list(List<StringName>* r_global_classes) {
 }
 
 void ScriptServer::save_global_classes() {
-    List<StringName> gc;
-    get_global_class_list(&gc);
-    Array gcarr;
-    for (List<StringName>::Element* E = gc.front(); E; E = E->next()) {
-        Dictionary d;
-        d["class"]    = E->get();
-        d["language"] = global_classes[E->get()].language;
-        d["path"]     = global_classes[E->get()].path;
-        d["base"]     = global_classes[E->get()].base;
-        gcarr.push_back(d);
+    List<StringName> class_names;
+    get_global_class_list(&class_names);
+
+    Array new_classes;
+    for (List<StringName>::Element* E = class_names.front(); E; E = E->next()) {
+        Dictionary class_data;
+        class_data["class"]    = E->get();
+        class_data["language"] = global_classes[E->get()].language;
+        class_data["path"]     = global_classes[E->get()].path;
+        class_data["base"]     = global_classes[E->get()].base;
+        new_classes.push_back(class_data);
     }
 
-    Array old;
-    if (ProjectSettings::get_singleton()->has_setting("_global_script_classes"
-        )) {
-        old = ProjectSettings::get_singleton()->get("_global_script_classes");
+    Array old_classes;
+    ProjectSettings* settings = ProjectSettings::get_singleton();
+    if (settings->has_setting("_global_script_classes")) {
+        old_classes = settings->get("_global_script_classes");
     }
-    if ((!old.empty() || gcarr.empty()) && gcarr.hash() == old.hash()) {
+
+    if (new_classes.hash() == old_classes.hash()) {
         return;
     }
-
-    if (gcarr.empty()) {
-        if (ProjectSettings::get_singleton()->has_setting(
-                "_global_script_classes"
-            )) {
-            ProjectSettings::get_singleton()->clear("_global_script_classes");
-        }
-    } else {
-        ProjectSettings::get_singleton()->set("_global_script_classes", gcarr);
-    }
-    ProjectSettings::get_singleton()->save();
+    settings->set("_global_script_classes", new_classes);
+    settings->save();
 }
 
 ////////////////////

--- a/docs/ProjectSettings.xml
+++ b/docs/ProjectSettings.xml
@@ -42,13 +42,6 @@ SPDX-License-Identifier: MIT
                 [/codeblock]
             </description>
         </method>
-        <method name="clear">
-            <return type="void" />
-            <argument index="0" name="name" type="String" />
-            <description>
-                Clears the whole configuration (not recommended, may break things).
-            </description>
-        </method>
         <method name="get_order" qualifiers="const">
             <return type="int" />
             <argument index="0" name="name" type="String" />

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1014,35 +1014,24 @@ void EditorData::script_class_save_icon_paths() {
     List<StringName> keys;
     _script_class_icon_paths.get_key_list(&keys);
 
-    Dictionary d;
+    Dictionary new_paths;
     for (List<StringName>::Element* E = keys.front(); E; E = E->next()) {
         if (ScriptServer::is_global_class(E->get())) {
-            d[E->get()] = _script_class_icon_paths[E->get()];
+            new_paths[E->get()] = _script_class_icon_paths[E->get()];
         }
     }
 
-    Dictionary old;
-    if (ProjectSettings::get_singleton()->has_setting(
-            "_global_script_class_icons"
-        )) {
-        old =
-            ProjectSettings::get_singleton()->get("_global_script_class_icons");
+    Dictionary old_paths;
+    ProjectSettings* settings = ProjectSettings::get_singleton();
+    if (settings->has_setting("_global_script_class_icons")) {
+        old_paths = settings->get("_global_script_class_icons");
     }
-    if ((!old.empty() || d.empty()) && d.hash() == old.hash()) {
+
+    if (new_paths.hash() == old_paths.hash()) {
         return;
     }
-
-    if (d.empty()) {
-        if (ProjectSettings::get_singleton()->has_setting(
-                "_global_script_class_icons"
-            )) {
-            ProjectSettings::get_singleton()->clear("_global_script_class_icons"
-            );
-        }
-    } else {
-        ProjectSettings::get_singleton()->set("_global_script_class_icons", d);
-    }
-    ProjectSettings::get_singleton()->save();
+    settings->set("_global_script_class_icons", new_paths);
+    settings->save();
 }
 
 void EditorData::script_class_load_icon_paths() {


### PR DESCRIPTION
Currently, [`ProjectSettings`](https://docs.rebeltoolbox.com/en/latest/api/class_projectsettings.html) has a [`clear(String name)`](https://docs.rebeltoolbox.com/en/latest/api/class_projectsettings.html#class-projectsettings-method-clear) method, which the documentation describes as:
```
Clears the whole configuration (not recommended, may break things).
```
First, this method does not erase the whole configuration (which would break things), it only erases the specified setting. Second, the user can also erase the specified setting, by using the [`set_setting(String name, Variant value)`](https://docs.rebeltoolbox.com/en/latest/api/class_projectsettings.html#class-projectsettings-method-set-setting) method with a value of `null`. So, not only is the `clear(String name)` method unlikely to be used, if the user wants to erase a specified setting they can use `set_setting(String name, Variant value)`.  Therefore, although removing this method will break compatibility in existing games that use the `clear(String name)` method, these are easily fixed by using the `set_setting()` method with a `null` value.

In addition, there is a need for an internal `clear()` method that will clear the whole configuration. Since the current `clear()` method doesn't do what it says, we want to repurpose the `clear()` method to do what it should: clear the whole configuration. However, we don't want to allow users to do this, because it will break things. Unfortunately, Rebel Engine does not allow us to bind overloaded methods. Therefore we need to remove the current bound `clear(String name)` to enable a `clear()` method to be created.

This PR removes the current bound `ProjectSettings` `clear(String name)` method and creates an internal `clear()` method that clears the whole configuration. It includes fixing the two internal uses of the current `clear(String name)` method and replaces them with the `set(String name, Variant value)` method. In addition, instead of erasing the setting, it uses an empty dictionary value, which also considerably simplifies the calls.