### PR TITLE
Fix invalid export presets in imported projects

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1681,8 +1681,14 @@ void EditorExport::load_config() {
         }
 
         if (!preset.is_valid()) {
-            index++;
-            ERR_CONTINUE(!preset.is_valid());
+            ERR_CONTINUE_MSG(
+                !preset.is_valid(),
+                vformat(
+                    "Export preset %d: %s name not recognized.",
+                    index++,
+                    platform
+                )
+            );
         }
 
         preset->set_name(config->get_value(section, "name"));

--- a/projects_manager/import_project.cpp
+++ b/projects_manager/import_project.cpp
@@ -81,6 +81,50 @@ void convert_physics_engine(const String& project_file) {
 }
 } // namespace
 
+static void update_export_presets(const String& destination_folder) {
+    const String export_presets_file =
+        destination_folder.plus_file("export_presets.cfg");
+    ConfigFile export_presets;
+    if (export_presets.load(export_presets_file) != OK) {
+        return;
+    }
+    Vector<Pair<String, String>> platform_renames;
+    platform_renames.push_back(Pair<String, String>("Linux/X11", "Linux"));
+    platform_renames.push_back(Pair<String, String>("HTML5", "Web"));
+    platform_renames.push_back(Pair<String, String>("Mac OSX", "MacOS"));
+
+    const String preset_section("preset.");
+    const String name("name");
+    const String platform("platform");
+    bool export_presets_updated = false;
+    bool section_found          = true;
+    int section_index           = 0;
+    while (section_found) {
+        const String section = preset_section + itos(section_index++);
+        if (!export_presets.has_section(section)) {
+            section_found = false;
+            continue;
+        }
+        for (int i = 0; i < platform_renames.size(); i++) {
+            const Pair<String, String>& platform_rename = platform_renames[i];
+            String old_name                             = platform_rename.first;
+            if (export_presets.get_value(section, name) == old_name
+                && export_presets.get_value(section, platform) == old_name) {
+                String new_name = platform_rename.second;
+                export_presets.set_value(section, name, new_name);
+                export_presets.set_value(section, platform, new_name);
+                export_presets_updated = true;
+            }
+        }
+    }
+    if (export_presets_updated) {
+        ERR_FAIL_COND_MSG(
+            export_presets.save(export_presets_file) != OK,
+            "Failed to update export_presets.cfg"
+        );
+    }
+}
+
 namespace ImportProject {
 bool import_godot_project(
     const String& source_project_file,
@@ -95,6 +139,7 @@ bool import_godot_project(
     );
     const String project_file = destination_folder.plus_file("project.rebel");
     convert_physics_engine(project_file);
+    update_export_presets(destination_folder);
     return true;
 }
 } // namespace ImportProject


### PR DESCRIPTION
Currently, when opening an imported project in the editor, it may raise the following error:
```
ERROR: Condition "!preset.is_valid()" is true. Continuing.
   at: load_config (editor/editor_export.cpp:1685)
```
This error is raised when reading the project's `export_presets.cfg` file, and the name of the preset does not match a known platform name. The result is some export presets are not shown in the editor.

#80 included renaming the project export presets. When opening the project, presets using the old names fail to load. This can be fixed manually by opening the `export_presets.cfg` file and renaming the presets to match the new names.

This PR prevents this from occurring in the future by adding updates to a project's `export_presets.cfg` file when a project is imported. In addition, it updates the error message, to make it make the error clearer should this problem occur again in the future.