### PR TITLE
Allow ScrollContainer's ensure_control_visible() method to accept a `const Control` parameter

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -245,7 +245,7 @@ void ScrollContainer::_gui_focus_changed(Control* p_control) {
     }
 }
 
-void ScrollContainer::ensure_control_visible(Control* p_control) {
+void ScrollContainer::ensure_control_visible(const Control* p_control) {
     ERR_FAIL_COND_MSG(
         !is_a_parent_of(p_control),
         "Must be a parent of the control."

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -73,7 +73,7 @@ public:
 
     HScrollBar* get_h_scrollbar();
     VScrollBar* get_v_scrollbar();
-    void ensure_control_visible(Control* p_control);
+    void ensure_control_visible(const Control* p_control);
 
     virtual bool clips_input() const;
 


### PR DESCRIPTION
Currently, `ScrollContainer`'s `ensure_control_visible()` method takes a `Control` as a parameter. Since the `Control` is not changed, it can accept a `const Control`. Accepting a `const Control` allows `ensure_control_visible()` to be called using a pointer to a `Control` that cannot be changed.

This PR updates `ScrollContainer`'s `ensure_control_visible()` method to accept a `const Control` parameter.