### PR TITLE
Fix automated branch rebase failure

### DIFF
--- a/.github/workflows/update-ca-bundle.yaml
+++ b/.github/workflows/update-ca-bundle.yaml
@@ -28,7 +28,13 @@ jobs:
         working-directory: RebelEngine
         run: |
           #Create branch
+          echo "::group::git config"
+          git config user.name "Rebel Bot"
+          git config user.email "RebelToolboxBot@users.noreply.github.com"
+          echo "::endgroup::"
+          echo "::group::git fetch origin"
           git fetch origin
+          echo "::endgroup::"
           echo "::group::git switch main"
           if ! git switch main 2>/dev/null ; then
             git switch -c main origin/main
@@ -94,8 +100,6 @@ jobs:
         if: env.has_changes == 'yes'
         run: |
           #Create commit
-          git config user.name "Rebel Bot"
-          git config user.email "RebelToolboxBot@users.noreply.github.com"
           echo "Adding files..."
           git add .
           echo "Creating commit..."

--- a/.github/workflows/update-translations.yaml
+++ b/.github/workflows/update-translations.yaml
@@ -26,7 +26,13 @@ jobs:
       - name: Create branch
         run: |
           #Create branch
+          echo "::group::git config"
+          git config user.name "Rebel Documentation"
+          git config user.email "158277139+RebelDocumentation@users.noreply.github.com"
+          echo "::endgroup::"
+          echo "::group::git fetch origin"
           git fetch origin
+          echo "::endgroup::"
           echo "::group::git switch main"
           if ! git switch main 2>/dev/null ; then
             git switch -c main origin/main
@@ -97,8 +103,6 @@ jobs:
         if: env.has_changes == 'yes'
         run: |
           #Create commit
-          git config user.name "Rebel Documentation"
-          git config user.email "158277139+RebelDocumentation@users.noreply.github.com"
           echo "Adding files"
           git add .
           echo "Creating commit"


### PR DESCRIPTION
In our automated workflows that create pull requests, we try to reuse existing branches. We also rebase these branches to ensure there are no conflicts. However, if the branch has a commit, the rebasing fails with:
```
  Rebasing (1/1)
  Committer identity unknown
  
  *** Please tell me who you are.
  
  Run
  
    git config --global user.email "you@example.com"
    git config --global user.name "Your Name"
  
  to set your account's default identity.
  Omit --global to set the identity only in this repository.
  
  fatal: empty ident name (for <runner@runnervmvrwv9.zrqr2oex231ezjigm0txkepa0a.cx.internal.cloudapp.net>) not allowed
```
This failure results in the existing branch being unnecessarily deleted and recreated.

Currently, we only define the user identity when creating the commit, but it's also needed when rebasing existing commits. This PR moves the definition of the user identity to be the first calls to git in the affected automated workflows.