### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/actions/build-cache/action.yml
+++ b/.github/actions/build-cache/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     # Upload cache on completion and check it out now
     - name: Load .scons_cache directory
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{inputs.scons-cache}}
         key: ${{inputs.cache-name}}-${{env.BRANCH_NAME}}-${{github.ref}}-${{github.sha}}

--- a/.github/actions/build-dependencies/action.yml
+++ b/.github/actions/build-dependencies/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     # Use python 3.x release (works cross platform)
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         # Semantic version range syntax or exact version of a Python version
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
Our build tests are raising the following warnings:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/setup-python@v5, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR upgrades the GitHub actions to their latest versions:
- Upgrades GitHub Cache action from version 4 to 5
- Upgrades GitHub Setup Python action from version 5 to 6
- Upgrades GitHub Upload artifact action from version 4 to 7