### PR TITLE
Refactor ConfigFile

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -10,366 +10,319 @@
 #include "core/os/keyboard.h"
 #include "core/variant_parser.h"
 
-PoolStringArray ConfigFile::_get_sections() const {
-    List<String> s;
-    get_sections(&s);
-    PoolStringArray arr;
-    arr.resize(s.size());
-    int idx = 0;
-    for (const List<String>::Element* E = s.front(); E; E = E->next()) {
-        arr.set(idx++, E->get());
-    }
-
-    return arr;
-}
-
-PoolStringArray ConfigFile::_get_section_keys(const String& p_section) const {
-    List<String> s;
-    get_section_keys(p_section, &s);
-    PoolStringArray arr;
-    arr.resize(s.size());
-    int idx = 0;
-    for (const List<String>::Element* E = s.front(); E; E = E->next()) {
-        arr.set(idx++, E->get());
-    }
-
-    return arr;
-}
-
-void ConfigFile::set_value(
-    const String& p_section,
-    const String& p_key,
-    const Variant& p_value
+namespace {
+FileAccessEncrypted* get_file_access_encrypted(
+    Error& error,
+    FileAccess* file_access,
+    const FileAccessEncrypted::Mode& mode,
+    const String& password     = String(),
+    const Vector<uint8_t>& key = Vector<uint8_t>()
 ) {
-    if (p_value.get_type() == Variant::NIL) {
-        // erase
-        if (!values.has(p_section)) {
-            return; // ?
-        }
-        values[p_section].erase(p_key);
-        if (values[p_section].empty()) {
-            values.erase(p_section);
-        }
-
+    FileAccessEncrypted* file_access_encrypted = memnew(FileAccessEncrypted);
+    if (!key.empty()) {
+        error = file_access_encrypted->open_and_parse(file_access, key, mode);
     } else {
-        if (!values.has(p_section)) {
-            values[p_section] = OrderedHashMap<String, Variant>();
-        }
-
-        values[p_section][p_key] = p_value;
+        error = file_access_encrypted
+                    ->open_and_parse_password(file_access, password, mode);
     }
+    return file_access_encrypted;
 }
 
-Variant ConfigFile::get_value(
-    const String& p_section,
-    const String& p_key,
-    Variant p_default
-) const {
-    if (!values.has(p_section) || !values[p_section].has(p_key)) {
-        ERR_FAIL_COND_V_MSG(
-            p_default.get_type() == Variant::NIL,
-            Variant(),
-            vformat(
-                "Couldn't find the given section \"%s\" and key \"%s\", and no "
-                "default was given.",
-                p_section,
-                p_key
-            )
-        );
-        return p_default;
-    }
-    return values[p_section][p_key];
-}
-
-bool ConfigFile::has_section(const String& p_section) const {
-    return values.has(p_section);
-}
-
-bool ConfigFile::has_section_key(const String& p_section, const String& p_key)
-    const {
-    if (!values.has(p_section)) {
-        return false;
-    }
-    return values[p_section].has(p_key);
-}
-
-void ConfigFile::get_sections(List<String>* r_sections) const {
-    for (OrderedHashMap<String, OrderedHashMap<String, Variant>>::ConstElement
-             E = values.front();
-         E;
-         E = E.next()) {
-        r_sections->push_back(E.key());
-    }
-}
-
-void ConfigFile::get_section_keys(const String& p_section, List<String>* r_keys)
-    const {
-    ERR_FAIL_COND_MSG(
-        !values.has(p_section),
-        vformat("Cannot get keys from nonexistent section \"%s\".", p_section)
-    );
-
-    for (OrderedHashMap<String, Variant>::ConstElement E =
-             values[p_section].front();
-         E;
-         E = E.next()) {
-        r_keys->push_back(E.key());
-    }
-}
-
-void ConfigFile::erase_section(const String& p_section) {
-    ERR_FAIL_COND_MSG(
-        !values.has(p_section),
-        vformat("Cannot erase nonexistent section \"%s\".", p_section)
-    );
-    values.erase(p_section);
-}
-
-void ConfigFile::erase_section_key(
-    const String& p_section,
-    const String& p_key
+Error load_stream(
+    ConfigFile& config_file,
+    VariantParser::Stream& stream,
+    const String& source_name
 ) {
-    ERR_FAIL_COND_MSG(
-        !values.has(p_section),
-        vformat(
-            "Cannot erase key \"%s\" from nonexistent section \"%s\".",
-            p_key,
-            p_section
-        )
-    );
-    ERR_FAIL_COND_MSG(
-        !values[p_section].has(p_key),
-        vformat(
-            "Cannot erase nonexistent key \"%s\" from section \"%s\".",
-            p_key,
-            p_section
-        )
-    );
-
-    values[p_section].erase(p_key);
-}
-
-Error ConfigFile::save(const String& p_path) {
-    Error err;
-    FileAccess* file = FileAccess::open(p_path, FileAccess::WRITE, &err);
-
-    if (err) {
-        if (file) {
-            memdelete(file);
-        }
-        return err;
-    }
-
-    return _internal_save(file);
-}
-
-Error ConfigFile::save_encrypted(
-    const String& p_path,
-    const Vector<uint8_t>& p_key
-) {
-    Error err;
-    FileAccess* f = FileAccess::open(p_path, FileAccess::WRITE, &err);
-
-    if (err) {
-        return err;
-    }
-
-    FileAccessEncrypted* fae = memnew(FileAccessEncrypted);
-    err = fae->open_and_parse(f, p_key, FileAccessEncrypted::MODE_WRITE_AES256);
-    if (err) {
-        memdelete(fae);
-        memdelete(f);
-        return err;
-    }
-    return _internal_save(fae);
-}
-
-Error ConfigFile::save_encrypted_pass(
-    const String& p_path,
-    const String& p_pass
-) {
-    Error err;
-    FileAccess* f = FileAccess::open(p_path, FileAccess::WRITE, &err);
-
-    if (err) {
-        return err;
-    }
-
-    FileAccessEncrypted* fae = memnew(FileAccessEncrypted);
-    err                      = fae->open_and_parse_password(
-        f,
-        p_pass,
-        FileAccessEncrypted::MODE_WRITE_AES256
-    );
-    if (err) {
-        memdelete(fae);
-        memdelete(f);
-        return err;
-    }
-
-    return _internal_save(fae);
-}
-
-Error ConfigFile::_internal_save(FileAccess* file) {
-    for (OrderedHashMap<String, OrderedHashMap<String, Variant>>::Element E =
-             values.front();
-         E;
-         E = E.next()) {
-        if (E != values.front()) {
-            file->store_string("\n");
-        }
-        file->store_string("[" + E.key() + "]\n\n");
-
-        for (OrderedHashMap<String, Variant>::Element F = E.get().front(); F;
-             F                                          = F.next()) {
-            String vstr;
-            VariantWriter::write_to_string(F.get(), vstr);
-            file->store_string(
-                F.key().property_name_encode() + "=" + vstr + "\n"
-            );
-        }
-    }
-
-    memdelete(file);
-
-    return OK;
-}
-
-Error ConfigFile::load(const String& p_path) {
-    Error err;
-    FileAccess* f = FileAccess::open(p_path, FileAccess::READ, &err);
-
-    if (!f) {
-        return err;
-    }
-
-    return _internal_load(p_path, f);
-}
-
-Error ConfigFile::load_encrypted(
-    const String& p_path,
-    const Vector<uint8_t>& p_key
-) {
-    Error err;
-    FileAccess* f = FileAccess::open(p_path, FileAccess::READ, &err);
-
-    if (err) {
-        return err;
-    }
-
-    FileAccessEncrypted* fae = memnew(FileAccessEncrypted);
-    err = fae->open_and_parse(f, p_key, FileAccessEncrypted::MODE_READ);
-    if (err) {
-        memdelete(fae);
-        memdelete(f);
-        return err;
-    }
-    return _internal_load(p_path, fae);
-}
-
-Error ConfigFile::load_encrypted_pass(
-    const String& p_path,
-    const String& p_pass
-) {
-    Error err;
-    FileAccess* f = FileAccess::open(p_path, FileAccess::READ, &err);
-
-    if (err) {
-        return err;
-    }
-
-    FileAccessEncrypted* fae = memnew(FileAccessEncrypted);
-    err =
-        fae->open_and_parse_password(f, p_pass, FileAccessEncrypted::MODE_READ);
-    if (err) {
-        memdelete(fae);
-        memdelete(f);
-        return err;
-    }
-
-    return _internal_load(p_path, fae);
-}
-
-Error ConfigFile::_internal_load(const String& p_path, FileAccess* f) {
-    VariantParser::StreamFile stream;
-    stream.f = f;
-
-    Error err = _parse(p_path, &stream);
-
-    memdelete(f);
-
-    return err;
-}
-
-Error ConfigFile::parse(const String& p_data) {
-    VariantParser::StreamString stream;
-    stream.s = p_data;
-    return _parse("<string>", &stream);
-}
-
-Error ConfigFile::_parse(
-    const String& p_path,
-    VariantParser::Stream* p_stream
-) {
-    String assign;
-    Variant value;
-    VariantParser::Tag next_tag;
-
-    int lines = 0;
-    String error_text;
-
     String section;
+    int line = 0;
+    String error_string;
+    Error error = OK;
 
-    while (true) {
-        assign = Variant();
-        next_tag.fields.clear();
-        next_tag.name = String();
+    while (error == OK) {
+        VariantParser::Tag tag;
+        String assign;
+        Variant value;
 
-        Error err = VariantParser::parse_tag_assign_eof(
-            p_stream,
-            lines,
-            error_text,
-            next_tag,
+        error = VariantParser::parse_tag_assign_eof(
+            &stream,
+            line,
+            error_string,
+            tag,
             assign,
             value,
             nullptr,
             true
         );
-        if (err == ERR_FILE_EOF) {
-            return OK;
-        } else if (err != OK) {
-            ERR_PRINT(vformat(
-                "ConfigFile parse error at %s:%d: %s.",
-                p_path,
-                lines,
-                error_text
-            ));
-            return err;
-        }
 
-        if (assign != String()) {
-            set_value(section, assign, value);
-        } else if (next_tag.name != String()) {
-            section = next_tag.name;
+        if (error == OK) {
+            if (assign != String()) {
+                config_file.set_value(section, assign, value);
+            } else if (tag.name != String()) {
+                section = tag.name;
+            }
         }
     }
 
+    if (error == ERR_FILE_EOF) {
+        return OK;
+    }
+    ERR_PRINT(vformat(
+        "ConfigFile parse error at %s:%d: %s.",
+        source_name,
+        line,
+        error_string
+    ));
+    return error;
+}
+
+Error load_file_access(
+    ConfigFile& config_file,
+    FileAccess* file_access,
+    const String& source_name
+) {
+    VariantParser::StreamFile stream;
+    stream.f = file_access;
+    return load_stream(config_file, stream, source_name);
+}
+
+void save_file_access(
+    const OrderedHashMap<String, OrderedHashMap<String, Variant>>& values,
+    FileAccess* file
+) {
+    for (auto section = values.front(); section; section = section.next()) {
+        if (section != values.front()) {
+            file->store_string("\n");
+        }
+        file->store_string(vformat("[%s]\n\n", section.key()));
+
+        for (auto key = section.get().front(); key; key = key.next()) {
+            String value;
+            VariantWriter::write_to_string(key.get(), value);
+            file->store_string(
+                vformat("%s=%s\n", key.key().property_name_encode(), value)
+            );
+        }
+    }
+}
+
+Error load_file(
+    ConfigFile& config_file,
+    const String& path,
+    const String& password     = String(),
+    const Vector<uint8_t>& key = Vector<uint8_t>()
+) {
+    Error error;
+    FileAccess* file_access = FileAccess::open(path, FileAccess::READ, &error);
+    if (!file_access) {
+        return error;
+    }
+
+    FileAccess* source = file_access;
+    if (!password.empty() || !key.empty()) {
+        source = get_file_access_encrypted(
+            error,
+            file_access,
+            FileAccessEncrypted::MODE_READ,
+            password,
+            key
+        );
+        if (error) {
+            memdelete(source);
+            memdelete(file_access);
+            return error;
+        }
+    }
+
+    error = load_file_access(config_file, source, path);
+    if (source != file_access) {
+        memdelete(source);
+    }
+    memdelete(file_access);
+    return error;
+}
+
+Error save_file(
+    const OrderedHashMap<String, OrderedHashMap<String, Variant>>& values,
+    const String& path,
+    const String& password     = String(),
+    const Vector<uint8_t>& key = Vector<uint8_t>()
+) {
+    Error error;
+    FileAccess* file_access = FileAccess::open(path, FileAccess::WRITE, &error);
+    if (!file_access) {
+        return error;
+    }
+
+    FileAccess* destination = file_access;
+    if (!password.empty() || !key.empty()) {
+        destination = get_file_access_encrypted(
+            error,
+            file_access,
+            FileAccessEncrypted::MODE_WRITE_AES256,
+            password,
+            key
+        );
+        if (error) {
+            memdelete(destination);
+            memdelete(file_access);
+            return error;
+        }
+    }
+
+    save_file_access(values, destination);
+    if (destination != file_access) {
+        memdelete(destination);
+    }
+    memdelete(file_access);
     return OK;
+}
+} // namespace
+
+Variant ConfigFile::get_value(
+    const String& section,
+    const String& key,
+    Variant default_value
+) const {
+    if (!values.has(section) || !values[section].has(key)) {
+        ERR_FAIL_COND_V_MSG(
+            default_value.get_type() == Variant::NIL,
+            Variant(),
+            vformat(
+                "No key \"%s\" in section \"%s\", and no default given.",
+                key,
+                section
+            )
+        );
+        return default_value;
+    }
+    return values[section][key];
+}
+
+void ConfigFile::set_value(
+    const String& section,
+    const String& key,
+    const Variant& value
+) {
+    if (value.get_type() == Variant::NIL) {
+        erase_section_key(section, key);
+        return;
+    }
+    if (!values.has(section)) {
+        values[section] = OrderedHashMap<String, Variant>();
+    }
+    values[section][key] = value;
+}
+
+bool ConfigFile::has_section(const String& section) const {
+    return values.has(section);
+}
+
+bool ConfigFile::has_section_key(const String& section, const String& key)
+    const {
+    if (!values.has(section)) {
+        return false;
+    }
+    return values[section].has(key);
+}
+
+void ConfigFile::get_sections(List<String>* sections) const {
+    for (auto section = values.front(); section; section = section.next()) {
+        sections->push_back(section.key());
+    }
+}
+
+void ConfigFile::get_section_keys(const String& section, List<String>* keys)
+    const {
+    ERR_FAIL_COND_MSG(
+        !values.has(section),
+        vformat("Cannot get keys from nonexistent section \"%s\".", section)
+    );
+    for (auto key = values[section].front(); key; key = key.next()) {
+        keys->push_back(key.key());
+    }
 }
 
 void ConfigFile::clear() {
     values.clear();
 }
 
-void ConfigFile::_bind_methods() {
-    ClassDB::bind_method(
-        D_METHOD("set_value", "section", "key", "value"),
-        &ConfigFile::set_value
+void ConfigFile::erase_section(const String& section) {
+    ERR_FAIL_COND_MSG(
+        !values.has(section),
+        vformat("Cannot erase non-existent section \"%s\".", section)
     );
+    values.erase(section);
+}
+
+void ConfigFile::erase_section_key(const String& section, const String& key) {
+    ERR_FAIL_COND_MSG(
+        !values.has(section),
+        vformat(
+            "Cannot erase key \"%s\" from non-existent section \"%s\".",
+            key,
+            section
+        )
+    );
+    ERR_FAIL_COND_MSG(
+        !values[section].has(key),
+        vformat(
+            "Cannot erase non-existent key \"%s\" from section \"%s\".",
+            key,
+            section
+        )
+    );
+    values[section].erase(key);
+}
+
+Error ConfigFile::load(const String& path) {
+    return load_file(*this, path);
+}
+
+Error ConfigFile::load_encrypted_pass(
+    const String& path,
+    const String& password
+) {
+    return load_file(*this, path, password);
+}
+
+Error ConfigFile::load_encrypted(
+    const String& path,
+    const Vector<uint8_t>& key
+) {
+    return load_file(*this, path, String(), key);
+}
+
+Error ConfigFile::parse(const String& data) {
+    VariantParser::StreamString stream;
+    stream.s = data;
+    return load_stream(*this, stream, "<string>");
+}
+
+Error ConfigFile::save(const String& path) const {
+    return save_file(values, path);
+}
+
+Error ConfigFile::save_encrypted_pass(
+    const String& path,
+    const String& password
+) const {
+    return save_file(values, path, password);
+}
+
+Error ConfigFile::save_encrypted(const String& path, const Vector<uint8_t>& key)
+    const {
+    return save_file(values, path, String(), key);
+}
+
+void ConfigFile::_bind_methods() {
     ClassDB::bind_method(
         D_METHOD("get_value", "section", "key", "default"),
         &ConfigFile::get_value,
         DEFVAL(Variant())
+    );
+    ClassDB::bind_method(
+        D_METHOD("set_value", "section", "key", "value"),
+        &ConfigFile::set_value
     );
 
     ClassDB::bind_method(
@@ -387,6 +340,7 @@ void ConfigFile::_bind_methods() {
         &ConfigFile::_get_section_keys
     );
 
+    ClassDB::bind_method(D_METHOD("clear"), &ConfigFile::clear);
     ClassDB::bind_method(
         D_METHOD("erase_section", "section"),
         &ConfigFile::erase_section
@@ -396,27 +350,48 @@ void ConfigFile::_bind_methods() {
         &ConfigFile::erase_section_key
     );
 
-    ClassDB::bind_method(D_METHOD("load", "path"), &ConfigFile::load);
     ClassDB::bind_method(D_METHOD("parse", "data"), &ConfigFile::parse);
-    ClassDB::bind_method(D_METHOD("save", "path"), &ConfigFile::save);
-
-    ClassDB::bind_method(
-        D_METHOD("load_encrypted", "path", "key"),
-        &ConfigFile::load_encrypted
-    );
+    ClassDB::bind_method(D_METHOD("load", "path"), &ConfigFile::load);
     ClassDB::bind_method(
         D_METHOD("load_encrypted_pass", "path", "password"),
         &ConfigFile::load_encrypted_pass
     );
-
     ClassDB::bind_method(
-        D_METHOD("save_encrypted", "path", "key"),
-        &ConfigFile::save_encrypted
+        D_METHOD("load_encrypted", "path", "key"),
+        &ConfigFile::load_encrypted
     );
+
+    ClassDB::bind_method(D_METHOD("save", "path"), &ConfigFile::save);
     ClassDB::bind_method(
         D_METHOD("save_encrypted_pass", "path", "password"),
         &ConfigFile::save_encrypted_pass
     );
+    ClassDB::bind_method(
+        D_METHOD("save_encrypted", "path", "key"),
+        &ConfigFile::save_encrypted
+    );
+}
 
-    ClassDB::bind_method(D_METHOD("clear"), &ConfigFile::clear);
+PoolStringArray ConfigFile::_get_sections() const {
+    List<String> sections;
+    get_sections(&sections);
+    PoolStringArray result;
+    result.resize(sections.size());
+    int idx = 0;
+    for (auto section = sections.front(); section; section = section->next()) {
+        result.set(idx++, section->get());
+    }
+    return result;
+}
+
+PoolStringArray ConfigFile::_get_section_keys(const String& section) const {
+    List<String> keys;
+    get_section_keys(section, &keys);
+    PoolStringArray result;
+    result.resize(keys.size());
+    int idx = 0;
+    for (auto key = keys.front(); key; key = key->next()) {
+        result.set(idx++, key->get());
+    }
+    return result;
 }

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -8,57 +8,62 @@
 #define CONFIG_FILE_H
 
 #include "core/ordered_hash_map.h"
-#include "core/os/file_access.h"
 #include "core/reference.h"
-#include "core/variant_parser.h"
+
+template <class T, class A>
+class List;
+template <class T>
+class PoolVector;
+class String;
+class Variant;
+template <class T>
+class Vector;
+
+enum Error;
+
+typedef PoolVector<String> PoolStringArray;
 
 class ConfigFile : public Reference {
     GDCLASS(ConfigFile, Reference);
 
-    OrderedHashMap<String, OrderedHashMap<String, Variant>> values;
-
-    PoolStringArray _get_sections() const;
-    PoolStringArray _get_section_keys(const String& p_section) const;
-    Error _internal_load(const String& p_path, FileAccess* f);
-    Error _internal_save(FileAccess* file);
-
-    Error _parse(const String& p_path, VariantParser::Stream* p_stream);
-
-protected:
-    static void _bind_methods();
-
 public:
-    void set_value(
-        const String& p_section,
-        const String& p_key,
-        const Variant& p_value
-    );
     Variant get_value(
-        const String& p_section,
-        const String& p_key,
-        Variant p_default = Variant()
+        const String& section,
+        const String& key,
+        Variant default_value = Variant()
     ) const;
+    void set_value(
+        const String& section,
+        const String& key,
+        const Variant& value
+    );
 
-    bool has_section(const String& p_section) const;
-    bool has_section_key(const String& p_section, const String& p_key) const;
+    bool has_section(const String& section) const;
+    bool has_section_key(const String& section, const String& key) const;
 
-    void get_sections(List<String>* r_sections) const;
-    void get_section_keys(const String& p_section, List<String>* r_keys) const;
-
-    void erase_section(const String& p_section);
-    void erase_section_key(const String& p_section, const String& p_key);
-
-    Error save(const String& p_path);
-    Error load(const String& p_path);
-    Error parse(const String& p_data);
+    void get_sections(List<String>* sections) const;
+    void get_section_keys(const String& section, List<String>* keys) const;
 
     void clear();
+    void erase_section(const String& section);
+    void erase_section_key(const String& section, const String& key);
 
-    Error load_encrypted(const String& p_path, const Vector<uint8_t>& p_key);
-    Error load_encrypted_pass(const String& p_path, const String& p_pass);
+    Error parse(const String& data);
+    Error load(const String& path);
+    Error load_encrypted_pass(const String& path, const String& pass);
+    Error load_encrypted(const String& path, const Vector<uint8_t>& key);
 
-    Error save_encrypted(const String& p_path, const Vector<uint8_t>& p_key);
-    Error save_encrypted_pass(const String& p_path, const String& p_pass);
+    Error save(const String& path) const;
+    Error save_encrypted_pass(const String& path, const String& password) const;
+    Error save_encrypted(const String& path, const Vector<uint8_t>& key) const;
+
+private:
+    static void _bind_methods();
+
+    PoolStringArray _get_sections() const;
+    PoolStringArray _get_section_keys(const String& section) const;
+
+    OrderedHashMap<String, OrderedHashMap<String, Variant>> values;
 };
 
 #endif // CONFIG_FILE_H

--- a/docs/ConfigFile.xml
+++ b/docs/ConfigFile.xml
@@ -152,7 +152,7 @@ SPDX-License-Identifier: MIT
                 Returns one of the [enum Error] code constants ([code]OK[/code] on success).
             </description>
         </method>
-        <method name="save">
+        <method name="save" qualifiers="const">
             <return type="int" enum="Error" />
             <argument index="0" name="path" type="String" />
             <description>
@@ -160,7 +160,7 @@ SPDX-License-Identifier: MIT
                 Returns one of the [enum Error] code constants ([code]OK[/code] on success).
             </description>
         </method>
-        <method name="save_encrypted">
+        <method name="save_encrypted" qualifiers="const">
             <return type="int" enum="Error" />
             <argument index="0" name="path" type="String" />
             <argument index="1" name="key" type="PoolByteArray" />
@@ -169,7 +169,7 @@ SPDX-License-Identifier: MIT
                 Returns one of the [enum Error] code constants ([code]OK[/code] on success).
             </description>
         </method>
-        <method name="save_encrypted_pass">
+        <method name="save_encrypted_pass" qualifiers="const">
             <return type="int" enum="Error" />
             <argument index="0" name="path" type="String" />
             <argument index="1" name="password" type="String" />

--- a/platforms/android/export/android_plugin_config.cpp
+++ b/platforms/android/export/android_plugin_config.cpp
@@ -6,6 +6,8 @@
 
 #include "android_plugin_config.h"
 
+#include "core/os/file_access.h"
+
 const char* AndroidPluginConfig::PLUGIN_CONFIG_EXT = ".gdap";
 
 const char* AndroidPluginConfig::CONFIG_SECTION         = "config";


### PR DESCRIPTION
This PR refactors `[ConfigFile](https://docs.rebeltoolbox.com/en/latest/api/class_configfile.html)` which includes:
- Addressing four memory leaks:
When loading or saving encrypted files, the `_internal_save()` and `_internal_load()` methods do not delete the `FileAccess` object `f`.https://github.com/RebelToolbox/RebelEngine/blob/35a733d1cf3b3d9218fdef1cd286442eb904c94b/core/io/config_file.cpp#L179-L184
- Making methods that create heap objects responsible for deleting them.
- Making the `save` methods `const`.
- Removing duplicate code.
- Hiding implementation details by moving `private` methods to an anonymous `namespace` in the definition file.
- Minimising the size of the header file by using forward declares instead of `include`s.

This should make `ConfigFile` easier to troubleshoot and maintain, while applying good coding practices and improving compile times.
