### PR TITLE
Fix Rebel Engine API reST documentation escaped spaces around inline markup

### DIFF
--- a/tools/scripts/rst_from_xml.py
+++ b/tools/scripts/rst_from_xml.py
@@ -6,6 +6,7 @@
 import argparse
 import os
 import re
+import string
 import textwrap
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
@@ -827,16 +828,71 @@ def rst_text(text):
     result = ""
     remaining_text = text
     while remaining_text:
-        plain_text, tag, remaining_text = extract_next_tag(remaining_text)
-        result += escape_special_characters(plain_text)
+        before_text, tag, remaining_text = extract_next_tag(remaining_text)
+        result += escape_special_characters(before_text)
+        if needs_escaped_space_before(result, tag):
+            result += r"\ "
         result += rst_tag(tag)
-        if (
-            result.endswith("`")
-            and remaining_text
-            and (remaining_text[0].isalnum() or remaining_text[0] == "(")
-        ):
+        if needs_escaped_space_after(tag, remaining_text):
             result += r"\ "
     return result
+
+
+def needs_escaped_space_before(before_text, tag):
+    if not before_text or not tag:
+        return False
+    if tag.is_block_tag():
+        return False
+    last_character = before_text[-1]
+    if not is_word_character(last_character):
+        return False
+    return True
+
+
+def needs_escaped_space_after(tag, after_text):
+    if not after_text:
+        return False
+    if tag.is_block_tag():
+        return False
+    next_character = after_text[0]
+    if not (is_word_character(next_character) or is_open_bracket(next_character)):
+        return False
+    return True
+
+
+def is_word_character(character):
+    chinese_punctuation = [
+        "。",
+        "，",
+        "、",
+        "—",
+        "！",
+        "？",
+        "：",
+        "；",
+        "（",
+        "）",
+        "…",
+        "”",
+        "‘",
+    ]
+    if character.isspace():
+        return False
+    if character in string.punctuation:
+        return False
+    if character in chinese_punctuation:
+        return False
+    return True
+
+
+def is_open_bracket(character):
+    open_brackets = [
+        "[",
+        "(",
+        "（",
+    ]
+    if character in open_brackets:
+        return True
 
 
 def add_line_breaks(text):
@@ -883,15 +939,7 @@ def extract_next_tag(text):
         return (before_text, None, after_text)
     tag = TagDef(tag_name)
     tag.name, tag.value = extract_tag_value(tag_name)
-    block_tags = [
-        "b",
-        "code",
-        "codeblock",
-        "i",
-        "img",
-        "url",
-    ]
-    if tag.name in block_tags:
+    if tag.has_contents():
         tag.contents, after_text = extract_tag_contents(tag.name, after_text)
     return (before_text, tag, after_text)
 
@@ -1134,10 +1182,29 @@ class TypeDef:
 
 
 class TagDef:
+    content_tags = [
+        "b",
+        "code",
+        "codeblock",
+        "i",
+        "img",
+        "url",
+    ]
+    block_tags = [
+        "codeblock",
+        "img",
+    ]
+
     def __init__(self, name):
         self.name = name
         self.value = ""
         self.contents = ""
+
+    def has_contents(self):
+        return self.name in TagDef.content_tags
+
+    def is_block_tag(self):
+        return self.name in TagDef.block_tags
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates the [`rst_from_xml.py`](https://github.com/RebelToolbox/RebelEngine/blob/main/tools/scripts/rst_from_xml.py) script to correctly insert escaped spaces before and after inline marked up text and links when creating reST files from XML.

[Rebel Documentation](https://github.com/RebelToolbox/RebelDocumentation) includes the [Rebel Engine API documentation](https://docs.rebeltoolbox.com/en/latest/api/index.html) that is edited here. Each class within the Rebel Engine API is documented using a standardised XML format stored in the [docs/](https://github.com/RebelToolbox/RebelEngine/tree/main/docs) folder. Rebel Documentation converts these XML files to [reStructuredText (reST)](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html) format using our [`rst_from_xml.py`](https://github.com/RebelToolbox/RebelEngine/blob/main/tools/scripts/rst_from_xml.py) script. The reST files are then converted to HTML files to create https://docs.rebeltoolbox.com/.

[Inline markup](https://www.w3.org/Amaya/User/doc/HTML-elements/inline.html) is used to provide text emphasis such as _italics_, **bold** and `code`, as well as [links](https://en.wikipedia.org/wiki/Hyperlink). The Rebel Engine API XML files use a form of [BBCode](https://www.bbcode.org/). reST files use `*`, `**` and ` `` `[[1](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#inline-markup)]. The `rst_from_xml.py` script converts the XML BBCode to reST markup. However, the reST markup has restrictions, which we need to ensure are addressed. The most significant restriction is that reST marked up text "**must be separated from surrounding text by non-word characters.**" Also, for some reason, marked up text cannot be followed directly by an open parenthesis `(` despite being punctuation. To work around this, a backslash escaped space can be used to separate the reST marked up text from word characters (or an open parenthesis) without inserting a space in the resulting HTML.

In the Rebel Engine API, we take care to ensure that there is always a space (or punctuation) before and after every BBCode marked up text in the Rebel Engine XML files. This is normally what is required. The current exception is when referencing another class. When referencing another class, we create a [`:ref:`](https://www.sphinx-doc.org/en/master/usage/referencing.html#role-ref) link to it. Sometimes we refer to the other class in the plural. In this specific instance, we do not want a space between the name of the other class, with its link, and the `s`. E.g. we want [AABB](https://docs.rebeltoolbox.com/en/latest/api/class_aabb.html)s, not [AABB](https://docs.rebeltoolbox.com/en/latest/api/class_aabb.html) s.

The problem is that, when a space or punctuation is not used before and after the marked up text or link, the creation of the reST inline text markups and links fail to get created. Worse, the end of the markup or link is then often seen as the start of the text markup or link and vice versa. The result, especially with links, is often incomprehensible and, at best, ugly. A space is probably required, but missing a space shouldn't break the HTML that is being created.

As noted above, there is a known exception for not having a space (or punctuation) after a reference to another class when it is referred to in the plural. Currently, this is hard-coded for in the [`rst_from_xml.py`](https://github.com/RebelToolbox/RebelEngine/blob/main/tools/scripts/rst_from_xml.py) script. However, there are other exceptions:

When working with other languages in our [translations](https://github.com/RebelToolbox/RebelEngine/tree/main/translations), spaces may not be used. For example, Simplified Chinese, not only doesn't use spaces, [its punctuation](https://en.wikipedia.org/wiki/Chinese_punctuation) characters include the required space. To create the reST files for the Chinese Simplified Rebel Engine API documentation, we need to ensure escaped spaces are inserted before and after all inline marked up text and links.

This is not only required for the Chinese Simplified translation (and probably other languages), it also removes the burden on the people writing the documentation or translations from the drastic consequences of missing a space before and after marked up text or links.

References:
[1] https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#inline-markup
