### PR TITLE
Use older versions of Windows and macOS for builds

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,7 +21,7 @@ jobs:
             build-options: production=yes target=release_debug
 
           - name: Windows Editor
-            os: windows-latest
+            os: windows-2022
             artifact: windows-editor
             build-options: production=yes target=release_debug
 
@@ -48,22 +48,22 @@ jobs:
 
           # Rebel Engine Windows builds
           - name: Windows Engine 64 bit
-            os: windows-latest
+            os: windows-2022
             artifact: windows-engine-x86-64
             build-options: production=yes tools=no target=release
 
           - name: Windows Engine 64 bit Debug
-            os: windows-latest
+            os: windows-2022
             artifact: windows-engine-x86-64-debug
             build-options: production=yes tools=no target=release_debug
 
           - name: Windows Engine 32 bit
-            os: windows-latest
+            os: windows-2022
             artifact: windows-engine-x86-32
             build-options: production=yes tools=no target=release bits=32
 
           - name: Windows Engine 32 bit Debug
-            os: windows-latest
+            os: windows-2022
             artifact: windows-engine-x86-32-debug
             build-options: production=yes tools=no target=release_debug bits=32
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -26,12 +26,12 @@ jobs:
             build-options: production=yes target=release_debug
 
           - name: macOS Editor x86 64 bit
-            os: macos-latest
+            os: macos-15
             artifact: macos-editor-x86-64
             build-options: production=yes target=release_debug
 
           - name: macOS Editor armv8 64 bit
-            os: macos-latest
+            os: macos-15
             artifact: macos-editor-arm64
             build-options: production=yes target=release_debug arch=arm64
 
@@ -69,22 +69,22 @@ jobs:
 
           # Rebel Engine macOS builds
           - name: macOS Engine x86 64 bit
-            os: macos-latest
+            os: macos-15
             artifact: macos-engine-x86-64
             build-options: production=yes tools=no target=release
 
           - name: macOS Engine x86 64 bit Debug
-            os: macos-latest
+            os: macos-15
             artifact: macos-engine-x86-64-debug
             build-options: production=yes tools=no target=release_debug
 
           - name: macOS Engine armv8 64 bit
-            os: macos-latest
+            os: macos-15
             artifact: macos-engine-arm64
             build-options: production=yes tools=no target=release arch=arm64
 
           - name: macOS Engine armv8 64 bit Debug
-            os: macos-latest
+            os: macos-15
             artifact: macos-engine-arm64-debug
             build-options: production=yes tools=no target=release_debug arch=arm64
 

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-macos:
-    runs-on: "macos-latest"
+    runs-on: "macos-15"
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -14,8 +14,7 @@ concurrency:
 
 jobs:
   build-windows:
-    # Windows 10 with latest image
-    runs-on: "windows-latest"
+    runs-on: "windows-2022"
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
GitHub has created new Windows and macOS runners:
- Windows Server 2025 with Visual Studio 2026 [[1](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md)]
- macOS 26 [[2](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md)]

Going forward, these new runners will be used when specifying `windows-latest`, `windows-2025` and `macos-latest`. These new runners have breaking changes [[3](https://github.com/actions/runner-images/issues/14017)][[4](https://github.com/actions/runner-images/issues/14167)]. Unfortunately, currently our builds fail when using these new runners. Therefore, we need to set fix the runners used to the older version until these breaking changes can be addressed.

This PR fixes the Windows OS used for our builds to Windows 2022 (with Visual Studio 2022) and macOS 15.

References:
[1] https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md
[2] https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
[3] https://github.com/actions/runner-images/issues/14017
[4] https://github.com/actions/runner-images/issues/14167