### PR TITLE
Link libgcc and libstdc++ statically only on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -424,7 +424,6 @@ if selected_platform in platform_list:
         env["warnings"] = ARGUMENTS.get("warnings", "extra")
         env["werror"] = methods.get_cmdline_bool("werror", True)
     if env["production"]:
-        env["use_static_cpp"] = methods.get_cmdline_bool("use_static_cpp", True)
         env["use_lto"] = methods.get_cmdline_bool("use_lto", True)
         print("use_lto is: " + str(env["use_lto"]))
         env["debug_symbols"] = methods.get_cmdline_bool("debug_symbols", False)

--- a/platforms/linux/detect.py
+++ b/platforms/linux/detect.py
@@ -68,11 +68,6 @@ def get_opts():
         BoolVariable("use_lld", "Use the LLD linker", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
         BoolVariable(
-            "use_static_cpp",
-            "Link libgcc and libstdc++ statically for better portability",
-            True,
-        ),
-        BoolVariable(
             "use_ubsan",
             "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)",
             False,
@@ -451,12 +446,5 @@ def configure(env):
         env.Append(CCFLAGS=["-m64"])
         env.Append(LINKFLAGS=["-m64", "-L/usr/lib/i686-linux-gnu"])
 
-    # Link those statically for portability
-    if env["use_static_cpp"]:
-        env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
-        if env["use_llvm"] and platform.system() != "FreeBSD":
-            env["LINKCOM"] = env["LINKCOM"] + " -l:libatomic.a"
-
-    else:
-        if env["use_llvm"] and platform.system() != "FreeBSD":
-            env.Append(LIBS=["atomic"])
+    if env["use_llvm"] and platform.system() != "FreeBSD":
+        env.Append(LIBS=["atomic"])

--- a/platforms/server/detect.py
+++ b/platforms/server/detect.py
@@ -33,11 +33,6 @@ def get_opts():
     return [
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable(
-            "use_static_cpp",
-            "Link libgcc and libstdc++ statically for better portability",
-            True,
-        ),
-        BoolVariable(
             "use_ubsan",
             "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)",
             False,
@@ -304,12 +299,6 @@ def configure(env):
     if env["execinfo"]:
         env.Append(LIBS=["execinfo"])
 
-    if platform.system() != "Darwin":
-        # Link those statically for portability
-        if env["use_static_cpp"]:
-            env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
-            if env["use_llvm"] and platform.system() != "FreeBSD":
-                env["LINKCOM"] = env["LINKCOM"] + " -l:libatomic.a"
-        else:
-            if env["use_llvm"] and platform.system() != "FreeBSD":
-                env.Append(LIBS=["atomic"])
+    if platform.system() != "Darwin" and platform.system() != "FreeBSD":
+        if env["use_llvm"]:
+            env.Append(LIBS=["atomic"])

--- a/platforms/windows/detect.py
+++ b/platforms/windows/detect.py
@@ -82,7 +82,7 @@ def get_opts():
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
         BoolVariable(
-            "use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True
+            "use_static_cpp", "Link MSVC C++ runtime libraries statically", True
         ),
         BoolVariable("use_asan", "Use address sanitizer (ASAN)", False),
     ]
@@ -394,14 +394,7 @@ def configure_mingw(env):
         else:  # default to 64-bit on Linux
             env["bits"] = "64"
 
-    if env["bits"] == "32":
-        if env["use_static_cpp"]:
-            env.Append(LINKFLAGS=["-static"])
-            env.Append(LINKFLAGS=["-static-libgcc"])
-            env.Append(LINKFLAGS=["-static-libstdc++"])
-    else:
-        if env["use_static_cpp"]:
-            env.Append(LINKFLAGS=["-static"])
+    env.Append(LINKFLAGS=["-static"])
 
     env["x86_libtheora_opt_gcc"] = True
 


### PR DESCRIPTION
Currently, [`libgcc`](https://gcc.gnu.org/onlinedocs/gccint/Libgcc.html) and [`libstdc++`](https://gcc.gnu.org/onlinedocs/libstdc++/) are linked statically by default.

An application needs access to all the libraries is uses. Libraries are linked to an application either statically or dynamically. Libraries that are linked statically are included in the application; making it bigger. Libraries are linked statically; so they don't need to be distributed with the application or found locally when running the application. When a local version of the library is used, if the version used to link the application is different from the version found locally, the application may fail. Some libraries are backwards compatible. If an application is built to depend on an older version of the library, it will still work if a newer version of the library is found. Operating systems include many libraries that applications can expect to find locally. 

Libraries can and do depend on other libraries; so there can be multiple dependencies on a single library. If an application and its libraries have multiple dependencies on another library, the application and its libraries must all use the same version of the library they depend on. To avoid the application or its libraries using a version that is linked statically being different from the version that is found locally, the application and all its libraries must be either statically linked to all libraries with multiple dependencies or they must all use the version found locally.

Linking `libgcc` and `libstdc++` statically allows applications that depend on these libraries to run on systems that do not have these libraries installed, or that have different, incompatible versions of these libraries than were used to link the application. However, it is highly unlikely that `libgcc` and `libstdc++` will not be installed with a Linux distro, because many applications depend on them. Furthermore, all current versions of `libgcc` and `libstdc++` are backwards compatible; so an application that is linked with an older version of these libraries will work on systems that have newer versions of these libraries. To maximise compatibility, applications are linked against the oldest available version of these libraries that support the needs of the libraries and application. Unless there is a good reason not to, on Linux, it is best to use the local versions of libraries. There is currently no need to link `libgcc` and `libstdc++` statically on Linux; especially when the application depends on other libraries that it expects to find locally too.

When compiling and linking for Windows using [MSVC](https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B), applications do not use `libgcc` or `libstdc++` (they use [Microsoft's C++ Standard Library](https://github.com/microsoft/STL)). When compiling for Windows using [`Mingw-w64`](https://www.mingw-w64.org/), `libgcc` or `libstdc++` are used. On Windows, `libgcc` and `libstdc++` are not available locally; so they would need to be distributed with the application or linked statically. Windows runtime libraries are not backwards compatible. Applications need to either ensure that the required libraries are installed beforehand, distributed with the applications or link the required libraries statically.

On Linux, Rebel Engine depends on various system libraries (in addition to `libgcc` and `libstdc++`). As noted in #165, release versions of Rebel Engine are linked against older versions of these libraries to ensure that it can run on most if not all current Linux distros. Rebel Engine is distributed as a single executable. All third-party libraries are compiled with Rebel Engine and linked together; so any shared dependencies on system libraries will be linked the same way. Therefore, there is currently no benefit to linking `libgcc` and `libstdc++` statically on Linux.

On Windows, when compiling using `mingw-w64`, to avoid requiring `libgcc` and `libstdc++` be distributed with the Rebel Engine executable, `libgcc` and `libstdc++` need to be linked statically. Furthermore, regardless of the toolchain used, to avoid the need for a specific runtime library to be installed beforehand or distributed with the executable, Rebel Engine links all libraries statically on Windows by default.

This PR removes the option of choosing whether or not to link `libgcc` or `libstdc++` statically. On Linux, `libgcc` or `libstdc++` are linked dynamically and depend on an the version installed with the operating system and used and shared by other libraries and applications. On Windows, when using `mingw-w64`, `libgcc` or `libstdc++` are linked statically. When using MSVC, there is no dependency on `libgcc` or `libstdc++`. When using MSVC, the option of whether or not to link the runtime library statically is kept, but the default is to link all libraries statically.
