### PR TITLE
Don't disable pie when linking

### DIFF
--- a/platforms/linux/detect.py
+++ b/platforms/linux/detect.py
@@ -234,18 +234,6 @@ def configure(env):
     env.Append(CCFLAGS=["-pipe"])
     env.Append(LINKFLAGS=["-pipe"])
 
-    # Check for gcc version >= 6 before adding -no-pie
-    version = get_compiler_version(env) or [-1, -1]
-    if using_gcc(env):
-        if version[0] >= 6:
-            env.Append(CCFLAGS=["-fpie"])
-            env.Append(LINKFLAGS=["-no-pie"])
-    # Do the same for clang should be fine with Clang 4 and higher
-    if using_clang(env):
-        if version[0] >= 4:
-            env.Append(CCFLAGS=["-fpie"])
-            env.Append(LINKFLAGS=["-no-pie"])
-
     ## Dependencies
 
     env.ParseConfig("pkg-config x11 --cflags --libs")


### PR DESCRIPTION
Currently, on Linux builds, [PIE](https://en.wikipedia.org/wiki/Position-independent_code#Position-independent_executables) is disabled in the linker. PIE was disabled to work around some GUI file managers identifying PIE executables as a shared library. 

There is currently no good reason for Rebel to disable PIE; so this PR removes the build instructions to disable it.