### PR TITLE
Fix unused template warnings

### DIFF
--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -852,7 +852,7 @@ public:
 
 // aid for registering
 template <class T>
-static Ref<VisualScriptNode> create_node_generic(const String& p_name) {
+Ref<VisualScriptNode> create_node_generic(const String& p_name) {
     Ref<T> node;
     node.instance();
     return node;

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -1116,16 +1116,6 @@ VisualScriptFunctionCall::VisualScriptFunctionCall() {
     rpc_call_mode    = RPC_DISABLED;
 }
 
-template <VisualScriptFunctionCall::CallMode cmode>
-static Ref<VisualScriptNode> create_function_call_node(const String& p_name) {
-    Ref<VisualScriptFunctionCall> node;
-    node.instance();
-    node->set_call_mode(cmode);
-    return node;
-}
-
-//////////////////////////////////////////
-////////////////SET//////////////////////
 //////////////////////////////////////////
 
 int VisualScriptPropertySet::get_output_sequence_port_count() const {
@@ -2088,16 +2078,6 @@ VisualScriptPropertySet::VisualScriptPropertySet() {
     basic_type = Variant::NIL;
 }
 
-template <VisualScriptPropertySet::CallMode cmode>
-static Ref<VisualScriptNode> create_property_set_node(const String& p_name) {
-    Ref<VisualScriptPropertySet> node;
-    node.instance();
-    node->set_call_mode(cmode);
-    return node;
-}
-
-//////////////////////////////////////////
-////////////////GET//////////////////////
 //////////////////////////////////////////
 
 int VisualScriptPropertyGet::get_output_sequence_port_count() const {
@@ -2843,16 +2823,6 @@ VisualScriptPropertyGet::VisualScriptPropertyGet() {
     type_cache = Variant::NIL;
 }
 
-template <VisualScriptPropertyGet::CallMode cmode>
-static Ref<VisualScriptNode> create_property_get_node(const String& p_name) {
-    Ref<VisualScriptPropertyGet> node;
-    node.instance();
-    node->set_call_mode(cmode);
-    return node;
-}
-
-//////////////////////////////////////////
-////////////////EMIT//////////////////////
 //////////////////////////////////////////
 
 int VisualScriptEmitSignal::get_output_sequence_port_count() const {

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -684,14 +684,6 @@ VisualScriptYieldSignal::VisualScriptYieldSignal() {
     base_type = "Object";
 }
 
-template <VisualScriptYieldSignal::CallMode cmode>
-static Ref<VisualScriptNode> create_yield_signal_node(const String& p_name) {
-    Ref<VisualScriptYieldSignal> node;
-    node.instance();
-    node->set_call_mode(cmode);
-    return node;
-}
-
 void register_visual_script_yield_nodes() {
     VisualScriptLanguage::singleton
         ->add_register_func("functions/wait/wait_frame", create_yield_node<VisualScriptYield::YIELD_FRAME>);


### PR DESCRIPTION
Removes unused template functions in definition files and the unneeded `static` keyword from template functions in header files.

Currently our development web builds are failing with a number of unused function template errors:
```
modules/visual_script/visual_script.h:855:30: error: unused function template 'create_node_generic' [-Werror,-Wunused-template]
  855 | static Ref<VisualScriptNode> create_node_generic(const String& p_name) {
      |                              ^~~~~~~~~~~~~~~~~~~
```
Our web builds use Emscripten, which uses the Clang compiler. Clang [recently added](https://github.com/llvm/llvm-project/pull/208001) the [`-Wunused-template`](https://clang.llvm.org/docs/DiagnosticsReference.html#wunused-template) warning to `-Wall` (the all warnings setting). Since we treat all warnings as errors, if the compiler finds unused template functions or variables, the build will fail.

When a function template is declared in a definition file, they can only be used in the definition file. Therefore, it's easy to identify unused function templates. Since unused functions are dead-code, they can be safely removed.

When they are declared in a header file, they can be used in any translation unit that includes the header file. The `static` keyword is used to restrict the visibility of functions and variables to the translation unit they are declared in. A `static` function template defined in a header file has internal linkage; so every translation unit that includes the header gets its own copy. When such a template is referenced from another inline function or template in a header, the definitions across translation units refer to different entities, which violates the "One Definition Rule" (ODR). Therefore, `static` should not be used for function definitions in header files [[1](https://github.com/llvm/llvm-project/issues/202945)]. Note: The unused template warning only identifies `static` function templates in header files where there is a translation unit that includes it but doesn't use the template function. There may be other `static` function templates in other header files, but they may be used in every translation unit they are included in.

Reference:
1. https://github.com/llvm/llvm-project/issues/202945