### PR TITLE
Drop the file: scheme when defining the export path

### DIFF
--- a/platforms/android/export/export_plugin.cpp
+++ b/platforms/android/export/export_plugin.cpp
@@ -3920,7 +3920,7 @@ Error EditorExportPlatformAndroid::export_project_helper(
                           ->globalize_path(export_path)
                           .simplify_path();
 
-        copy_args.push_back("-Pexport_path=file:" + export_path);
+        copy_args.push_back("-Pexport_path=" + export_path);
         copy_args.push_back("-Pexport_filename=" + export_filename);
 
         print_verbose(


### PR DESCRIPTION
We're getting the following warning message when exporting for Android:
```
Passing invalid URIs to URI or File converting methods. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Use a valid URL or a file path instead of 'file:/path/with spaces/'. Consult the upgrading guide for further information:
https://docs.gradle.org/8.13/userguide/upgrading_version_8.html#deprecated_invalid_url_decoding

If the file path has spaces or other reserved characters, a file URI needs to be properly encoded to be valid. However, we can avoid the complexity of creating a valid URI by just passing the file path.

This PR drops the file URI scheme and simply passes the file path.

References:
[1] https://docs.gradle.org/8.13/userguide/upgrading_version_8.html#deprecated_invalid_url_decoding
[2] https://en.wikipedia.org/wiki/File_URI_scheme
[3] https://en.wikipedia.org/wiki/Percent-encoding