### PR TITLE
Remove plural abbreviations

### DIFF
--- a/docs/AnimatedSprite.xml
+++ b/docs/AnimatedSprite.xml
@@ -56,7 +56,7 @@ SPDX-License-Identifier: MIT
             The displayed animation frame's index.
         </member>
         <member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
-            The [SpriteFrames] resource containing the animation(s).
+            The [SpriteFrames] resource containing frames and animation data.
         </member>
         <member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
             The texture's drawing offset.

--- a/docs/AnimatedSprite3D.xml
+++ b/docs/AnimatedSprite3D.xml
@@ -45,7 +45,7 @@ SPDX-License-Identifier: MIT
             The displayed animation frame's index.
         </member>
         <member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
-            The [SpriteFrames] resource containing the animation(s).
+            The [SpriteFrames] resource containing frames and animation data.
         </member>
         <member name="playing" type="bool" setter="_set_playing" getter="_is_playing" default="false">
             If [code]true[/code], the [member animation] is currently playing.

--- a/docs/LightOccluder2D.xml
+++ b/docs/LightOccluder2D.xml
@@ -20,7 +20,7 @@ SPDX-License-Identifier: MIT
     </methods>
     <members>
         <member name="light_mask" type="int" setter="set_occluder_light_mask" getter="get_occluder_light_mask" default="1">
-            The LightOccluder2D's light mask. The LightOccluder2D will cast shadows only from Light2D(s) that have the same light mask(s).
+            The LightOccluder2D's light mask. The LightOccluder2D will cast shadows only from [Light2D]s that have the same light mask.
         </member>
         <member name="occluder" type="OccluderPolygon2D" setter="set_occluder_polygon" getter="get_occluder_polygon">
             The [OccluderPolygon2D] used to compute the shadow.

--- a/docs/NetworkedMultiplayerPeer.xml
+++ b/docs/NetworkedMultiplayerPeer.xml
@@ -93,7 +93,7 @@ SPDX-License-Identifier: MIT
             Packets are not acknowledged, no resend attempts are made for lost packets. Packets may arrive in any order. Potentially faster than [constant TRANSFER_MODE_UNRELIABLE_ORDERED]. Use for non-critical data, and always consider whether the order matters.
         </constant>
         <constant name="TRANSFER_MODE_UNRELIABLE_ORDERED" value="1" enum="TransferMode">
-            Packets are not acknowledged, no resend attempts are made for lost packets. Packets are received in the order they were sent in. Potentially faster than [constant TRANSFER_MODE_RELIABLE]. Use for non-critical data or data that would be outdated if received late due to resend attempt(s) anyway, for example movement and positional data.
+            Packets are not acknowledged, no resend attempts are made for lost packets. Packets are received in the order they were sent in. Potentially faster than [constant TRANSFER_MODE_RELIABLE]. Use for non-critical data or data that would be outdated if received late due to resend attempts anyway, for example movement and positional data.
         </constant>
         <constant name="TRANSFER_MODE_RELIABLE" value="2" enum="TransferMode">
             Packets must be received and resend attempts should be made until the packets are acknowledged. Packets must be received in the order they were sent in. Most reliable transfer mode, but potentially the slowest due to the overhead. Use for critical data that must be transmitted and arrive in order, for example an ability being triggered or a chat message. Consider carefully if the information really is critical, and use sparingly.

--- a/docs/PackedScene.xml
+++ b/docs/PackedScene.xml
@@ -63,7 +63,7 @@ SPDX-License-Identifier: MIT
             <return type="Node" />
             <argument index="0" name="edit_state" type="int" enum="PackedScene.GenEditState" default="0" />
             <description>
-                Instantiates the scene's node hierarchy. Triggers child scene instantiation(s). Triggers a [constant Node.NOTIFICATION_INSTANCED] notification on the root node.
+                Instantiates the scene's node hierarchy. Triggers child scene instantiations. Triggers a [constant Node.NOTIFICATION_INSTANCED] notification on the root node.
             </description>
         </method>
         <method name="pack">

--- a/docs/ParticlesMaterial.xml
+++ b/docs/ParticlesMaterial.xml
@@ -255,7 +255,7 @@ SPDX-License-Identifier: MIT
             Trail particles' color will vary along this [GradientTexture].
         </member>
         <member name="trail_divisor" type="int" setter="set_trail_divisor" getter="get_trail_divisor" default="1">
-            Emitter will emit [code]amount[/code] divided by [code]trail_divisor[/code] particles. The remaining particles will be used as trail(s).
+            Emitter will emit [code]amount[/code] divided by [code]trail_divisor[/code] particles. The remaining particles will be used as trails.
         </member>
         <member name="trail_size_modifier" type="CurveTexture" setter="set_trail_size_modifier" getter="get_trail_size_modifier">
             Trail particles' size will vary along this [CurveTexture].

--- a/docs/Physics2DShapeQueryParameters.xml
+++ b/docs/Physics2DShapeQueryParameters.xml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: MIT
             If [code]true[/code], the query will take [PhysicsBody2D]s into account.
         </member>
         <member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="2147483647">
-            The physics layer(s) the query will take into account (as a bitmask). See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+            The physics layers the query will take into account (as a bitmask). See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
         </member>
         <member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[  ]">
             The list of objects or object [RID]s that will be excluded from collisions.

--- a/docs/PhysicsShapeQueryParameters.xml
+++ b/docs/PhysicsShapeQueryParameters.xml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: MIT
             If [code]true[/code], the query will take [PhysicsBody]s into account.
         </member>
         <member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="2147483647">
-            The physics layer(s) the query will take into account (as a bitmask). See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+            The physics layers the query will take into account (as a bitmask). See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
         </member>
         <member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[  ]">
             The list of objects or object [RID]s that will be excluded from collisions.

--- a/docs/ResourceFormatLoader.xml
+++ b/docs/ResourceFormatLoader.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
     </brief_description>
     <description>
         Rebel Engine loads resources in the editor or in exported games using ResourceFormatLoaders. They are queried automatically via the [ResourceLoader] singleton, or when a resource with internal dependencies is loaded. Each file type may load as a different resource type, so multiple ResourceFormatLoaders are registered in the engine.
-        Extending this class allows you to define your own loader. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatLoaders, it will be called automatically when loading resources of its handled type(s). You may also implement a [ResourceFormatSaver].
+        Extending this class allows you to define your own loader. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatLoaders, it will be called automatically when loading resources of its handled types. You may also implement a [ResourceFormatSaver].
         [b]Note:[/b] You can also extend [EditorImportPlugin] if the resource type you need exists but Rebel Engine is unable to load its format. Choosing one way over another depends on if the format is suitable or not for the final exported game. For example, it's better to import [code].png[/code] textures as [code].stex[/code] ([StreamTexture]) first, so they can be loaded with better efficiency on the graphics card.
     </description>
     <tutorials>

--- a/docs/ResourceFormatSaver.xml
+++ b/docs/ResourceFormatSaver.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
     </brief_description>
     <description>
         The engine can save resources when you do it from the editor, or when you use the [ResourceSaver] singleton. This is accomplished thanks to multiple [ResourceFormatSaver]s, each handling its own format and called automatically by the engine.
-        By default, Rebel Engine saves resources as [code].tres[/code] (text-based), [code].res[/code] (binary) or another built-in format, but you can choose to create your own format by extending this class. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatSavers, it will be called automatically when saving resources of its recognized type(s). You may also implement a [ResourceFormatLoader].
+        By default, Rebel Engine saves resources as [code].tres[/code] (text-based), [code].res[/code] (binary) or another built-in format, but you can choose to create your own format by extending this class. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatSavers, it will be called automatically when saving resources of its recognized types. You may also implement a [ResourceFormatLoader].
     </description>
     <tutorials>
     </tutorials>

--- a/docs/TileMap.xml
+++ b/docs/TileMap.xml
@@ -248,10 +248,10 @@ SPDX-License-Identifier: MIT
             Friction value for static body collisions (see [code]collision_use_kinematic[/code]).
         </member>
         <member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
-            The collision layer(s) for all colliders in the TileMap. See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+            The collision layers for all colliders in the TileMap. See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
         </member>
         <member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
-            The collision mask(s) for all colliders in the TileMap. See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+            The collision mask for all colliders in the TileMap. See [url=https://docs.rebeltoolbox.com/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
         </member>
         <member name="collision_use_kinematic" type="bool" setter="set_collision_use_kinematic" getter="get_collision_use_kinematic" default="false">
             If [code]true[/code], TileMap collisions will be handled as a kinematic body. If [code]false[/code], collisions will be handled as static body.
@@ -268,7 +268,7 @@ SPDX-License-Identifier: MIT
             The TileMap orientation mode. See [enum Mode] for possible values.
         </member>
         <member name="occluder_light_mask" type="int" setter="set_occluder_light_mask" getter="get_occluder_light_mask" default="1">
-            The light mask assigned to all light occluders in the TileMap. The TileSet's light occluders will cast shadows only from Light2D(s) that have the same light mask(s).
+            The light mask assigned to all light occluders in the TileMap. The TileSet's light occluders will cast shadows only from [Light2D]s that have the same light mask.
         </member>
         <member name="show_collision" type="bool" setter="set_show_collision" getter="is_show_collision_enabled" default="false">
             If [code]true[/code], collision shapes are visible in the editor. Doesn't affect collision shapes visibility at runtime. To show collision shapes at runtime, enable [b]Visible Collision Shapes[/b] in the [b]Debug[/b] menu instead.

--- a/docs/Tree.xml
+++ b/docs/Tree.xml
@@ -165,7 +165,7 @@ SPDX-License-Identifier: MIT
             <description>
                 Returns the currently focused item, or [code]null[/code] if no item is focused.
                 In [constant SELECT_ROW] and [constant SELECT_SINGLE] modes, the focused item is same as the selected item. In [constant SELECT_MULTI] mode, the focused item is the item under the focus cursor, not necessarily selected.
-                To get the currently selected item(s), use [method get_next_selected].
+                To get the currently selected item, use [method get_next_selected].
             </description>
         </method>
         <method name="get_selected_column" qualifiers="const">

--- a/docs/VisualInstance.xml
+++ b/docs/VisualInstance.xml
@@ -66,7 +66,7 @@ SPDX-License-Identifier: MIT
     </methods>
     <members>
         <member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
-            The render layer(s) this [VisualInstance] is drawn on.
+            The render layers this [VisualInstance] is drawn on.
             This object will only be visible for [Camera]s whose cull mask includes the render object this [VisualInstance] is set to.
         </member>
     </members>

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -827,17 +827,30 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent>& p_event) {
                 TTR("Insert Key Here"),
                 MENU_KEY_INSERT
             );
-            if (selection.size()) {
+            if (selection.size() == 1) {
                 menu->add_separator();
                 menu->add_icon_item(
                     get_icon("Duplicate", "EditorIcons"),
-                    TTR("Duplicate Selected Key(s)"),
+                    TTR("Duplicate Selected Key"),
                     MENU_KEY_DUPLICATE
                 );
                 menu->add_separator();
                 menu->add_icon_item(
                     get_icon("Remove", "EditorIcons"),
-                    TTR("Delete Selected Key(s)"),
+                    TTR("Delete Selected Key"),
+                    MENU_KEY_DELETE
+                );
+            } else if (selection.size() > 1) {
+                menu->add_separator();
+                menu->add_icon_item(
+                    get_icon("Duplicate", "EditorIcons"),
+                    TTR("Duplicate Selected Keys"),
+                    MENU_KEY_DUPLICATE
+                );
+                menu->add_separator();
+                menu->add_icon_item(
+                    get_icon("Remove", "EditorIcons"),
+                    TTR("Delete Selected Keys"),
                     MENU_KEY_DELETE
                 );
             }

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3856,17 +3856,30 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent>& p_event) {
                 TTR("Insert Key"),
                 MENU_KEY_INSERT
             );
-            if (editor->is_selection_active()) {
+            if (editor->get_selection_count() == 1) {
                 menu->add_separator();
                 menu->add_icon_item(
                     get_icon("Duplicate", "EditorIcons"),
-                    TTR("Duplicate Key(s)"),
+                    TTR("Duplicate Selected Key"),
                     MENU_KEY_DUPLICATE
                 );
                 menu->add_separator();
                 menu->add_icon_item(
                     get_icon("Remove", "EditorIcons"),
-                    TTR("Delete Key(s)"),
+                    TTR("Delete Selected Key"),
+                    MENU_KEY_DELETE
+                );
+            } else if (editor->get_selection_count() > 1) {
+                menu->add_separator();
+                menu->add_icon_item(
+                    get_icon("Duplicate", "EditorIcons"),
+                    TTR("Duplicate Selected Keys"),
+                    MENU_KEY_DUPLICATE
+                );
+                menu->add_separator();
+                menu->add_icon_item(
+                    get_icon("Remove", "EditorIcons"),
+                    TTR("Delete Selected Keys"),
                     MENU_KEY_DELETE
                 );
             }
@@ -5524,7 +5537,7 @@ bool AnimationTrackEditor::is_key_selected(int p_track, int p_key) const {
     return selection.has(sk);
 }
 
-bool AnimationTrackEditor::is_selection_active() const {
+int AnimationTrackEditor::get_selection_count() const {
     return selection.size();
 }
 
@@ -8283,7 +8296,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
     );
     ichb->add_child(insert_confirm_bezier);
     insert_confirm_reset = memnew(CheckBox);
-    insert_confirm_reset->set_text(TTR("Create RESET Track(s)"));
+    insert_confirm_reset->set_text(TTR("Create RESET Tracks"));
     insert_confirm_reset->set_pressed(
         EDITOR_GET("editors/animation/default_create_reset_tracks")
     );
@@ -8373,7 +8386,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
     cleanup_all->set_text(TTR("Clean-up all animations"));
     cleanup_vb->add_child(cleanup_all);
 
-    cleanup_dialog->set_title(TTR("Clean-Up Animation(s) (NO UNDO!)"));
+    cleanup_dialog->set_title(TTR("Clean-Up Animation (NO UNDO!)"));
     cleanup_dialog->get_ok()->set_text(TTR("Clean-Up"));
 
     cleanup_dialog->connect(

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -611,7 +611,7 @@ public:
     void show_select_node_warning(bool p_show);
 
     bool is_key_selected(int p_track, int p_key) const;
-    bool is_selection_active() const;
+    int get_selection_count() const;
     bool is_moving_selection() const;
     bool is_snap_enabled() const;
     float get_moving_selection_offset() const;

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -762,9 +762,14 @@ void OrphanResourcesDialog::ok_pressed() {
         return;
     }
 
-    delete_confirm->set_text(
-        vformat(TTR("Permanently delete %d item(s)? (No undo!)"), paths.size())
-    );
+    if (paths.size() == 1) {
+        delete_confirm->set_text(TTR("Permanently delete item? (No undo!)"));
+    } else {
+        delete_confirm->set_text(vformat(
+            TTR("Permanently delete %d items? (No undo!)"),
+            paths.size()
+        ));
+    }
     delete_confirm->popup_centered_clamped(delete_confirm->get_minimum_size());
 }
 

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -262,9 +262,15 @@ void EditorAssetInstaller::open(const String& p_path, int p_depth) {
         status_map[E->get()] = ti;
     }
 
-    if (num_file_conflicts >= 1) {
+    if (num_file_conflicts == 1) {
         asset_contents->set_text(vformat(
-            TTR("Contents of asset \"%s\" - %d file(s) conflict with your "
+            TTR("Contents of asset \"%s\" - 1 file conflicts with your project:"
+            ),
+            asset_name
+        ));
+    } else if (num_file_conflicts > 1) {
+        asset_contents->set_text(vformat(
+            TTR("Contents of asset \"%s\" - %d files conflict with your "
                 "project:"),
             asset_name,
             num_file_conflicts

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -1227,7 +1227,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
     import_profiles->set_mode(EditorFileDialog::MODE_OPEN_FILES);
     import_profiles->add_filter("*.profile; " + TTR("Rebel Feature Profile"));
     import_profiles->connect("files_selected", this, "_import_profiles");
-    import_profiles->set_title(TTR("Import Profile(s)"));
+    import_profiles->set_title(TTR("Import Profile"));
     import_profiles->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
     export_profile = memnew(EditorFileDialog);

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1070,7 +1070,7 @@ void EditorFileDialog::set_mode(Mode p_mode) {
             break;
         case MODE_OPEN_FILES:
             get_ok()->set_text(TTR("Open"));
-            set_title(TTR("Open File(s)"));
+            set_title(TTR("Open Files"));
             can_create_dir = false;
             break;
         case MODE_OPEN_DIR:

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2943,12 +2943,18 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
                 }
 
                 const int saved = _save_external_resources();
-                if (saved > 0) {
+                if (saved == 1) {
+                    show_accept(
+                        TTR("The current scene has no root node, but the "
+                            "modified external resource was saved anyway."),
+                        TTR("OK")
+                    );
+                } else if (saved > 1) {
                     show_accept(
                         vformat(
                             TTR("The current scene has no root node, but %d "
-                                "modified external resource(s) were saved "
-                                "anyway."),
+                                "modified external resources were saved anyway."
+                            ),
                             saved
                         ),
                         TTR("OK")
@@ -3335,9 +3341,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
                         );
                         save_confirmation->set_text(
                             (p_option == FILE_QUIT
-                                 ? TTR("Save changes to the following scene(s) "
+                                 ? TTR("Save changes to the following scenes "
                                        "before quitting?")
-                                 : TTR("Save changes to the following scene(s) "
+                                 : TTR("Save changes to the following scenes "
                                        "before opening Projects Manager?"))
                             + unsaved_scenes
                         );

--- a/editor/editor_sub_scene.cpp
+++ b/editor/editor_sub_scene.cpp
@@ -222,7 +222,7 @@ EditorSubScene::EditorSubScene() {
     scene   = nullptr;
     is_root = false;
 
-    set_title(TTR("Select Node(s) to Import"));
+    set_title(TTR("Select Nodes to Import"));
     set_hide_on_ok(false);
 
     VBoxContainer* vb = memnew(VBoxContainer);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -645,7 +645,7 @@ void AnimationNodeBlendTreeEditor::_delete_nodes_request() {
         return;
     }
 
-    undo_redo->create_action(TTR("Delete Node(s)"));
+    undo_redo->create_action(TTR("Delete Nodes"));
 
     for (List<StringName>::Element* F = to_erase.front(); F; F = F->next()) {
         _delete_request(F->get());

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -7771,7 +7771,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
         case SKELETON_MAKE_BONES: {
             Map<Node*, Object*>& selection = editor_selection->get_selection();
 
-            undo_redo->create_action(TTR("Create Custom Bone(s) from Node(s)"));
+            undo_redo->create_action(TTR("Create Custom Bones from Nodes"));
             for (Map<Node*, Object*>::Element* E = selection.front(); E;
                  E                               = E->next()) {
                 Node2D* n2d = Object::cast_to<Node2D>(E->key());
@@ -8812,7 +8812,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode* p_editor) {
     p->add_shortcut(
         ED_SHORTCUT(
             "canvas_item_editor/skeleton_make_bones",
-            TTR("Make Custom Bone(s) from Node(s)"),
+            TTR("Make Custom Bones from Nodes"),
             KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_B
         ),
         SKELETON_MAKE_BONES

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -137,9 +137,13 @@ void SpriteFramesEditor::_sheet_preview_draw() {
     }
 
     split_sheet_dialog->get_ok()->set_disabled(false);
-    split_sheet_dialog->get_ok()->set_text(
-        vformat(TTR("Add %d Frame(s)"), frames_selected.size())
-    );
+    if (frames_selected.size() == 1) {
+        split_sheet_dialog->get_ok()->set_text(TTR("Add frame"));
+    } else {
+        split_sheet_dialog->get_ok()->set_text(
+            vformat(TTR("Add %d frames"), frames_selected.size())
+        );
+    }
 }
 
 void SpriteFramesEditor::_sheet_preview_input(const Ref<InputEvent>& p_event) {

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -236,8 +236,13 @@ void ThemeItemImportTree::_update_items_tree() {
     if (color_amount > 0) {
         Array arr;
         arr.push_back(color_amount);
-        select_colors_label->set_text(TTR("{num} color(s)").format(arr, "{num}")
-        );
+        if (color_amount == 1) {
+            select_colors_label->set_text(TTR("1 color"));
+        } else {
+            select_colors_label->set_text(
+                TTR("{num} colors").format(arr, "{num}")
+            );
+        }
         select_all_colors_button->set_visible(true);
         select_full_colors_button->set_visible(true);
         deselect_all_colors_button->set_visible(true);
@@ -251,9 +256,13 @@ void ThemeItemImportTree::_update_items_tree() {
     if (constant_amount > 0) {
         Array arr;
         arr.push_back(constant_amount);
-        select_constants_label->set_text(
-            TTR("{num} constant(s)").format(arr, "{num}")
-        );
+        if (constant_amount == 1) {
+            select_constants_label->set_text(TTR("1 constant"));
+        } else {
+            select_constants_label->set_text(
+                TTR("{num} constants").format(arr, "{num}")
+            );
+        }
         select_all_constants_button->set_visible(true);
         select_full_constants_button->set_visible(true);
         deselect_all_constants_button->set_visible(true);
@@ -267,7 +276,12 @@ void ThemeItemImportTree::_update_items_tree() {
     if (font_amount > 0) {
         Array arr;
         arr.push_back(font_amount);
-        select_fonts_label->set_text(TTR("{num} font(s)").format(arr, "{num}"));
+        if (font_amount == 1) {
+            select_fonts_label->set_text(TTR("1 font"));
+        } else {
+            select_fonts_label->set_text(TTR("{num} fonts").format(arr, "{num}")
+            );
+        }
         select_all_fonts_button->set_visible(true);
         select_full_fonts_button->set_visible(true);
         deselect_all_fonts_button->set_visible(true);
@@ -281,7 +295,12 @@ void ThemeItemImportTree::_update_items_tree() {
     if (icon_amount > 0) {
         Array arr;
         arr.push_back(icon_amount);
-        select_icons_label->set_text(TTR("{num} icon(s)").format(arr, "{num}"));
+        if (icon_amount == 1) {
+            select_icons_label->set_text(TTR("1 icon"));
+        } else {
+            select_icons_label->set_text(TTR("{num} icons").format(arr, "{num}")
+            );
+        }
         select_all_icons_button->set_visible(true);
         select_full_icons_button->set_visible(true);
         deselect_all_icons_button->set_visible(true);
@@ -297,9 +316,13 @@ void ThemeItemImportTree::_update_items_tree() {
     if (stylebox_amount > 0) {
         Array arr;
         arr.push_back(stylebox_amount);
-        select_styleboxes_label->set_text(
-            TTR("{num} stylebox(es)").format(arr, "{num}")
-        );
+        if (stylebox_amount == 1) {
+            select_styleboxes_label->set_text(TTR("1 stylebox"));
+        } else {
+            select_styleboxes_label->set_text(
+                TTR("{num} styleboxes").format(arr, "{num}")
+            );
+        }
         select_all_styleboxes_button->set_visible(true);
         select_full_styleboxes_button->set_visible(true);
         deselect_all_styleboxes_button->set_visible(true);

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -483,7 +483,7 @@ TileSetEditor::TileSetEditor(EditorNode* p_editor) {
         tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]
     );
     tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->set_tooltip(
-        TTR("Add Texture(s) to TileSet.")
+        TTR("Add Texture to TileSet.")
     );
 
     tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE] = memnew(ToolButton);
@@ -1014,10 +1014,17 @@ void TileSetEditor::_on_textures_added(const PoolStringArray& p_paths) {
         _on_texture_list_selected(texture_list->get_item_count() - 1);
     }
 
-    if (invalid_count > 0) {
+    if (invalid_count == 1) {
+        err_dialog->set_text(
+            TTR("1 file was not added, because it was already on the list.")
+        );
+        err_dialog->popup_centered(Size2(300, 60));
+    }
+    if (invalid_count > 1) {
         err_dialog->set_text(vformat(
-            TTR("%s file(s) were not added because was already on the list."),
-            String::num(invalid_count, 0)
+            TTR("%d files were not added, because they were already on the "
+                "list."),
+            invalid_count
         ));
         err_dialog->popup_centered(Size2(300, 60));
     }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2142,7 +2142,7 @@ void VisualShaderEditor::_node_dragged(
 void VisualShaderEditor::_nodes_dragged() {
     drag_dirty = false;
 
-    undo_redo->create_action(TTR("Node(s) Moved"));
+    undo_redo->create_action(TTR("Nodes moved"));
 
     for (List<DragOp>::Element* E = drag_buffer.front(); E; E = E->next()) {
         undo_redo->add_do_method(

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1614,10 +1614,13 @@ void ProjectSettingsEditor::_translation_res_add(const PoolStringArray& p_paths
         }
     }
 
-    undo_redo->create_action(vformat(
-        TTR("Translation Resource Remap: Add %d Path(s)"),
-        p_paths.size()
-    ));
+    if (p_paths.size() == 1) {
+        undo_redo->create_action(TTR("Add localization remap resource"));
+    } else {
+        undo_redo->create_action(
+            vformat(TTR("Add %d localization remap resources"), p_paths.size())
+        );
+    }
     undo_redo->add_do_property(
         ProjectSettings::get_singleton(),
         "locale/translation_remaps",
@@ -1661,10 +1664,13 @@ void ProjectSettingsEditor::_translation_res_option_add(
     }
     remaps[key] = r;
 
-    undo_redo->create_action(vformat(
-        TTR("Translation Resource Remap: Add %d Remap(s)"),
-        p_paths.size()
-    ));
+    if (p_paths.size() == 1) {
+        undo_redo->create_action(TTR("Add localization locale remap"));
+    } else {
+        undo_redo->create_action(
+            vformat(TTR("Add %d localization locale remaps"), p_paths.size())
+        );
+    }
     undo_redo->add_do_property(
         ProjectSettings::get_singleton(),
         "locale/translation_remaps",

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -207,7 +207,11 @@ void SceneTreeDock::_perform_instance_scenes(
         return;
     }
 
-    editor_data->get_undo_redo().create_action(TTR("Instance Scene(s)"));
+    if (instances.size() == 1) {
+        editor_data->get_undo_redo().create_action(TTR("Instance scene"));
+    } else {
+        editor_data->get_undo_redo().create_action(TTR("Instance scenes"));
+    }
 
     for (int i = 0; i < instances.size(); i++) {
         Node* instanced_scene = instances[i];
@@ -536,7 +540,11 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
                 owner = paste_parent;
             }
 
-            editor_data->get_undo_redo().create_action(TTR("Paste Node(s)"));
+            if (node_clipboard.size() == 1) {
+                editor_data->get_undo_redo().create_action(TTR("Paste node"));
+            } else {
+                editor_data->get_undo_redo().create_action(TTR("Paste nodes"));
+            }
             editor_data->get_undo_redo().add_do_method(
                 editor_selection,
                 "clear"
@@ -791,10 +799,13 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
             List<Node*> selection = editor_selection->get_selected_node_list();
             if (selection.size() == 0) {
                 break;
+            } else if (selection.size() == 1) {
+                editor_data->get_undo_redo().create_action(TTR("Duplicate node")
+                );
+            } else {
+                editor_data->get_undo_redo().create_action(TTR("Duplicate nodes"
+                ));
             }
-
-            editor_data->get_undo_redo().create_action(TTR("Duplicate Node(s)")
-            );
             editor_data->get_undo_redo().add_do_method(
                 editor_selection,
                 "clear"
@@ -2575,9 +2586,17 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
     editor->get_editor_plugins_over()->make_visible(false);
 
     if (p_cut) {
-        editor_data->get_undo_redo().create_action(TTR("Cut Node(s)"));
+        if (remove_list.size() == 1) {
+            editor_data->get_undo_redo().create_action(TTR("Cut node"));
+        } else {
+            editor_data->get_undo_redo().create_action(TTR("Cut nodes"));
+        }
     } else {
-        editor_data->get_undo_redo().create_action(TTR("Remove Node(s)"));
+        if (remove_list.size() == 1) {
+            editor_data->get_undo_redo().create_action(TTR("Remove node"));
+        } else {
+            editor_data->get_undo_redo().create_action(TTR("Remove nodes"));
+        }
     }
 
     bool entire_scene = false;
@@ -2846,7 +2865,11 @@ void SceneTreeDock::_create() {
         ERR_FAIL_COND(selection.size() <= 0);
 
         UndoRedo* ur = EditorNode::get_singleton()->get_undo_redo();
-        ur->create_action(TTR("Change type of node(s)"));
+        if (selection.size() == 1) {
+            ur->create_action(TTR("Change type of node"));
+        } else {
+            ur->create_action(TTR("Change type of nodes"));
+        }
 
         for (List<Node*>::Element* E = selection.front(); E; E = E->next()) {
             Node* n = E->get();
@@ -3661,11 +3684,27 @@ void SceneTreeDock::_tree_rmb(const Vector2& p_menu_pos) {
 
     if (profile_allow_editing) {
         menu->add_separator();
-        menu->add_icon_shortcut(
-            get_icon("Remove", "EditorIcons"),
-            ED_SHORTCUT("scene_tree/delete", TTR("Delete Node(s)"), KEY_DELETE),
-            TOOL_ERASE
-        );
+        if (selection.size() == 1) {
+            menu->add_icon_shortcut(
+                get_icon("Remove", "EditorIcons"),
+                ED_SHORTCUT(
+                    "scene_tree/delete",
+                    TTR("Delete Node"),
+                    KEY_DELETE
+                ),
+                TOOL_ERASE
+            );
+        } else {
+            menu->add_icon_shortcut(
+                get_icon("Remove", "EditorIcons"),
+                ED_SHORTCUT(
+                    "scene_tree/delete",
+                    TTR("Delete Nodes"),
+                    KEY_DELETE
+                ),
+                TOOL_ERASE
+            );
+        }
     }
     menu->set_size(Size2(1, 1));
     menu->set_position(p_menu_pos);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -292,45 +292,68 @@ bool SceneTreeEditor::_add_nodes(
             );
         }
 
-        int num_connections = p_node->get_persistent_signal_connection_count();
-        int num_groups      = p_node->get_persistent_group_count();
+        int connection_count = p_node->get_persistent_signal_connection_count();
+        int group_count      = p_node->get_persistent_group_count();
 
-        if (num_connections >= 1 && num_groups >= 1) {
-            item->add_button(
-                0,
-                get_icon("SignalsAndGroups", "EditorIcons"),
-                BUTTON_SIGNALS,
-                false,
-                vformat(
-                    TTR("Node has %s connection(s) and %s group(s).\nClick to "
-                        "show signals dock."),
-                    num_connections,
-                    num_groups
-                )
-            );
-        } else if (num_connections >= 1) {
-            item->add_button(
-                0,
-                get_icon("Signals", "EditorIcons"),
-                BUTTON_SIGNALS,
-                false,
-                vformat(
-                    TTR("Node has %s connection(s).\nClick to show signals "
-                        "dock."),
-                    num_connections
-                )
-            );
-        } else if (num_groups >= 1) {
-            item->add_button(
-                0,
-                get_icon("Groups", "EditorIcons"),
-                BUTTON_GROUPS,
-                false,
-                vformat(
-                    TTR("Node is in %s group(s).\nClick to show groups dock."),
-                    num_groups
-                )
-            );
+        String tool_tip;
+        if (connection_count == 0) {
+            if (group_count == 0) {
+                // No signal connections or groups.
+            } else if (group_count == 1) {
+                tool_tip = TTR("Node is in a group.");
+            } else { // group_count > 1
+                tool_tip = vformat(TTR("Node is in %d groups."), group_count);
+            }
+        } else if (connection_count == 1) {
+            if (group_count == 0) {
+                tool_tip = TTR("Node has a signal connection.");
+            } else if (group_count == 1) {
+                tool_tip =
+                    TTR("Node has a signal connection and is in a group");
+            } else { // group_count > 1
+                tool_tip = vformat(
+                    TTR("Node has a signal connection and is in %d groups"),
+                    group_count
+                );
+            }
+        } else { // connection_count > 1
+            if (group_count == 0) {
+                tool_tip = vformat(
+                    TTR("Node has %d signal connections"),
+                    connection_count
+                );
+            } else if (group_count == 1) {
+                tool_tip = vformat(
+                    TTR("Node has %d signal connections and is in a group"),
+                    connection_count
+                );
+            } else { // group_count > 1
+                tool_tip = vformat(
+                    TTR("Node has %d signal connections and is in %d groups"),
+                    connection_count,
+                    group_count
+                );
+            }
+        }
+
+        Ref<Texture> button_icon;
+        int button_id = BUTTON_SIGNALS;
+        if (connection_count > 0 && group_count > 0) {
+            button_icon  = get_icon("SignalsAndGroups", "EditorIcons");
+            tool_tip    += "\nClick to show signals dock.";
+        } else if (connection_count > 0) {
+            button_icon  = get_icon("Signals", "EditorIcons");
+            tool_tip    += "\nClick to show signals dock.";
+        } else if (group_count > 0) {
+            button_icon  = get_icon("Groups", "EditorIcons");
+            button_id    = BUTTON_GROUPS;
+            tool_tip    += "\nClick to show groups dock.";
+        } else {
+            // No signal connections or groups.
+        }
+
+        if (connection_count > 0 || group_count > 0) {
+            item->add_button(0, button_icon, button_id, false, tool_tip);
         }
     }
 

--- a/modules/gdscript/docs/@GDScript.xml
+++ b/modules/gdscript/docs/@GDScript.xml
@@ -61,9 +61,9 @@ SPDX-License-Identifier: MIT
             <description>
                 Returns the arc cosine of [code]s[/code] in radians. Use to get the angle of cosine [code]s[/code]. [code]s[/code] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method acos] will return [constant NAN].
                 [codeblock]
-                # c is 0.523599 or 30 degrees if converted with rad2deg(s)
                 c = acos(0.866025)
                 [/codeblock]
+                [code]s[/code] is 0.523599 or 30 degrees if converted with [method rad2deg]
             </description>
         </method>
         <method name="asin">
@@ -72,9 +72,9 @@ SPDX-License-Identifier: MIT
             <description>
                 Returns the arc sine of [code]s[/code] in radians. Use to get the angle of sine [code]s[/code]. [code]s[/code] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method asin] will return [constant NAN].
                 [codeblock]
-                # s is 0.523599 or 30 degrees if converted with rad2deg(s)
                 s = asin(0.5)
                 [/codeblock]
+                [code]s[/code] is 0.523599 or 30 degrees if converted with [method rad2deg]
             </description>
         </method>
         <method name="assert">
@@ -297,7 +297,7 @@ SPDX-License-Identifier: MIT
                 a = floor(-2.99) # a is -3.0
                 [/codeblock]
                 See also [method ceil], [method round], [method stepify], and [int].
-                [b]Note:[/b] This method returns a float. If you need an integer and [code]s[/code] is a non-negative number, you can use [code]int(s)[/code] directly.
+                [b]Note:[/b] This method returns a float. If you need an integer and [code]s[/code] is a non-negative number, you can use [int][code](s)[/code] directly.
             </description>
         </method>
         <method name="fmod">

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3148,7 +3148,11 @@ void VisualScriptEditor::drop_data_fw(
         int new_id = script->get_available_id();
 
         if (files.size()) {
-            undo_redo->create_action(TTR("Add Node(s)"));
+            if (files.size() == 1) {
+                undo_redo->create_action(TTR("Add Node)"));
+            } else {
+                undo_redo->create_action(TTR("Add Nodes)"));
+            }
 
             for (int i = 0; i < files.size(); i++) {
                 Ref<Resource> res = ResourceLoader::load(files[i]);
@@ -3243,7 +3247,11 @@ void VisualScriptEditor::drop_data_fw(
 
         Vector2 pos = _get_pos_in_graph(p_point);
 
-        undo_redo->create_action(TTR("Add Node(s) From Tree"));
+        if (nodes.size() == 1) {
+            undo_redo->create_action(TTR("Add Node from Tree"));
+        } else {
+            undo_redo->create_action(TTR("Add Nodes from Tree"));
+        }
         int base_id = script->get_available_id();
 
         if (use_node || nodes.size() > 1) {
@@ -3841,7 +3849,7 @@ static bool _get_in_slot(
 }
 
 void VisualScriptEditor::_begin_node_move() {
-    undo_redo->create_action(TTR("Move Node(s)"));
+    undo_redo->create_action(TTR("Move Node"));
 }
 
 void VisualScriptEditor::_end_node_move() {


### PR DESCRIPTION
As identified by [Weblate](https://hosted.weblate.org/translate/rebel-toolbox/rebel-editor/en/?q=check:optional_plural), the Rebel Engine API and Rebel Editor documentation contain a number of plural abbreviations (also known as optional plurals) e.g. "file(s)"; instead of the noun phrase "file or files". Not only is this bad writing practice, it can be problematic in translations, when a language may not have a simple plural form that can be abbreviated the same way.

This PR removes all plural abbreviations in the Rebel Engine API and Rebel Editor. In the Rebel Engine API, it was simpler and tidier to only use the singular or plural where appropriate instead of the noun phrase. In the Rebel Editor, it was generally better to programmatically detect when the singular and plural should be used and use the correct form.