### PR TITLE
Escape additional special characters when creating reST files

### DIFF
--- a/tools/scripts/rst_from_xml.py
+++ b/tools/scripts/rst_from_xml.py
@@ -930,6 +930,20 @@ def escape_special_characters(text):
                 escaped_text[:position] + r"\_" + escaped_text[position + 1 :]
             )
         position = escaped_text.find("_", position + 2)
+    position = escaped_text.find("`")
+    while position != -1:
+        if not text[position + 1].isspace():
+            escaped_text = (
+                escaped_text[:position] + r"\`" + escaped_text[position + 1 :]
+            )
+        position = escaped_text.find("_", position + 2)
+    position = escaped_text.find("|")
+    while position != -1:
+        if not text[position + 1].isspace():
+            escaped_text = (
+                escaped_text[:position] + r"\|" + escaped_text[position + 1 :]
+            )
+        position = escaped_text.find("_", position + 2)
     return escaped_text
 
 


### PR DESCRIPTION
When converting the Rebel Engine API documentation XML files to [restructuredText (reST)](https://en.wikipedia.org/wiki/ReStructuredText) files, we need to escape characters that are used for inline markup if we don't want them to be used for inline markup and they would be recognised as inline markup. To be recognised as an inline markup character a number of conditions need to be met [[1](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-markup-recognition-rules)]. The two characters `` ` `` and `|` are used for inline markup, but we also use them in the Rebel Engine API documentation to describe the [enum constants](https://docs.rebeltoolbox.com/en/latest/api/class_%40globalscope.html#enumerations) that represent those characters. In the original English version of the documentation, these characters are surrounded by white space, but in, for example, the Spanish translation they are not.
This PR ensures that when converting the XML files to reST files, these characters are escaped when they are not used for inline markup and they are not followed by white space.

References:
1. https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-markup-recognition-rules