### PR TITLE
Use POSIX standard shell compliant scripts for pre-commit scripts

### DIFF
--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -48,9 +48,9 @@ Python style checks to all Python and SCons files.
 ## `pre-commit-style-check`
 
 To standardise the style checks,
-both `pre-commit-clang-format` and `pre-commit-black` call `pre-commit-style-check`.
-
-`pre-commit-style-check` takes six optional parameters:
+both `pre-commit-clang-format` and `pre-commit-black` call `pre-commit-style-check` using [`.`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#dot).
+`.` is used to make the caller's variables available in `pre-commit-style-check`.
+`pre-commit-style-check` uses six variables:
 - `application_name`: The style check application to run.
 - `options`: The options passed to the style check application.
 - `include_files`: A list of specific filenames to be included.

--- a/tools/hooks/pre-commit-black
+++ b/tools/hooks/pre-commit-black
@@ -1,9 +1,8 @@
-#!/usr/bin/env bash
-
-# git pre-commit hook that runs a black Python style check.
+#!/bin/sh
+# Git pre-commit hook that runs a black Python style check.
 
 # The application and options.
-application="black"
+application_name="black"
 options=""
 
 # Files and file extensions to parse.
@@ -13,10 +12,11 @@ include_extensions=".py"
 # Directories to ignore.
 exclude_directories="thirdparty"
 
-. "$(dirname -- "$0")/pre-commit-style-check" \
-    "$application"                            \
-    "$options"                                \
-    "$include_files"                          \
-    "$include_extensions"                     \
-    "$exclude_directories"                    \
-    "$exclude_file_patterns"                  \
+# `pre-commit-style-check` uses six variables:
+# `application_name`: The style check application to run.
+# `options`: The options passed to the style check application.
+# `include_files`: A list of specific filenames to be included.
+# `include_extensions`: A list of filename extensions to be included.
+# `exclude_directories`: A list of directories to be excluded.
+# `exclude_file_patterns`: A list of file patterns to be exclued.
+. "$(dirname -- "$0")/pre-commit-style-check"

--- a/tools/hooks/pre-commit-clang-format
+++ b/tools/hooks/pre-commit-clang-format
@@ -1,9 +1,8 @@
-#!/usr/bin/env bash
-
-# git pre-commit hook that runs a clang-format style check.
+#!/bin/sh
+# Git pre-commit hook that runs a clang-format style check.
 
 # The application and options.
-application="clang-format"
+application_name="clang-format"
 options="--Wno-error=unknown"
 
 # File extensions to parse.
@@ -25,29 +24,30 @@ recommended_clang_format_major_version="17"
 clang_format_version="$(clang-format --version | sed "s/[^0-9\.]*\([0-9\.]*\).*/\1/")"
 clang_format_major_version="$(echo "$clang_format_version" | cut -d. -f1)"
 
-if [[ "$clang_format_major_version" -lt "$required_clang_format_major_version" ]]; then
+if [ "$clang_format_major_version" -lt "$required_clang_format_major_version" ]; then
     echo "Error: Your version of clang-format is $clang_format_version."
     echo "The minimum required version of clang-format is $required_clang_format_major_version."
     echo "Please upgrade clang-format to ensure formatting is applied correctly."
     exit 1
 fi
 
-if [[ "$clang_format_major_version" -lt "$recommended_clang_format_major_version" ]]; then
+if [ "$clang_format_major_version" -lt "$recommended_clang_format_major_version" ]; then
     echo "Warning: Your version of clang-format is $clang_format_version."
     echo "The recommended version of clang-format is $recommended_clang_format_major_version."
     echo "Consider upgrading clang-format as formatting may not be applied correctly."
 fi
 
-if [[ "$clang_format_major_version" -gt "$recommended_clang_format_major_version" ]]; then
+if [ "$clang_format_major_version" -gt "$recommended_clang_format_major_version" ]; then
     echo "Warning: Your version of clang-format is $clang_format_version."
     echo "The maximum tested version of clang-format is $recommended_clang_format_major_version."
     echo "Consider downgrading clang-format as formatting may not be applied correctly."
 fi
 
-. "$(dirname -- "$0")/pre-commit-style-check" \
-    "$application"                            \
-    "$options"                                \
-    "$include_files"                          \
-    "$include_extensions"                     \
-    "$exclude_directories"                    \
-    "$exclude_file_patterns"                  \
+# `pre-commit-style-check` uses six variables:
+# `application_name`: The style check application to run.
+# `options`: The options passed to the style check application.
+# `include_files`: A list of specific filenames to be included.
+# `include_extensions`: A list of filename extensions to be included.
+# `exclude_directories`: A list of directories to be excluded.
+# `exclude_file_patterns`: A list of file patterns to be exclued.
+. "$(dirname -- "$0")/pre-commit-style-check"

--- a/tools/hooks/pre-commit-documentation-checks
+++ b/tools/hooks/pre-commit-documentation-checks
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-
+#!/bin/sh
 # Git pre-commit hook that checks the API XML documentation spelling and syntax.
 
 # Set exit on error.

--- a/tools/hooks/pre-commit-style-check
+++ b/tools/hooks/pre-commit-style-check
@@ -1,23 +1,22 @@
-#!/usr/bin/env bash
-
+#!/bin/sh
 # Runs an application style check.
 # Features:
 #  - Aborts commit when the commit does not comply with the style guidelines.
 #  - Creates a patch with the proposed style changes.
-
-application_name="$1"
-options="$2"
-include_files="$3"
-include_extensions="$4"
-exclude_directories="$5"
-exclude_file_patterns="$6"
+# Uses six variables:
+# `application_name`: The style check application to run.
+# `options`: The options passed to the style check application.
+# `include_files`: A list of specific filenames to be included.
+# `include_extensions`: A list of filename extensions to be included.
+# `exclude_directories`: A list of directories to be excluded.
+# `exclude_file_patterns`: A list of file patterns to be exclued.
 
 # Get full paths to applications.
-application=$(which "$application_name" 2>/dev/null)
-zenity=$(which zenity 2>/dev/null)
-xmessage=$(which xmessage 2>/dev/null)
-powershell=$(which powershell 2>/dev/null)
-pygmentize=$(which pygmentize 2>/dev/null)
+application=$(command -v "$application_name" 2>/dev/null)
+zenity=$(command -v zenity 2>/dev/null)
+xmessage=$(command -v xmessage 2>/dev/null)
+powershell=$(command -v powershell 2>/dev/null)
+pygmentize=$(command -v pygmentize 2>/dev/null)
 
 # Set exit on error.
 set -e
@@ -42,24 +41,26 @@ include_file() {
 
     # Exclude files in exclude_directories.
     for exclude_directory in $exclude_directories; do
-        [[ "$directory" = $exclude_directory* ]] && return 1
+        case $directory in $exclude_directory*)
+            return 1;;
+        esac
     done
 
     # Exclude files which match exclude_file_patterns.
     for exclude_file_pattern in $exclude_file_patterns; do
-        if grep -q "$exclude_file_pattern" <<< "$filename"; then
-            return 1
-        fi
+        case $filename in *$exclude_file_pattern*)
+            return 1;;
+        esac
     done
 
     # Include files that match include_files.
     for include_file in $include_files; do
-        [[ "$include_file" = "$filename" ]] && return 0
+        [ "$include_file" = "$filename" ] && return 0
     done
 
     # Include extensions that match include_extensions.
     for include_extension in $include_extensions; do
-        [[ "$include_extension" = "$extension" ]] && return 0
+        [ "$include_extension" = "$extension" ] && return 0
     done
     return 1
 }


### PR DESCRIPTION
[Our Git pre-commit hooks](https://github.com/RebelToolbox/RebelEngine/tree/main/tools/hooks) are not working in Visual Studio.

Our [Git hooks](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks) scripts currently require the [`bash`](https://www.gnu.org/software/bash/) shell to run. Although `bash` is available on most GNU/Linux systems, it's not a requirement. More importantly, on Windows, [Visual Studio](https://en.wikipedia.org/wiki/Visual_Studio)'s [Git tools](https://learn.microsoft.com/en-us/visualstudio/version-control/git-with-visual-studio?view=vs-2022) do not support `bash`.

To maximise Rebel's cross-platform compatibility, our `pre-commit` scripts should be [POSIX](https://en.wikipedia.org/wiki/POSIX) compliant and run on any [POSIX compliant shell](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html). 

This PR converts our `pre-commit` hooks to run on any POSIX compliant shell including the one used by Visual Studio. This includes:
- Using the POSIX standard  `#!/bin/sh` [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) instead of `#!/usr/bin/env bash`
- Using the [`command -v`](https://www.man7.org/linux/man-pages/man1/command.1p.html) shell command to determine if an application is installed instead of the Linux [`which`](https://linux.die.net/man/1/which) application, which itself may not be installed.
- Using the POSIX compliant condition tests: single `[` `]` instead of `bash`'s extended double `[[` `]]`
- Relying on the `.` (dot) command to transfer variables; not command line parameters
- Using `case` instead of the [`grep`](https://en.wikipedia.org/wiki/Grep) application with a `bash` [here string](https://en.wikipedia.org/wiki/Here_document#Here_strings) to check for substrings.