### PR TITLE
Update hooks README.md to include codespell

### DIFF
--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -6,9 +6,10 @@ These hooks help Rebel Engine contributors comply with the Rebel Engine style gu
 ## Installation
 
 Ensure that
-[`clang-format`](https://clang.llvm.org/docs/ClangFormat.html)
-and
+[`clang-format`](https://clang.llvm.org/docs/ClangFormat.html),
 [`black`](https://pypi.org/project/black/)
+and
+[`codespell`](https://pypi.org/project/codespell/)
 are installed and available in the system `path`.
 Copy all the files from this folder into your `.git/hooks` folder.
 Confirm that all the scripts are executable.
@@ -42,8 +43,10 @@ Python style checks to all Python and SCons files.
 
 ## `pre-commit-documentation-checks`
 
-`pre-commit-make-documentation-checks` checks the API XML documentation syntax.
-`pre-commit-make-documentation-checks` performs a dry run of `tools/scripts/rst_from_xml.py`.
+`pre-commit-make-documentation-checks` runs
+[`codespell`](https://pypi.org/project/codespell/)
+on all documentaton files.
+It then performs a dry run of `tools/scripts/rst_from_xml.py`.
 
 ## `pre-commit-style-check`
 


### PR DESCRIPTION
The [Git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) provided in the [`/tools/hooks`](https://github.com/RebelToolbox/RebelEngine/tree/main/tools/hooks) folder use [`codespell`](https://pypi.org/project/codespell/) to check the spelling in the Rebel API documentation files. It is required to be installed and available, but `codespell` is not mentioned in the [`README.md`](https://github.com/RebelToolbox/RebelEngine/blob/main/tools/hooks/README.md) file.

This PR updates the `README.md` file to include the use of `codespell`.