### PR TITLE
Convert project key with C::: to C:/

### DIFF
--- a/projects_manager/projects_list_item.cpp
+++ b/projects_manager/projects_list_item.cpp
@@ -157,7 +157,8 @@ void ProjectsListItem::_configure_item() {
 }
 
 void ProjectsListItem::_extract_project_values() {
-    project_folder = project_key.replace("::", "/");
+    project_folder = project_key.replace(":::", ":/");
+    project_folder = project_folder.replace("::", "/");
 
     Ref<ConfigFile> settings_file = memnew(ConfigFile);
     String settings_file_name     = project_folder.plus_file("project.rebel");


### PR DESCRIPTION
Currently, on Windows, Projects Manager is failing to find projects' settings files.

When converting the project key to the path with the settings file, `::` is converted to `/`. However, on Windows the path begins with the drive letter followed by a colon e.g. `C:` and the project key will have a triple colon e.g. `C:::`. Currently, the project key with `C:::` is converted to `C/:` instead of `C:/`.

This PR ensures that triple colons `:::` are correctly converted to `:/`.