### PR TITLE
Apply official Semantic Versioning to Rebel Engine

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,10 +1,6 @@
 name: Create Release
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version"
-        required: true
   schedule:
     # Create nightly development release every day at midnight.
     - cron: '0 0 * * *'
@@ -12,8 +8,8 @@ on:
 jobs:
   builds:
     name: ${{ matrix.name }}
-    # Don't run on forks.
-    if: github.repository == 'RebelToolbox/RebelEngine'
+    # Don't run nightly scheduled release on forks.
+    if: github.event_name != 'schedule' || github.repository == 'RebelToolbox/RebelEngine'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -192,6 +188,8 @@ jobs:
           artifact: ${{ matrix.artifact }}
           build-options: ${{ matrix.build-options }}
           use-build-cache: false
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
 
   android-templates:
     name: Create Android Templates
@@ -433,22 +431,16 @@ jobs:
       - name: Create version.txt File
         run: |
           #Creating version.txt file.
-          echo "::group::Create extract_version.py."
-          set +H
-          echo "#!/usr/bin/env python3" > extract_version.py
-          echo "import version" >> extract_version.py
-          echo "version_number = str(version.major)" >> extract_version.py
-          echo "version_number += '.' +  str(version.minor)" >> extract_version.py
-          echo "if version.patch != 0:" >> extract_version.py
-          echo "  version_number += '.' + str(version.patch)" >> extract_version.py
-          echo "version_number += '.' + version.status" >> extract_version.py
-          echo "file = open(\"version.txt\", \"w\")" >> extract_version.py
-          echo "file.write(version_number + \"\\n\")" >> extract_version.py
-          echo "file.close()" >> extract_version.py
-          echo "::endgroup::"
-          # Run python script to create version.txt file.
-          chmod +x extract_version.py
-          ./extract_version.py
+          echo > $(python3 -c '
+          import version
+          version_number = str(version.major)
+          version_number += "." + str(version.minor)
+          version_number += "." + str(version.patch)
+          pre_release = version.pre_release if hasattr(version, "pre_release") else None
+          if pre_release:
+              version_number += "-" + pre_release
+          print(version_number)
+          ') > version.txt
 
       - name: Create Zip File
         run: |
@@ -500,14 +492,17 @@ jobs:
 
       - name: Set Version
         run: |
-          # If a development or nightly version, append the date.
-          version=dev
-          if [[ "${{ github.event.inputs.version }}" != "" ]]; then
-            version=${{ github.event.inputs.version }}
-          fi
-          if [[ $version == "dev" ]]; then
-            version=dev-$(date +'%Y-%m-%d')
-          fi
+          #Setting version.
+          version=$(python3 -c '
+          import version
+          version_number = str(version.major)
+          version_number += "." + str(version.minor)
+          version_number += "." + str(version.patch)
+          pre_release = version.pre_release if hasattr(version, "pre_release") else None
+          if pre_release:
+              version_number += "-" + pre_release
+          print(version_number)
+          ')
           echo "version=$version" >> $GITHUB_ENV
 
       - name: Download Artifacts
@@ -543,19 +538,28 @@ jobs:
           name: rebel-${{ env.version }}
           path: release
 
+      - name: Remove previous nightly releases
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Removing previous nightly releases"
+          gh release list | grep "Nightly" | while IFS=$'\t' read title type tag published ; do
+            gh release delete $tag --cleanup-tag
+          done
+
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           #Creating release
-          echo "Removing previous development and nightly releases"
-          gh release list | grep dev | while IFS=$'\t' read title type tag published ; do
-            gh release delete $tag --cleanup-tag
-          done
-          if [[ $version == dev* ]] ; then
-            echo "Creating $(date +'%Y-%m-%d') Nightly"
-            gh release create $version ./release/* --generate-notes --title "Nightly $(date +'%Y-%m-%d')"
+          if [[ ${{ github.event_name }} == "schedule" ]] ; then
+            echo "Creating $version Nightly $(date +'%Y-%m-%d')"
+            gh release create v$version ./release/* --generate-notes --title "Nightly $(date +'%Y-%m-%d')" --prerelease
+          elif [[ $version == *-* ]] ; then
+            echo "Creating Rebel Engine pre-release version $version"
+            gh release create v$version ./release/* --generate-notes --title "Rebel Engine v$version" --prerelease
           else
-            echo "Creating Rebel Engine $version"
-            gh release create $version ./release/* --generate-notes --title "Rebel Engine v$version"
+            echo "Creating Rebel Engine release version $version"
+            gh release create v$version ./release/* --generate-notes --title "Rebel Engine v$version"
           fi

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -453,7 +453,7 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 #ifdef DEBUG_METHODS_ENABLED
 
     uint64_t hash =
-        hash_djb2_one_64(HashMapHasherDefault::hash(VERSION_FULL_CONFIG));
+        hash_djb2_one_64(HashMapHasherDefault::hash(VERSION_FULL_BUILD));
 
     List<StringName> names;
 

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -10,7 +10,6 @@
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 
 void Engine::set_iterations_per_second(int p_ips) {
     ERR_FAIL_COND_MSG(
@@ -69,25 +68,25 @@ void Engine::set_portals_active(bool p_active) {
 
 Dictionary Engine::get_version_info() const {
     Dictionary dict;
-    dict["major"]  = VERSION_MAJOR;
-    dict["minor"]  = VERSION_MINOR;
-    dict["patch"]  = VERSION_PATCH;
-    dict["hex"]    = VERSION_HEX;
-    dict["status"] = VERSION_STATUS;
-    dict["build"]  = VERSION_BUILD;
+    dict["major"] = VERSION_MAJOR;
+    dict["minor"] = VERSION_MINOR;
+    dict["patch"] = VERSION_PATCH;
+#ifdef VERSION_PRE_RELEASE
+    dict["status"] = VERSION_PRE_RELEASE;
+#else  // ! VERSION_PRE_RELEASE
+    dict["status"] = "Release";
+#endif // VERSION_PRE_RELEASE
+    dict["build"]  = VERSION_DATE;
     dict["year"]   = VERSION_YEAR;
-
-    String hash  = VERSION_HASH;
-    dict["hash"] = hash.length() == 0 ? String("unknown") : hash;
-
-    String stringver = String(dict["major"]) + "." + String(dict["minor"]);
-    if ((int)dict["patch"] != 0) {
-        stringver += "." + String(dict["patch"]);
-    }
-    stringver +=
-        "-" + String(dict["status"]) + " (" + String(dict["build"]) + ")";
-    dict["string"] = stringver;
-
+    dict["month"]  = VERSION_MONTH;
+    dict["day"]    = VERSION_DAY;
+    dict["string"] = VERSION_FULL_BUILD;
+#ifdef VERSION_HASH
+    dict["hash"] = VERSION_HASH;
+#else  // ! VERSION_HASH
+    dict["hash"] = String("Unknown");
+#endif // VERSION_HASH
+    dict["hex"] = VERSION_HEX;
     return dict;
 }
 

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -174,8 +174,8 @@ Error HTTPClient::request_raw(
         // Should it add utf8 encoding?
     }
     if (add_uagent) {
-        request += "User-Agent: RebelEngine/" + String(VERSION_FULL_BUILD)
-                 + " (" + OS::get_singleton()->get_name() + ")\r\n";
+        request += "User-Agent: RebelEngine/" + String(VERSION_NUMBER) + " ("
+                 + OS::get_singleton()->get_name() + ")\r\n";
     }
     if (add_accept) {
         request += "Accept: */*\r\n";

--- a/core/version.h
+++ b/core/version.h
@@ -9,22 +9,12 @@
 
 #include "core/version_generated.gen.h"
 
-// Rebel Engine versions are of the form <major>.<minor> for the initial
-// release, and then <major>.<minor>.<patch> for subsequent bugfix releases
-// where <patch> is not 0.
+// Rebel Engine uses Semantic Versioning. See https://semver.org
+// Every major and minor version will have its own branch.
+// Patch versions will be tagged on their major.minor branch.
 
-// Defines the main "branch" version.
-// Patch versions in this branch should be forward-compatible.
-// Example: "1.1"
 #define VERSION_BRANCH _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR)
-#if VERSION_PATCH
-// Example: "1.1.1"
 #define VERSION_NUMBER VERSION_BRANCH "." _MKSTR(VERSION_PATCH)
-#else // VERSION_PATCH == 0
-// we don't include it in the "pretty" version number.
-// Example: "1.1" instead of "1.1.0"
-#define VERSION_NUMBER VERSION_BRANCH
-#endif // VERSION_PATCH
 
 // Version number encoded as hexadecimal int with one byte for each number.
 // This makes it easy to make comparisons in code and scripts.
@@ -32,20 +22,19 @@
 #define VERSION_HEX                                                            \
     0x10000 * VERSION_MAJOR + 0x100 * VERSION_MINOR + VERSION_PATCH
 
-// Describes the full configuration of that Rebel Engine version.
-// Includes the version number, the status (beta, stable, etc.) and
-// potential module-specific features (e.g. mono).
-// Example: "1.1.stable.mono"
-#define VERSION_FULL_CONFIG                                                    \
-    VERSION_NUMBER "." VERSION_STATUS VERSION_MODULE_CONFIG
+// If it's a pre-release, it includes the pre-release identifier after a '-'.
+#ifdef VERSION_PRE_RELEASE
+#define VERSION_FULL VERSION_NUMBER "-" VERSION_PRE_RELEASE
+#else // ! VERSION_PRE_RELEASE
+#define VERSION_FULL VERSION_NUMBER
+#endif // VERSION_PRE_RELEASE
 
-// Similar to VERSION_FULL_CONFIG, but
-// also includes the (potentially custom) VERSION_BUILD description (e.g.
-// official, custom_build, etc.). Example: "1.1.stable.mono.official"
-#define VERSION_FULL_BUILD VERSION_FULL_CONFIG "." VERSION_BUILD
+// Includes the ISO build date after a '+'.
+// E.g. 1.0-dev+2025.8.22
+#define VERSION_FULL_BUILD                                                     \
+    VERSION_FULL "+" _MKSTR(VERSION_YEAR) "." _MKSTR(VERSION_MONTH             \
+    ) "." _MKSTR(VERSION_DAY)
 
-// Same as above, but prepended with Rebel Engine's name and a cosmetic "v" for
-// "version". Example: "Rebel Engine v1.1.stable.mono.official"
-#define VERSION_FULL_NAME VERSION_NAME " v" VERSION_FULL_BUILD
+#define VERSION_FULL_NAME VERSION_NAME " v" VERSION_FULL
 
 #endif // VERSION_H

--- a/docs/Engine.xml
+++ b/docs/Engine.xml
@@ -112,16 +112,19 @@ SPDX-License-Identifier: MIT
             <return type="Dictionary" />
             <description>
                 Returns the current engine version information in a Dictionary.
-                [code]major[/code]    - Holds the major version number as an int
-                [code]minor[/code]    - Holds the minor version number as an int
-                [code]patch[/code]    - Holds the patch version number as an int
-                [code]hex[/code]      - Holds the full version number encoded as a hexadecimal int with one byte (2 places) per number (see example below)
-                [code]status[/code]   - Holds the status (e.g. "beta", "rc1", "rc2", ... "stable") as a String
-                [code]build[/code]    - Holds the build name (e.g. "custom_build") as a String
-                [code]hash[/code]     - Holds the full Git commit hash as a String
-                [code]year[/code]     - Holds the year the version was released in as an int
-                [code]string[/code]   - [code]major[/code] + [code]minor[/code] + [code]patch[/code] + [code]status[/code] + [code]build[/code] in a single String
-                The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code]. [b]Note:[/b] It's still an int internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for easy version comparisons from code:
+                [code]major[/code]    - The build major version number as an int.
+                [code]minor[/code]    - The build minor version number as an int.
+                [code]patch[/code]    - The build patch version number as an int.
+                [code]status[/code]   - Holds the build status (e.g. "dev", "beta", "rc1", "Release", etc.) as a String.
+                [code]build[/code]    - The build date in YYYY-MM-DD ISO date format.
+                [code]year[/code]     - The year the build was created as an int.
+                [code]month[/code]    - The month the build was created as an int.
+                [code]day[/code]      - The day of the month the build was created as an int.
+                [code]string[/code]   - The full Semantic Version (e.g. 1.0-dev+2025.8.22) as a string.
+                [code]hash[/code]     - If available, the full Git commit hash as a String.
+                [code]hex[/code]      - The version number encoded as a hexadecimal int.
+                The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code].
+                [b]Note:[/b] It's still an int internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for easy version comparisons from code:
                 [codeblock]
                 if Engine.get_version_info().hex &gt;= 0x030200:
                     # Do things specific to version 3.2 or later

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -10,7 +10,6 @@
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "editor_node.h"
 
 // The metadata key used to store and retrieve the version text to copy to the
@@ -128,10 +127,11 @@ EditorAbout::EditorAbout() {
     version_info_vbc->add_child(v_spacer);
 
     version_btn = memnew(LinkButton);
-    String hash = String(VERSION_HASH);
-    if (hash.length() != 0) {
-        hash = " " + vformat("[%s]", hash.left(9));
-    }
+#ifdef VERSION_HASH
+    String hash = vformat(" [%s]", String(VERSION_HASH).left(9));
+#else
+    String hash = "";
+#endif // VERSION_HASH
     version_btn->set_text(VERSION_FULL_NAME + hash);
     // Set the text to copy in metadata as it slightly differs from the button's
     // text.

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -362,7 +362,7 @@ String EditorExportPlatform::find_export_template(
     String template_file_name,
     String* err
 ) const {
-    String current_version = VERSION_FULL_CONFIG;
+    String current_version = VERSION_FULL;
     String template_path   = EditorSettings::get_singleton()
                                ->get_templates_dir()
                                .plus_file(current_version)

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -23,7 +23,6 @@
 #include "core/project_settings.h"
 #include "core/translation.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "editor/audio_stream_preview.h"
 #include "editor/dependency_editor.h"
 #include "editor/editor_about.h"
@@ -8616,11 +8615,12 @@ EditorNode::EditorNode() {
     version_info_vbc->add_child(v_spacer);
 
     version_btn = memnew(LinkButton);
-    version_btn->set_text(VERSION_FULL_CONFIG);
-    String hash = String(VERSION_HASH);
-    if (hash.length() != 0) {
-        hash = " " + vformat("[%s]", hash.left(9));
-    }
+    version_btn->set_text(VERSION_FULL_BUILD);
+#ifdef VERSION_HASH
+    String hash = vformat(" [%s]", String(VERSION_HASH).left(9));
+#else
+    String hash = "";
+#endif // VERSION_HASH
     // Set the text to copy in metadata as it slightly differs from the button's
     // text.
     version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -44,7 +44,7 @@ void ExportTemplateManager::_update_template_status() {
     memdelete(da);
 
     // Update the state of the current version.
-    String current_version = VERSION_FULL_CONFIG;
+    String current_version = VERSION_FULL;
     current_value->set_text(current_version);
 
     if (templates.has(current_version)) {
@@ -261,9 +261,9 @@ void ExportTemplateManager::_refresh_mirrors() {
     }
     is_refreshing_mirrors = true;
 
-    String current_version = VERSION_FULL_CONFIG;
+    String current_version = VERSION_FULL;
     const String mirrors_metadata_url =
-        "https://rebeltoolbox.org/mirrorlist/" + current_version + ".json";
+        "https://rebeltoolbox.org/mirrors/" + current_version + ".json";
     request_mirrors->request(mirrors_metadata_url);
 }
 
@@ -787,7 +787,7 @@ void ExportTemplateManager::_hide_dialog() {
 bool ExportTemplateManager::can_install_android_template() {
     const String templates_dir =
         EditorSettings::get_singleton()->get_templates_dir().plus_file(
-            VERSION_FULL_CONFIG
+            VERSION_FULL
         );
     return FileAccess::exists(templates_dir.plus_file("android_template.zip"));
 }
@@ -795,7 +795,7 @@ bool ExportTemplateManager::can_install_android_template() {
 Error ExportTemplateManager::install_android_template() {
     const String& templates_path =
         EditorSettings::get_singleton()->get_templates_dir().plus_file(
-            VERSION_FULL_CONFIG
+            VERSION_FULL
         );
     const String& source_zip = templates_path.plus_file("android_template.zip");
     ERR_FAIL_COND_V(!FileAccess::exists(source_zip), ERR_CANT_OPEN);
@@ -819,7 +819,7 @@ Error ExportTemplateManager::install_android_template_from_file(
         FileAccessRef f =
             FileAccess::open("res://android/.build_version", FileAccess::WRITE);
         ERR_FAIL_COND_V(!f, ERR_CANT_CREATE);
-        f->store_line(VERSION_FULL_CONFIG);
+        f->store_line(VERSION_FULL);
         f->close();
     }
 
@@ -1059,15 +1059,6 @@ ExportTemplateManager::ExportTemplateManager() {
     set_hide_on_ok(false);
     get_ok()->set_text(TTR("Close"));
 
-    // Downloadable export templates are only available for stable and official
-    // alpha/beta/RC builds (which always have a number following their status,
-    // e.g. "alpha1"). Therefore, don't display download-related features when
-    // using a development version (whose builds aren't numbered).
-    downloads_available = String(VERSION_STATUS) != String("dev")
-                       && String(VERSION_STATUS) != String("alpha")
-                       && String(VERSION_STATUS) != String("beta")
-                       && String(VERSION_STATUS) != String("rc");
-
     VBoxContainer* main_vb = memnew(VBoxContainer);
     add_child(main_vb);
 
@@ -1122,7 +1113,7 @@ ExportTemplateManager::ExportTemplateManager() {
         "pressed",
         this,
         "_open_template_folder",
-        varray(VERSION_FULL_CONFIG)
+        varray(VERSION_FULL)
     );
 
     current_uninstall_button = memnew(Button);
@@ -1131,12 +1122,8 @@ ExportTemplateManager::ExportTemplateManager() {
         TTR("Uninstall templates for the current version.")
     );
     current_installed_hb->add_child(current_uninstall_button);
-    current_uninstall_button->connect(
-        "pressed",
-        this,
-        "_uninstall_template",
-        varray(VERSION_FULL_CONFIG)
-    );
+    current_uninstall_button
+        ->connect("pressed", this, "_uninstall_template", varray(VERSION_FULL));
 
     main_vb->add_child(memnew(HSeparator));
 
@@ -1189,14 +1176,6 @@ ExportTemplateManager::ExportTemplateManager() {
     );
     download_install_hb->add_child(download_current_button);
     download_current_button->connect("pressed", this, "_download_current");
-
-    // Update downloads buttons to prevent unsupported downloads.
-    if (!downloads_available) {
-        download_current_button->set_disabled(true);
-        download_current_button->set_tooltip(TTR(
-            "Official export templates aren't available for development builds."
-        ));
-    }
 
     HBoxContainer* install_file_hb = memnew(HBoxContainer);
     install_file_hb->set_alignment(BoxContainer::ALIGN_END);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -11,7 +11,6 @@
 #include "core/project_settings.h"
 #include "core/ustring.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "editor/editor_log.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/spatial_editor_plugin.h"
@@ -2613,28 +2612,28 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 
             // Construct a GitHub repository URL and open it in the user's
             // default web browser.
-            if (String(VERSION_HASH).length() >= 1) {
-                // Git commit hash information available; use it for greater
-                // accuracy, including for development versions.
-                OS::get_singleton()->shell_open(vformat(
-                    "https://github.com/RebelToolbox/RebelEngine/blob/%s/"
-                    "%s#L%d",
-                    VERSION_HASH,
-                    file,
-                    line_number
-                ));
-            } else {
-                // Git commit hash information unavailable; fall back to tagged
-                // releases.
-                OS::get_singleton()->shell_open(vformat(
-                    "https://github.com/RebelToolbox/RebelEngine/blob/"
-                    "%s-stable/"
-                    "%s#L%d",
-                    VERSION_NUMBER,
-                    file,
-                    line_number
-                ));
-            }
+#ifdef VERSION_HASH
+            // Git commit hash information available; use it for greater
+            // accuracy, including for development versions.
+            OS::get_singleton()->shell_open(vformat(
+                "https://github.com/RebelToolbox/RebelEngine/blob/%s/"
+                "%s#L%d",
+                VERSION_HASH,
+                file,
+                line_number
+            ));
+#else  // ! VERSION_HASH
+       // Git commit hash information unavailable; fall back to tagged
+       // releases.
+            OS::get_singleton()->shell_open(vformat(
+                "https://github.com/RebelToolbox/RebelEngine/blob/"
+                "%s/"
+                "%s#L%d",
+                VERSION_NUMBER,
+                file,
+                line_number
+            ));
+#endif // VERSION_HASH
         } break;
     }
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -23,7 +23,6 @@
 #include "core/script_language.h"
 #include "core/translation.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "drivers/register_driver_types.h"
 #include "main/app_icon.gen.h"
 #include "main/input_default.h"
@@ -145,10 +144,11 @@ static String unescape_cmdline(const String& p_str) {
 }
 
 static String get_full_version_string() {
-    String hash = String(VERSION_HASH);
-    if (hash.length() != 0) {
-        hash = "." + hash.left(9);
-    }
+#ifdef VERSION_HASH
+    String hash = vformat(" [%s]", String(VERSION_HASH).left(9));
+#else
+    String hash = "";
+#endif // VERSION_HASH
     return String(VERSION_FULL_BUILD) + hash;
 }
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -15,7 +15,6 @@
 #include "core/os/file_access.h"
 #include "core/variant.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "drivers/png/png_driver_common.h"
 #include "editor/import/resource_importer_scene.h"
 #include "gltf_accessor.h"
@@ -8356,9 +8355,12 @@ Error GLTFDocument::_serialize_version(Ref<GLTFState> state) {
     Dictionary asset;
     asset["version"] = version;
 
-    String hash        = VERSION_HASH;
-    asset["generator"] = String(VERSION_FULL_NAME) + String("@")
-                       + (hash.length() == 0 ? String("unknown") : hash);
+#ifdef VERSION_HASH
+    String hash(VERSION_HASH);
+#else
+    String hash("unknown");
+#endif // VERSION_HASH
+    asset["generator"]   = String(VERSION_FULL_NAME) + String("@") + hash;
     state->json["asset"] = asset;
     ERR_FAIL_COND_V(!asset.has("version"), Error::FAILED);
     ERR_FAIL_COND_V(!state->json.has("asset"), Error::FAILED);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -269,7 +269,7 @@ MonoString* rebel_icall_Internal_UpdateApiAssembliesFromPrebuilt(
 MonoString* rebel_icall_Internal_FullTemplatesDir() {
     String full_templates_dir =
         EditorSettings::get_singleton()->get_templates_dir().plus_file(
-            VERSION_FULL_CONFIG
+            VERSION_FULL
         );
     return GDMonoMarshal::mono_string_from_rebel(full_templates_dir);
 }

--- a/platforms/android/export/export_plugin.cpp
+++ b/platforms/android/export/export_plugin.cpp
@@ -3622,13 +3622,13 @@ Error EditorExportPlatformAndroid::export_project_helper(
             String version = f->get_line().strip_edges();
             print_verbose("- build version: " + version);
             f->close();
-            if (version != VERSION_FULL_CONFIG) {
+            if (version != VERSION_FULL) {
                 EditorNode::get_singleton()->show_warning(vformat(
                     TTR("Android build version mismatch:\n   Template "
                         "installed: %s\n   Rebel Version: %s\nPlease reinstall "
                         "Android project template from 'Project' menu."),
                     version,
-                    VERSION_FULL_CONFIG
+                    VERSION_FULL
                 ));
                 return ERR_UNCONFIGURED;
             }
@@ -3799,7 +3799,7 @@ Error EditorExportPlatformAndroid::export_project_helper(
         cmdline.push_back(
             "-Pperform_signing=" + sign_flag
         ); // argument to specify whether the build should be signed.
-        cmdline.push_back("-Peditor_version=" + String(VERSION_FULL_CONFIG));
+        cmdline.push_back("-Peditor_version=" + String(VERSION_FULL));
 
         // NOTE: The release keystore is not included in the verbose logging
         // to avoid accidentally leaking sensitive information when sharing

--- a/platforms/linux/linux_crash_handler.cpp
+++ b/platforms/linux/linux_crash_handler.cpp
@@ -9,7 +9,6 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #ifdef DEBUG_ENABLED
@@ -53,14 +52,14 @@ static void handle_crash(int sig) {
 
     // Print the engine version just before, so that people are reminded to
     // include the version in backtrace reports.
-    if (String(VERSION_HASH).length() != 0) {
-        fprintf(
-            stderr,
-            "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n"
-        );
-    } else {
-        fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
-    }
+#ifdef VERSION_HASH
+    fprintf(
+        stderr,
+        "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n"
+    );
+#else
+    fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+#endif // VERSION_HASH
     fprintf(stderr, "Dumping the backtrace. %ls\n", msg.c_str());
     char** strings = backtrace_symbols(bt_buffer, size);
     if (strings) {

--- a/platforms/macos/macos_crash_handler.mm
+++ b/platforms/macos/macos_crash_handler.mm
@@ -9,7 +9,6 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #include <string.h>
@@ -76,14 +75,14 @@ static void handle_crash(int sig) {
 
     // Print the engine version just before, so that people are reminded to
     // include the version in backtrace reports.
-    if (String(VERSION_HASH).length() != 0) {
-        fprintf(
-            stderr,
-            "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n"
-        );
-    } else {
-        fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
-    }
+#ifdef VERSION_HASH
+    fprintf(
+        stderr,
+        "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n"
+    );
+#else
+    fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+#endif // VERSION_HASH
     fprintf(stderr, "Dumping the backtrace. %ls\n", msg.c_str());
     char** strings = backtrace_symbols(bt_buffer, size);
     if (strings) {

--- a/platforms/windows/windows_crash_handler.cpp
+++ b/platforms/windows/windows_crash_handler.cpp
@@ -9,7 +9,6 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #ifdef CRASH_HANDLER_EXCEPTION
@@ -195,14 +194,14 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS* ep) {
 
     // Print the engine version just before, so that people are reminded to
     // include the version in backtrace reports.
-    if (String(VERSION_HASH).length() != 0) {
-        fprintf(
-            stderr,
-            "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n"
-        );
-    } else {
-        fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
-    }
+#ifdef VERSION_HASH
+    fprintf(
+        stderr,
+        "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n"
+    );
+#else
+    fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+#endif // VERSION_HASH
     fprintf(stderr, "Dumping the backtrace. %ls\n", msg.c_str());
 
     int n = 0;

--- a/projects_manager/projects_manager.cpp
+++ b/projects_manager/projects_manager.cpp
@@ -16,7 +16,6 @@
 #include "core/os/os.h"
 #include "core/translation.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_themes.h"
@@ -755,12 +754,13 @@ Control* ProjectsManager::_create_tools() {
     // Pushes the version label down.
     Control* version_spacer          = memnew(Control);
     version_container->add_child(version_spacer);
-    version_label       = memnew(LinkButton);
-    String version_hash = String(VERSION_HASH);
-    if (!version_hash.empty()) {
-        version_hash = vformat(" [%s]", version_hash.left(9));
-    }
-    version_label->set_text(vformat("v%s%s", VERSION_FULL_BUILD, version_hash));
+    version_label = memnew(LinkButton);
+#ifdef VERSION_HASH
+    String hash = vformat(" [%s]", String(VERSION_HASH).left(9));
+#else
+    String hash = "";
+#endif // VERSION_HASH
+    version_label->set_text(vformat("v%s%s", VERSION_FULL_BUILD, hash));
     version_label->set_self_modulate(Color(1, 1, 1, 0.6f));
     version_label->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
     version_label->set_tooltip(TTR("Click to copy."));

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -74,8 +74,9 @@ void CanvasItemMaterial::_update_shader() {
 
     // Add a comment to describe the shader origin (useful when converting to
     // ShaderMaterial).
-    String code = "// NOTE: Shader automatically converted from " VERSION_NAME
-                  " " VERSION_FULL_CONFIG "'s CanvasItemMaterial.\n\n";
+    String code =
+        "// NOTE: Shader automatically converted from " VERSION_FULL_NAME
+        "'s CanvasItemMaterial.\n\n";
 
     code += "shader_type canvas_item;\nrender_mode ";
     switch (blend_mode) {

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -459,8 +459,9 @@ void SpatialMaterial::_update_shader() {
 
     // Add a comment to describe the shader origin (useful when converting to
     // ShaderMaterial).
-    String code = "// NOTE: Shader automatically converted from " VERSION_NAME
-                  " " VERSION_FULL_CONFIG "'s SpatialMaterial.\n\n";
+    String code =
+        "// NOTE: Shader automatically converted from " VERSION_FULL_NAME
+        "'s SpatialMaterial.\n\n";
 
     code += "shader_type spatial;\nrender_mode ";
     switch (blend_mode) {

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -123,8 +123,9 @@ void ParticlesMaterial::_update_shader() {
 
     // Add a comment to describe the shader origin (useful when converting to
     // ShaderMaterial).
-    String code = "// NOTE: Shader automatically converted from " VERSION_NAME
-                  " " VERSION_FULL_CONFIG "'s ParticlesMaterial.\n\n";
+    String code =
+        "// NOTE: Shader automatically converted from " VERSION_FULL_NAME
+        "'s ParticlesMaterial.\n\n";
 
     code += "shader_type particles;\n";
 

--- a/version.py
+++ b/version.py
@@ -1,9 +1,7 @@
-short_name = "rebel"
 name = "Rebel Engine"
+short_name = "rebel"
+website = "https://rebeltoolbox.com"
 major = 1
 minor = 0
 patch = 0
-status = "dev"
-module_config = ""
-year = 2023
-website = "https://rebeltoolbox.com"
+pre_release = "dev"


### PR DESCRIPTION
Currently, in Rebel Editor, when we go to `Editor` -> `Manage Export Templates...`, we get an error: "Error getting the list of mirrors" This is caused by the `User Agent` string specified in the request header being considered unacceptable by the server hosting the mirrors list. Instead of the mirrors list, we are sent a [406 Not Acceptable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/406) error.

This problem will not be limited to trying to get the list of mirrors from https://rebeltoolbox.com. This issue will be seen by all users of the [HTTPClient](https://docs.rebeltoolbox.com/en/latest/api/class_httpclient.html#httpclient) trying to access a site that uses [Mod Security](https://modsecurity.org/) with the [core rule set](https://coreruleset.org/). To fix this we should send a `User Agent` string that complies with the standard [[1](https://www.rfc-editor.org/rfc/rfc9110.html#name-user-agent)] and will not get blocked by Mod Security. To achieve this we need to update our approach to versioning.

This PR updates Rebel to use official Semantic Versioning [[2](https://semver.org/)] and uses this to create a `User Agent` string that complies with the standard. In addition, the script to create releases is updated to use Semantic Versioning, which also enables us to provide export template downloads from within Rebel Editor for pre-release versions too.

References:
[1] https://www.rfc-editor.org/rfc/rfc9110.html#name-user-agent
[2] https://semver.org/
