### PR TITLE
Fix test logs artifact filename

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -127,7 +127,7 @@ jobs:
         if: ${{ matrix.test }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}-test-logs
+          name: ${{ matrix.cache-name }}-test-logs
           path: |
             editor.log
             project.log


### PR DESCRIPTION
#202 uploads the Linux builds' tests' log files; so failures can be reviewed manually. However, the name of the artifact being uploaded is currently `false-test-logs` not `<build-name>-test-logs`.

`${{ matrix.artifact }}` is a boolean variable set to specify whether or not the build file created is uploaded as an artifact, not the name of the artifact to be uploaded. Currently, `${{ matrix.cache-name }} is the variable used to specify the name of the artifact to be uploaded.

This PR changes the name of the log files artifact to ${{ matrix.cache-name }} to match the name of the build artifacts that are uploaded.