### PR TITLE
Provide IDE support for modules with third-party includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,8 @@
 cmake_minimum_required(VERSION 3.18)
 project(RebelEngine)
 
-file(GLOB_RECURSE HEADERS **/*.h)
-file(GLOB_RECURSE SOURCES
-        **/*.c
-        **/*.cpp
-)
-include_directories(.)
-add_library(${PROJECT_NAME} STATIC ${SOURCES})
+file(GLOB_RECURSE project_source_files *.c *.cpp)
+# Modules include third-party libraries that expect different header search paths.
+add_subdirectory(modules)
+add_executable(${PROJECT_NAME} ${project_source_files})
+target_include_directories(${PROJECT_NAME} PRIVATE .)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,0 +1,34 @@
+# CMakeLists.txt used for IDE support.
+
+# Changes to project source files need to be applied to the parent directory.
+set(parent_source_files ${project_source_files})
+
+# Add modules that build third-party libraries.
+add_subdirectory(bullet)
+add_subdirectory(cvtt)
+add_subdirectory(enet)
+add_subdirectory(etc)
+add_subdirectory(freetype)
+add_subdirectory(jpg)
+add_subdirectory(mbedtls)
+add_subdirectory(minimp3)
+add_subdirectory(noise_texture)
+add_subdirectory(ogg)
+add_subdirectory(pvr)
+add_subdirectory(raycast)
+add_subdirectory(recast)
+add_subdirectory(regex)
+add_subdirectory(squish)
+add_subdirectory(stb_vorbis)
+add_subdirectory(svg)
+add_subdirectory(theora)
+add_subdirectory(tinyexr)
+add_subdirectory(upnp)
+add_subdirectory(vhacd)
+add_subdirectory(vorbis)
+add_subdirectory(webp)
+add_subdirectory(websocket)
+add_subdirectory(xatlas_unwrap)
+
+# Apply changes to project source files.
+set(project_source_files ${parent_source_files} PARENT_SCOPE)

--- a/modules/bullet/CMakeLists.txt
+++ b/modules/bullet/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(bullet EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(bullet PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(bullet PRIVATE ${CMAKE_SOURCE_DIR}/third-party/bullet)

--- a/modules/cvtt/CMakeLists.txt
+++ b/modules/cvtt/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(cvtt EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(cvtt PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(cvtt PRIVATE ${CMAKE_SOURCE_DIR}/third-party/cvtt)

--- a/modules/enet/CMakeLists.txt
+++ b/modules/enet/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(enet EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(enet PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(enet PRIVATE ${CMAKE_SOURCE_DIR}/third-party/enet)

--- a/modules/etc/CMakeLists.txt
+++ b/modules/etc/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(etc EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(etc PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(etc PRIVATE ${CMAKE_SOURCE_DIR}/third-party/etc2comp)

--- a/modules/freetype/CMakeLists.txt
+++ b/modules/freetype/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(freetype EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(freetype PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(freetype PRIVATE ${CMAKE_SOURCE_DIR}/third-party/freetype/include)

--- a/modules/jpg/CMakeLists.txt
+++ b/modules/jpg/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(jpg EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(jpg PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(jpg PRIVATE ${CMAKE_SOURCE_DIR}/third-party/jpeg-compressor)

--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(mbedtls EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(mbedtls PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(mbedtls PRIVATE ${CMAKE_SOURCE_DIR}/third-party/mbedtls/include)

--- a/modules/minimp3/CMakeLists.txt
+++ b/modules/minimp3/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(minimp3 EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(minimp3 PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(minimp3 PRIVATE ${CMAKE_SOURCE_DIR}/third-party/minimp3)

--- a/modules/noise_texture/CMakeLists.txt
+++ b/modules/noise_texture/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(noise_texture EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(noise_texture PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(noise_texture PRIVATE ${CMAKE_SOURCE_DIR}/third-party/open_simplex_noise)

--- a/modules/ogg/CMakeLists.txt
+++ b/modules/ogg/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(ogg EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(ogg PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(ogg PRIVATE ${CMAKE_SOURCE_DIR}/third-party/libogg)

--- a/modules/pvr/CMakeLists.txt
+++ b/modules/pvr/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(pvr EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(pvr PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(pvr PRIVATE ${CMAKE_SOURCE_DIR}/third-party/pvrtccompressor)

--- a/modules/raycast/CMakeLists.txt
+++ b/modules/raycast/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(raycast EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(raycast PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(raycast PRIVATE ${CMAKE_SOURCE_DIR}/third-party/embree/include)

--- a/modules/recast/CMakeLists.txt
+++ b/modules/recast/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(recast EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(recast PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(recast PRIVATE ${CMAKE_SOURCE_DIR}/third-party/recastnavigation/Recast/Include)

--- a/modules/regex/CMakeLists.txt
+++ b/modules/regex/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(regex EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(regex PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(regex PRIVATE ${CMAKE_SOURCE_DIR}/third-party/pcre2/src)

--- a/modules/squish/CMakeLists.txt
+++ b/modules/squish/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(squish EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(squish PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(squish PRIVATE ${CMAKE_SOURCE_DIR}/third-party/libsquish)

--- a/modules/stb_vorbis/CMakeLists.txt
+++ b/modules/stb_vorbis/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(stb_vorbis EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(stb_vorbis PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(stb_vorbis PRIVATE ${CMAKE_SOURCE_DIR}/third-party/misc)

--- a/modules/svg/CMakeLists.txt
+++ b/modules/svg/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(svg EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(svg PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(svg PRIVATE ${CMAKE_SOURCE_DIR}/third-party/nanosvg)

--- a/modules/theora/CMakeLists.txt
+++ b/modules/theora/CMakeLists.txt
@@ -1,0 +1,20 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(theora EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(theora PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(theora PRIVATE ${CMAKE_SOURCE_DIR}/third-party/libogg)
+target_include_directories(theora PRIVATE ${CMAKE_SOURCE_DIR}/third-party/libtheora)
+target_include_directories(theora PRIVATE ${CMAKE_SOURCE_DIR}/third-party/libvorbis)
+target_include_directories(theora PRIVATE ${CMAKE_SOURCE_DIR}/third-party/yuv2rgb)

--- a/modules/tinyexr/CMakeLists.txt
+++ b/modules/tinyexr/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(tinyexr EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(tinyexr PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(tinyexr PRIVATE ${CMAKE_SOURCE_DIR}/third-party/tinyexr)

--- a/modules/upnp/CMakeLists.txt
+++ b/modules/upnp/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(upnp EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(upnp PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(upnp PRIVATE ${CMAKE_SOURCE_DIR}/third-party/miniupnp/miniupnpc/include)

--- a/modules/vhacd/CMakeLists.txt
+++ b/modules/vhacd/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(vhacd EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(vhacd PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(vhacd PRIVATE ${CMAKE_SOURCE_DIR}/third-party/vhacd/include)

--- a/modules/vorbis/CMakeLists.txt
+++ b/modules/vorbis/CMakeLists.txt
@@ -1,0 +1,18 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(vorbis EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(vorbis PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(vorbis PRIVATE ${CMAKE_SOURCE_DIR}/third-party/libvogg)
+target_include_directories(vorbis PRIVATE ${CMAKE_SOURCE_DIR}/third-party/libvorbis)

--- a/modules/webp/CMakeLists.txt
+++ b/modules/webp/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(webp EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(webp PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(webp PRIVATE ${CMAKE_SOURCE_DIR}/third-party/libwebp)

--- a/modules/websocket/CMakeLists.txt
+++ b/modules/websocket/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(websocket EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(websocket PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(websocket PRIVATE ${CMAKE_SOURCE_DIR}/third-party/wslay/includes)

--- a/modules/xatlas_unwrap/CMakeLists.txt
+++ b/modules/xatlas_unwrap/CMakeLists.txt
@@ -1,0 +1,17 @@
+# CMakeLists.txt used for IDE support.
+# Third-party libraries have different header search paths.
+
+file(GLOB_RECURSE module_source_files *.cpp)
+
+# We need to remove the module source files from the project source files.
+set(project_source_files_without_module_source_files ${parent_source_files})
+foreach (file ${module_source_files})
+    list(REMOVE_ITEM project_source_files_without_module_source_files ${file} PARENT_SCOPE)
+endforeach ()
+# Apply changes to the project source files to the parent directory.
+set(parent_source_files ${project_source_files_without_module_source_files} PARENT_SCOPE)
+
+add_library(xatlas EXCLUDE_FROM_ALL ${module_source_files})
+target_include_directories(xatlas PRIVATE ${CMAKE_SOURCE_DIR})
+# Add third-party library's header search paths.
+target_include_directories(xatlas PRIVATE ${CMAKE_SOURCE_DIR}/third-party/xatlas)


### PR DESCRIPTION
#269 created a basic `CMakeLists.txt` file to support [IDE](https://en.wikipedia.org/wiki/Integrated_development_environment)s (such as [Android Studio](https://developer.android.com/studio) and [JetBrains](https://www.jetbrains.com/)' [CLion](https://www.jetbrains.com/clion/)) that work natively with [CMake](https://cmake.org/) and expect a `CMakeLists.txt` file. This PR extends that support to modules that build third-party libraries.

We use [SCons](https://scons.org/) not CMake to build Rebel Engine. However, when developing modules that use third-party libraries, IDEs that use `CMakeLists.txt` files cannot find third-party library header files, because the third-party header search directories that are included in the SCons build files are not not included in the `CMakeLists.txt` file. For the IDEs that use `CMakeLists.txt` files, we need to add the third-party header directories to the `CMakeLists.txt` header search directories. However, the third-party header directories should only be added to the modules that build the third-party libraries. Therefore, we need to create a `CMakeLists.txt` file for each module that builds a third-party library. The `CMakeLists.txt` file for each module creates a library for that module and adds the third-party header directories to the header search path for that module.

To simplify things, we use [GLOB](https://cmake.org/cmake/help/latest/command/file.html#glob) to add all the C++ code files to the CMakeLists.txt file for the project; instead of listing each file individually. However, for this to work, the module's code files cannot be added to both the project and the module library. Therefore, we need to remove the module's code files from the projects list of code files. To keep this modular, this is done within each module's CMakeLists.txt file.