### PR TITLE
Defer Projects Manager's Projects List's call to ensure_control_visible()

### DIFF
--- a/projects_manager/projects_list.cpp
+++ b/projects_manager/projects_list.cpp
@@ -358,7 +358,10 @@ ProjectsListItem* ProjectsList::_create_item(
 }
 
 void ProjectsList::_ensure_item_visible(int p_index) {
-    scroll_container->ensure_control_visible(projects[p_index]);
+    scroll_container->call_deferred(
+        "ensure_control_visible",
+        projects[p_index]
+    );
 }
 
 void ProjectsList::_filter_projects() {


### PR DESCRIPTION
Currently, when renaming a project in Projects Manager, the position of the project in the list is updated, but, despite a call being made to `ScrollContainer`'s `ensure_control_visible()` the view is not updated to ensure the item remains visible.

This PR defers the call to `ScrollContainer`'s `ensure_control_visible()` to ensure that the changes to the control's new position are available before calculating how much to scroll the `ScrollContainer`.