### PR TITLE
Convert functions inside unnamed namespaces to static functions

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -10,8 +10,7 @@
 #include "core/os/keyboard.h"
 #include "core/variant_parser.h"
 
-namespace {
-FileAccessEncrypted* get_file_access_encrypted(
+static FileAccessEncrypted* get_file_access_encrypted(
     Error& error,
     FileAccess* file_access,
     const FileAccessEncrypted::Mode& mode,
@@ -28,7 +27,7 @@ FileAccessEncrypted* get_file_access_encrypted(
     return file_access_encrypted;
 }
 
-Error load_stream(
+static Error load_stream(
     ConfigFile& config_file,
     VariantParser::Stream& stream,
     const String& source_name
@@ -75,7 +74,7 @@ Error load_stream(
     return error;
 }
 
-Error load_file_access(
+static Error load_file_access(
     ConfigFile& config_file,
     FileAccess* file_access,
     const String& source_name
@@ -85,7 +84,7 @@ Error load_file_access(
     return load_stream(config_file, stream, source_name);
 }
 
-void save_file_access(
+static void save_file_access(
     const OrderedHashMap<String, OrderedHashMap<String, Variant>>& values,
     FileAccess* file
 ) {
@@ -107,7 +106,7 @@ void save_file_access(
     }
 }
 
-Error load_file(
+static Error load_file(
     ConfigFile& config_file,
     const String& path,
     const String& password     = String(),
@@ -143,7 +142,7 @@ Error load_file(
     return error;
 }
 
-Error save_file(
+static Error save_file(
     const OrderedHashMap<String, OrderedHashMap<String, Variant>>& values,
     const String& path,
     const String& password     = String(),
@@ -178,7 +177,6 @@ Error save_file(
     memdelete(file_access);
     return OK;
 }
-} // namespace
 
 Variant ConfigFile::get_value(
     const String& section,

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -52,8 +52,7 @@
 #define MIN_FOV 0.01
 #define MAX_FOV 179
 
-namespace {
-constexpr real_t lerp_weight_from_inertia(real_t inertia, real_t delta) {
+static constexpr real_t lerp_weight_from_inertia(real_t inertia, real_t delta) {
     // A higher inertia should increase lag, which requires a lower lerp weight.
     // An inertia of zero should produce instant movement: a lerp weight of 1.
     if (inertia == 0.0) {
@@ -65,7 +64,6 @@ constexpr real_t lerp_weight_from_inertia(real_t inertia, real_t delta) {
     }
     return weight;
 }
-} // namespace
 
 void ViewportRotationControl::_notification(int p_what) {
     if (p_what == NOTIFICATION_ENTER_TREE) {

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -449,22 +449,16 @@ void TileMapEditor::_sbox_input(const Ref<InputEvent>& p_ie) {
     }
 }
 
-// Implementation detail of TileMapEditor::_update_palette();
-// In modern C++ this could have been inside its body.
-namespace {
-struct _PaletteEntry {
-    int id;
-    String name;
-
-    bool operator<(const _PaletteEntry& p_rhs) const {
-        // Natural no case comparison will compare strings based on CharType
-        // order (except digits) and on numbers that start on the same position.
-        return name.naturalnocasecmp_to(p_rhs.name) < 0;
-    }
-};
-} // namespace
-
 void TileMapEditor::_update_palette() {
+    struct PaletteEntry {
+        int id = 0;
+        String name;
+
+        bool operator<(const PaletteEntry& p_rhs) const {
+            return name.naturalnocasecmp_to(p_rhs.name) < 0;
+        }
+    };
+
     if (!node) {
         return;
     }
@@ -520,7 +514,7 @@ void TileMapEditor::_update_palette() {
 
     String filter = search_box->get_text().strip_edges();
 
-    Vector<_PaletteEntry> entries;
+    Vector<PaletteEntry> entries;
 
     for (List<int>::Element* E = tiles.front(); E; E = E->next()) {
         String name = tileset->tile_get_name(E->get());
@@ -541,7 +535,7 @@ void TileMapEditor::_update_palette() {
             continue;
         }
 
-        const _PaletteEntry entry = {E->get(), name};
+        const PaletteEntry entry = {E->get(), name};
         entries.push_back(entry);
     }
 

--- a/modules/fbx/fbx_parser/FBXBinaryTokenizer.cpp
+++ b/modules/fbx/fbx_parser/FBXBinaryTokenizer.cpp
@@ -58,7 +58,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 
 namespace FBXDocParser {
-// ------------------------------------------------------------------------------------------------
 Token::Token(
     const char* sbegin,
     const char* send,
@@ -77,25 +76,20 @@ Token::Token(
     // measure from sBegin to sEnd and validate?
 }
 
-namespace {
-
-// ------------------------------------------------------------------------------------------------
-// signal tokenization error
-void TokenizeError(const std::string& message, size_t offset) {
+static void TokenizeError(const std::string& message, size_t offset) {
     print_error(
         "[FBX-Tokenize] " + String(message.c_str()) + ", offset " + itos(offset)
     );
 }
 
 // ------------------------------------------------------------------------------------------------
-size_t Offset(const char* begin, const char* cursor) {
+static size_t Offset(const char* begin, const char* cursor) {
     // ai_assert(begin <= cursor);
 
     return cursor - begin;
 }
 
-// ------------------------------------------------------------------------------------------------
-void TokenizeError(
+static void TokenizeError(
     const std::string& message,
     const char* begin,
     const char* cursor
@@ -103,8 +97,11 @@ void TokenizeError(
     TokenizeError(message, Offset(begin, cursor));
 }
 
-// ------------------------------------------------------------------------------------------------
-uint32_t ReadWord(const char* input, const char*& cursor, const char* end) {
+static uint32_t ReadWord(
+    const char* input,
+    const char*& cursor,
+    const char* end
+) {
     const size_t k_to_read = sizeof(uint32_t);
     if (Offset(cursor, end) < k_to_read) {
         TokenizeError("cannot ReadWord, out of bounds", input, cursor);
@@ -119,8 +116,7 @@ uint32_t ReadWord(const char* input, const char*& cursor, const char* end) {
     return word;
 }
 
-// ------------------------------------------------------------------------------------------------
-uint64_t ReadDoubleWord(
+static uint64_t ReadDoubleWord(
     const char* input,
     const char*& cursor,
     const char* end
@@ -139,8 +135,11 @@ uint64_t ReadDoubleWord(
     return dword;
 }
 
-// ------------------------------------------------------------------------------------------------
-uint8_t ReadByte(const char* input, const char*& cursor, const char* end) {
+static uint8_t ReadByte(
+    const char* input,
+    const char*& cursor,
+    const char* end
+) {
     if (Offset(cursor, end) < sizeof(uint8_t)) {
         TokenizeError("cannot ReadByte, out of bounds", input, cursor);
     }
@@ -152,8 +151,7 @@ uint8_t ReadByte(const char* input, const char*& cursor, const char* end) {
     return word;
 }
 
-// ------------------------------------------------------------------------------------------------
-unsigned int ReadString(
+static unsigned int ReadString(
     const char*& sbegin_out,
     const char*& send_out,
     const char* input,
@@ -202,8 +200,7 @@ unsigned int ReadString(
     return length;
 }
 
-// ------------------------------------------------------------------------------------------------
-void ReadData(
+static void ReadData(
     const char*& sbegin_out,
     const char*& send_out,
     const char* input,
@@ -352,8 +349,7 @@ void ReadData(
     send_out = cursor;
 }
 
-// ------------------------------------------------------------------------------------------------
-bool ReadScope(
+static bool ReadScope(
     TokenList& output_tokens,
     const char* input,
     const char*& cursor,
@@ -485,9 +481,6 @@ bool ReadScope(
     return true;
 }
 
-} // anonymous namespace
-
-// ------------------------------------------------------------------------------------------------
 // TODO: Test FBX Binary files newer than the 7500 version to check if the 64
 // bits address behaviour is consistent
 void TokenizeBinary(

--- a/modules/fbx/fbx_parser/FBXParser.cpp
+++ b/modules/fbx/fbx_parser/FBXParser.cpp
@@ -63,15 +63,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h> /* strtol */
 #include <zlib.h>
 
-using namespace FBXDocParser;
-
-namespace {
+namespace FBXDocParser {
 
 // Initially, we did reinterpret_cast, breaking strict aliasing rules.
 // This actually caused trouble on Android, so let's be safe this time.
 // https://github.com/assimp/assimp/issues/24
 template <typename T>
-T SafeParse(const char* data, const char* end) {
+static T SafeParse(const char* data, const char* end) {
     // Actual size validation happens during Tokenization so
     // this is valid as an assertion.
     (void)(end);
@@ -80,9 +78,6 @@ T SafeParse(const char* data, const char* end) {
     ::memcpy(&result, data, sizeof(T));
     return result;
 }
-} // namespace
-
-namespace FBXDocParser {
 
 // ------------------------------------------------------------------------------------------------
 Element::Element(const TokenPtr key_token, Parser& parser) :
@@ -509,11 +504,8 @@ std::string ParseTokenAsString(const TokenPtr t, const char*& err_out) {
     return std::string(s + 1, length - 2);
 }
 
-namespace {
-
-// ------------------------------------------------------------------------------------------------
 // read the type code and element count of a binary data array and stop there
-void ReadBinaryDataArrayHead(
+static void ReadBinaryDataArrayHead(
     const char*& data,
     const char* end,
     char& type,
@@ -540,10 +532,9 @@ void ReadBinaryDataArrayHead(
     data  += 5;
 }
 
-// ------------------------------------------------------------------------------------------------
 // read binary data array, assume cursor points to the 'compression mode' field
 // (i.e. behind the header)
-void ReadBinaryDataArray(
+static void ReadBinaryDataArray(
     char type,
     uint32_t count,
     const char*& data,
@@ -625,9 +616,6 @@ void ReadBinaryDataArray(
     // ai_assert(data == end);
 }
 
-} // namespace
-
-// ------------------------------------------------------------------------------------------------
 // read an array of float3 tuples
 void ParseVectorDataArray(std::vector<Vector3>& out, const ElementPtr el) {
     out.resize(0);

--- a/modules/fbx/fbx_parser/FBXProperties.cpp
+++ b/modules/fbx/fbx_parser/FBXProperties.cpp
@@ -66,12 +66,9 @@ Property::Property() {}
 // ------------------------------------------------------------------------------------------------
 Property::~Property() {}
 
-namespace {
-
-// ------------------------------------------------------------------------------------------------
 // read a typed property out of a FBX element. The return value is NULL if the
 // property cannot be read.
-PropertyPtr ReadTypedProperty(const ElementPtr element) {
+static PropertyPtr ReadTypedProperty(const ElementPtr element) {
     // ai_assert(element.KeyToken().StringContents() == "P");
 
     const TokenList& tok = element->Tokens();
@@ -109,10 +106,9 @@ PropertyPtr ReadTypedProperty(const ElementPtr element) {
     return nullptr;
 }
 
-// ------------------------------------------------------------------------------------------------
 // peek into an element and check if it contains a FBX property, if so return
 // its name.
-std::string PeekPropertyName(const Element& element) {
+static std::string PeekPropertyName(const Element& element) {
     // ai_assert(element.KeyToken().StringContents() == "P");
     const TokenList& tok = element.Tokens();
     if (tok.size() < 4) {
@@ -122,9 +118,6 @@ std::string PeekPropertyName(const Element& element) {
     return ParseTokenAsString(tok[0]);
 }
 
-} // namespace
-
-// ------------------------------------------------------------------------------------------------
 PropertyTable::PropertyTable() : templateProps(), element() {}
 
 // ------------------------------------------------------------------------------------------------

--- a/modules/fbx/fbx_parser/FBXTokenizer.cpp
+++ b/modules/fbx/fbx_parser/FBXTokenizer.cpp
@@ -59,7 +59,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace FBXDocParser {
 
-// ------------------------------------------------------------------------------------------------
 Token::Token(
     const char* p_sbegin,
     const char* p_send,
@@ -77,13 +76,9 @@ Token::Token(
 #endif
 }
 
-// ------------------------------------------------------------------------------------------------
 Token::~Token() {}
 
-namespace {
-
-// ------------------------------------------------------------------------------------------------
-void TokenizeError(
+static void TokenizeError(
     const std::string& message,
     unsigned int line,
     unsigned int column
@@ -95,8 +90,7 @@ void TokenizeError(
 }
 
 // process a potential data token up to 'cur', adding it to 'output_tokens'.
-// ------------------------------------------------------------------------------------------------
-void ProcessDataToken(
+static void ProcessDataToken(
     TokenList& output_tokens,
     const char*& start,
     const char*& end,
@@ -136,9 +130,6 @@ void ProcessDataToken(
     start = end = nullptr;
 }
 
-} // namespace
-
-// ------------------------------------------------------------------------------------------------
 void Tokenize(TokenList& output_tokens, const char* input, size_t length) {
     // line and column numbers numbers are one-based
     unsigned int line   = 1;

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -11,9 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-namespace {
-
-int sfind(const String& p_text, int p_from) {
+static int sfind(const String& p_text, int p_from) {
     if (p_from < 0) {
         return -1;
     }
@@ -60,7 +58,6 @@ int sfind(const String& p_text, int p_from) {
 
     return -1;
 }
-} // namespace
 
 String sformat(
     const String& p_text,

--- a/modules/noise_texture/open_simplex_noise.cpp
+++ b/modules/noise_texture/open_simplex_noise.cpp
@@ -6,12 +6,10 @@
 
 #include "open_simplex_noise.h"
 
-namespace {
-constexpr uint8_t byte_from_noise(const double noise) {
+static constexpr uint8_t byte_from_noise(const double noise) {
     // Convert noise value [-1:1] to byte [0:255].
     return static_cast<uint8_t>(CLAMP((noise + 1) / 2 * 255, 0, 255));
 }
-} // namespace
 
 OpenSimplexNoise::OpenSimplexNoise() {
     initialise_contexts();

--- a/projects_manager/extract_zip_file_dialog.cpp
+++ b/projects_manager/extract_zip_file_dialog.cpp
@@ -14,8 +14,7 @@
 #include "editor/editor_themes.h"
 #include "scene/gui/container.h"
 
-namespace {
-String get_zipped_project_folder(const unzFile& unz_file) {
+static String get_zipped_project_folder(const unzFile& unz_file) {
     int error = unzGoToFirstFile(unz_file);
     while (error == UNZ_OK) {
         unz_file_info file_info;
@@ -39,7 +38,7 @@ String get_zipped_project_folder(const unzFile& unz_file) {
     return {};
 }
 
-void create_folder(
+static void create_folder(
     const String& folder_path,
     const String& zipped_project_folder,
     const String& project_folder
@@ -51,7 +50,7 @@ void create_folder(
     memdelete(dir_access);
 }
 
-void uncompress_file(
+static void uncompress_file(
     const unzFile& unz_file,
     const String& file_name,
     const unsigned long uncompressed_size,
@@ -74,7 +73,7 @@ void uncompress_file(
     }
 }
 
-void unzip_project_files(
+static void unzip_project_files(
     const unzFile& unz_file,
     const String& zipped_project_folder,
     const String& project_folder
@@ -111,7 +110,6 @@ void unzip_project_files(
         error = unzGoToNextFile(unz_file);
     }
 }
-} // namespace
 
 ExtractZipFileDialog::ExtractZipFileDialog() {
     set_theme(create_custom_theme());

--- a/projects_manager/import_project.cpp
+++ b/projects_manager/import_project.cpp
@@ -9,8 +9,7 @@
 #include "core/project_settings.h"
 #include "core/ustring.h"
 
-namespace {
-bool create_rebel_project_from_godot_project(
+static bool create_rebel_project_from_godot_project(
     const String& source_project_file,
     const String& destination_folder
 ) {
@@ -55,7 +54,7 @@ bool create_rebel_project_from_godot_project(
     return true;
 }
 
-void convert_physics_engine(const String& project_file) {
+static void convert_physics_engine(const String& project_file) {
     const String physics_section = "physics";
     ConfigFile config_file;
     config_file.load(project_file);
@@ -79,7 +78,6 @@ void convert_physics_engine(const String& project_file) {
 
     config_file.save(project_file);
 }
-} // namespace
 
 namespace ImportProject {
 bool import_godot_project(

--- a/projects_manager/new_project_dialog.cpp
+++ b/projects_manager/new_project_dialog.cpp
@@ -18,8 +18,7 @@
 #include "drivers/gles3/rasterizer_gles3.h"
 #endif // SERVER_ENABLED
 
-namespace {
-bool create_project(
+static bool create_project(
     const String& project_folder,
     const ProjectSettings::CustomSettings& project_settings
 ) {
@@ -61,7 +60,6 @@ bool create_project(
 
     return true;
 }
-} // namespace
 
 NewProjectDialog::NewProjectDialog() {
     set_theme(create_custom_theme());

--- a/projects_manager/projects_list.cpp
+++ b/projects_manager/projects_list.cpp
@@ -15,8 +15,7 @@
 #include "scene/gui/label.h"
 #include "scene/gui/panel_container.h"
 
-namespace {
-Set<String> get_favorites(List<PropertyInfo>& properties) {
+static Set<String> get_favorites(List<PropertyInfo>& properties) {
     Set<String> favorites;
     for (List<PropertyInfo>::Element* E = properties.front(); E;
          E                              = E->next()) {
@@ -28,7 +27,6 @@ Set<String> get_favorites(List<PropertyInfo>& properties) {
     }
     return favorites;
 }
-} // namespace
 
 ProjectsList::ProjectsList() {
     set_theme(create_custom_theme());

--- a/projects_manager/projects_manager.cpp
+++ b/projects_manager/projects_manager.cpp
@@ -33,8 +33,7 @@
 #include "drivers/gles3/rasterizer_gles3.h"
 #endif
 
-namespace {
-void apply_editor_settings() {
+static void apply_editor_settings() {
     if (!EditorSettings::get_singleton()) {
         EditorSettings::create();
     }
@@ -77,7 +76,7 @@ void apply_editor_settings() {
     );
 }
 
-void apply_window_settings() {
+static void apply_window_settings() {
     OS* os = OS::get_singleton();
     os->set_min_window_size(Size2(750, 420) * EDSCALE);
     // TODO: Automatically resize hiDPI display windows on Windows and Linux.
@@ -89,7 +88,7 @@ void apply_window_settings() {
     os->set_low_processor_usage_mode(true);
 }
 
-void create_project_directories() {
+static void create_project_directories() {
     DirAccessRef dir_access =
         DirAccess::create(DirAccess::AccessType::ACCESS_FILESYSTEM);
 
@@ -116,7 +115,10 @@ void create_project_directories() {
     }
 }
 
-void edit_project(const String& project_name, const String& project_folder) {
+static void edit_project(
+    const String& project_name,
+    const String& project_folder
+) {
     print_line(vformat("Editing project: %s (%s)", project_name, project_folder)
     );
     OS* os = OS::get_singleton();
@@ -139,7 +141,10 @@ void edit_project(const String& project_name, const String& project_folder) {
     ERR_FAIL_COND(error);
 }
 
-void run_project(const String& project_name, const String& project_folder) {
+static void run_project(
+    const String& project_name,
+    const String& project_folder
+) {
     print_line(vformat("Running project: %s (%s)", project_name, project_folder)
     );
     OS* os = OS::get_singleton();
@@ -154,7 +159,6 @@ void run_project(const String& project_name, const String& project_folder) {
     Error error       = os->execute(exec, args, false, &pid);
     ERR_FAIL_COND(error);
 }
-} // namespace
 
 ProjectsManager::ProjectsManager() {
     apply_editor_settings();


### PR DESCRIPTION
Converts functions inside unnamed `namespace`s to `static` functions.

Although there was initially a move to use unnamed `namepace`s, because "The use of the static keyword [was] deprecated when declaring objects in a namespace scope, the unnamed-namespace provides a superior alternative."[1], the deprecation was reversed [[2](https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1012)] for the C++11 standard. Putting functions inside an unnamed `namespace` or declaring them `static` has the same effect: keeping them inside the translation unit. However, declaring each function `static` has the advantage of making it immediately obvious the function can only be used inside the translation unit. Whereas, the declaration of the unnamed `namespace` may not be visible and hence it may not be immediately obvious that the function can only be used inside the translation unit; especially when the unnamed `namespace` contains multiple functions.

**Note:** Unnamed `namespace`s are still required for for declaring types that are only used inside the translation unit. However, this PR does include moving the `PaletteEntry` `struct` inside the only function that uses it.

References:
[1]  The C++03 Standard, section 7.3.1.1/2
[2] https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1012