### PR TITLE
Update .gitignore to exclude all Android build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ logs/
 # Gradle generated
 .gradle/
 local.properties
-platforms/android/project/*/build/
+platforms/android/project/**/build/
 platforms/android/project/*/.cxx/
 platforms/android/project/*/libs/
 platforms/android/project/**/jniLibs/


### PR DESCRIPTION
The new version of Gradle places its build reports in the Android project root directory. All build files (including the build system's build reports) should be excluded from the repository.

This PR updates `.gitignore` to exclude all the Android project `build` directories (not just the modules' build directories).