### PR TITLE
Don't create a Config File section heading, if the section name is blank

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -93,7 +93,9 @@ void save_file_access(
         if (section != values.front()) {
             file->store_string("\n");
         }
-        file->store_string(vformat("[%s]\n\n", section.key()));
+        if (!section.key().empty()) {
+            file->store_string(vformat("[%s]\n\n", section.key()));
+        }
 
         for (auto key = section.get().front(); key; key = key.next()) {
             String value;


### PR DESCRIPTION
Currently, when writing a [`ConfigFile`](https://docs.rebeltoolbox.com/en/latest/api/class_configfile.html) if the section heading is blank, it creates an empty section heading. However, the expected output is to create key-value pairs without a section. In other words, instead of saving the file like this:
```
[]

version=3

[player]

name="Steve"
best_score=200
```
The file should be saved like this:
```
version=3

[player]

name="Steve"
best_score=200
```
This PR ensures that a section heading is not created if the section name is blank.

**Note:** This change does not impact how data is loaded or managed. The data is still loaded, accessed and changed using a blank section heading. It only changes how the data looks when it is stored in the file.
