### PR TITLE
Update link to Rebel Documentation

### DIFF
--- a/docs/JNISingleton.xml
+++ b/docs/JNISingleton.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: MIT
         The JNISingleton is implemented only in the Android export. It's used to call methods and connect signals from an Android plugin written in Java or Kotlin. Methods and signals can be called and connected to the JNISingleton as if it is a Node. See [url=https://en.wikipedia.org/wiki/Java_Native_Interface]Java Native Interface - Wikipedia[/url] for more information.
     </description>
     <tutorials>
-        <link title="Creating Android plugins">https://docs.rebeltoolbox.com/en/latest/tutorials/platform/android/android_plugin.html</link>
+        <link title="Creating Android plugins">https://docs.rebeltoolbox.com/en/latest/tutorials/platforms/android/android_plugin.html</link>
     </tutorials>
     <methods>
     </methods>


### PR DESCRIPTION
Following RebelToolbox/RebelDocumentation#73, this PR updates the API documentation link to the Rebel Documentation.