### PR TITLE
Fix Projects Manager's Projects List Item's refresh() method

### DIFF
--- a/projects_manager/projects_list_item.h
+++ b/projects_manager/projects_list_item.h
@@ -52,14 +52,17 @@ private:
     Label* project_name_label;
     TextureButton* favorite_button;
     TextureRect* icon_texture;
+    VBoxContainer* project_details_container;
 
     bool hover = false;
 
+    void _configure_item();
     void _extract_project_values();
     void _on_draw();
     void _on_gui_input(const Ref<InputEvent>& p_input_event);
     void _on_favorite_pressed();
     void _on_show_folder_pressed(const String& p_folder);
+    void _reset_item();
 };
 
 class ProjectsListItemComparator {


### PR DESCRIPTION
Currently, `ProjectsListIem`'s `refresh()` method only refreshes a subset of the item's values. For example, if the item is longer missing, it leaves the item greyed out, it does not update the project's icon, it does not update the open folder icon or its tool-tip, etc.

This PR ensures that the `refresh()` method refreshes all the item's values. It also removes duplicate code and separates configuring the item from creating the item UI.