### PR TITLE
Exclude dependabot bot from the list of authors

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,6 +1,7 @@
 changelog:
   exclude:
     authors:
+      - dependabot
       - github-actions
   categories:
     - title: Exciting New Features ✨


### PR DESCRIPTION
Currently, in the [release notes](https://github.com/RebelToolbox/RebelEngine/releases/), @dependabot is included in the list of contributors.

This PR adds @dependabot to the list of authors to be excluded from the release notes.