### PR TITLE
Assign properties using the 'propName = value'  syntax

### DIFF
--- a/platforms/android/project/app/build.gradle
+++ b/platforms/android/project/app/build.gradle
@@ -45,8 +45,8 @@ configurations.implementation {
 }
 
 android {
-    namespace 'com.rebeltoolbox.rebelapp'
-    compileSdk versions.compileSdk
+    namespace = 'com.rebeltoolbox.rebelapp'
+    compileSdk = versions.compileSdk
 
     compileOptions {
         sourceCompatibility versions.javaVersion
@@ -63,7 +63,7 @@ android {
         // The default ignore pattern for the 'assets' directory includes
         // hidden files and directories that are used by Rebel projects.
         aaptOptions {
-            ignoreAssetsPattern "!.svn:!.git:!.gitignore:!.ds_store:!*.scc:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"
+            ignoreAssetsPattern = "!.svn:!.git:!.gitignore:!.ds_store:!*.scc:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"
         }
 
         ndk {
@@ -75,14 +75,14 @@ android {
 
         manifestPlaceholders.editorVersion = stringProperty("editor_version", buildVersion())
 
-        applicationId stringProperty("export_package_name", "com.rebeltoolbox.rebelapp")
-        versionName stringProperty("export_version_name", "1.0")
-        versionCode integerProperty("export_version_code", 1)
-        minSdk integerProperty("export_version_min_sdk", versions.minSdk)
-        targetSdk integerProperty("export_version_target_sdk", versions.targetSdk)
+        applicationId = stringProperty("export_package_name", "com.rebeltoolbox.rebelapp")
+        versionName = stringProperty("export_version_name", "1.0")
+        versionCode = integerProperty("export_version_code", 1)
+        minSdk = integerProperty("export_version_min_sdk", versions.minSdk)
+        targetSdk = integerProperty("export_version_target_sdk", versions.targetSdk)
     }
 
-    ndkVersion versions.ndkVersion
+    ndkVersion = versions.ndkVersion
 
     packagingOptions {
         resources {
@@ -120,19 +120,19 @@ android {
 
     buildTypes {
         debug {
-            signingConfig project.hasProperty("perform_signing")
+            signingConfig = project.hasProperty("perform_signing")
                 ? signingConfigs.debug
                 : null
         }
         release {
-            signingConfig project.hasProperty("perform_signing")
+            signingConfig = project.hasProperty("perform_signing")
                 ? signingConfigs.release
                 : null
         }
     }
 
     lint {
-        abortOnError false
+        abortOnError = false
         disable 'MissingTranslation', 'UnusedResources'
     }
 

--- a/platforms/android/project/build.gradle
+++ b/platforms/android/project/build.gradle
@@ -24,22 +24,22 @@ def templateBuildTasks = {
 }
 
 tasks.register('createAndroidTemplates') {
-    group "Rebel"
-    description "Creates the Rebel Engine Android templates for each previously built build type and architecture."
+    group = "Rebel"
+    description = "Creates the Rebel Engine Android templates for each previously built build type and architecture."
     dependsOn templateBuildTasks
     finalizedBy 'createCustomBuildTemplate'
 }
 
 tasks.register('createDevelopmentAndroidTemplates') {
-    group "Rebel"
-    description "Creates development Android templates for each previously built build type and architecture."
+    group = "Rebel"
+    description = "Creates development Android templates for each previously built build type and architecture."
     gradle.startParameter.projectProperties += [doNotStrip: true]
     finalizedBy 'createAndrdoidTempates'
 }
 
 tasks.register('cleanAndroidTemplates', Delete) {
-    group "Rebel"
-    description "Cleans and deletes all the Rebel Engine Android libraries and templates."
+    group = "Rebel"
+    description = "Cleans and deletes all the Rebel Engine Android libraries and templates."
     delete "app/libs"
     delete "app/src/debug"
     delete "app/src/release"

--- a/platforms/android/project/engine/build.gradle
+++ b/platforms/android/project/engine/build.gradle
@@ -16,13 +16,13 @@ configurations.implementation {
 }
 
 android {
-    namespace 'com.rebeltoolbox.rebelengine'
-    compileSdk versions.compileSdk
-    ndkVersion versions.ndkVersion
+    namespace = 'com.rebeltoolbox.rebelengine'
+    compileSdk = versions.compileSdk
+    ndkVersion = versions.ndkVersion
 
     defaultConfig {
-        minSdk versions.minSdk
-        targetSdk versions.targetSdk
+        minSdk = versions.minSdk
+        targetSdk = versions.targetSdk
         manifestPlaceholders.libraryVersion = buildVersion()
     }
 
@@ -41,13 +41,13 @@ android {
     }
 
     lint {
-        abortOnError false
+        abortOnError = false
         disable 'MissingTranslation', 'UnusedResources'
     }
 
     buildFeatures {
-        aidl true
-        buildConfig true
+        aidl = true
+        buildConfig = true
     }
 
     // Provides access to the Rebel source files.


### PR DESCRIPTION
With the new version of Gradle we get the following warning:
```
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated.
This is scheduled to be removed in Gradle 10.0.

Solutions: Use assignment ('namespace = <value>') instead.
```
This PR updates the Android Gradle build files to use the 'propName = value'  syntax.