### PR TITLE
Update create release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -431,7 +431,7 @@ jobs:
       - name: Create version.txt File
         run: |
           #Creating version.txt file.
-          echo > $(python3 -c '
+          echo $(python3 -c '
           import version
           version_number = str(version.major)
           version_number += "." + str(version.minor)

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -558,8 +558,8 @@ jobs:
             gh release create v$version ./release/* --generate-notes --title "Nightly $(date +'%Y-%m-%d')" --prerelease
           elif [[ $version == *-* ]] ; then
             echo "Creating Rebel Engine pre-release version $version"
-            gh release create v$version ./release/* --generate-notes --title "Rebel Engine v$version" --prerelease
+            gh release create v$version ./release/* --target ${{ github.ref_name }} --generate-notes --title "Rebel Engine v$version" --prerelease
           else
             echo "Creating Rebel Engine release version $version"
-            gh release create v$version ./release/* --generate-notes --title "Rebel Engine v$version"
+            gh release create v$version ./release/* --target ${{ github.ref_name }} --generate-notes --title "Rebel Engine v$version"
           fi

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -413,6 +413,7 @@ jobs:
         with:
           name: ios-template
           path: ios-template.zip
+          retention-days: 1
 
   create-templates-zip:
     name: Create Templates Zip File
@@ -481,6 +482,7 @@ jobs:
         with:
           name: rebel-templates
           path: rebel-templates.zip
+          retention-days: 1
 
   create-release:
     name: Create Release


### PR DESCRIPTION
Updates the create release workflow to:
- Fix the `version.txt` file included in the release templates' zip file.
- Use the selected branch as the target branch for creating releases.
- Reduce the retention time for intermediate files to 1 day.
