### PR TITLE
Increase Android's minimum SDK version from 21 to 23

### DIFF
--- a/platforms/android/export/export_plugin.cpp
+++ b/platforms/android/export/export_plugin.cpp
@@ -214,7 +214,7 @@ static const char* AAB_ASSETS_DIRECTORY =
 // Also update platforms/android/project/app/config.gradle:
 // - minSdk
 // - targetSdk
-static const int DEFAULT_MIN_SDK_VERSION    = 21;
+static const int DEFAULT_MIN_SDK_VERSION    = 23;
 static const int DEFAULT_TARGET_SDK_VERSION = 36;
 
 const String SDK_VERSION_RANGE = vformat(

--- a/platforms/android/project/app/config.gradle
+++ b/platforms/android/project/app/config.gradle
@@ -3,7 +3,7 @@ ext.versions = [
     // Also update platforms/android/export/export_plugin.cpp:
     // - DEFAULT_MIN_SDK_VERSION
     // - DEFAULT_TARGET_SDK_VERSION
-    minSdk             : 21,
+    minSdk             : 23,
     targetSdk          : 36,
     javaVersion        : 17,
     // Also update platforms/android/detect.py get_ndk_version()


### PR DESCRIPTION
The 10th September 2025 release of the AndroidX Jetpack libraries release notes[[1](https://developer.android.com/jetpack/androidx/versions/all-channel)] state:

_**Note:** Starting in June 2025, new releases of many AndroidX libraries previously targeting minSdk 21 will be updated to require minSdk 23. Some libraries won't be re-released and will therefore continue to support minSdk 21._

Until now the AndroidX libraries we've been using were able to continue using a minimum SDK version of 21. The upgrade of the AndroidX Fragment version from 1.8.9 to 1.9.0, requires the minimum SDK to be increased to 23.

[AndroidX](https://developer.android.com/jetpack/androidx/) libraries provide backward compatibility for new Android features across Android releases. However, the backward compatibility is limited to supporting 99% of devices. As identified in issue 380448311[[2](https://issuetracker.google.com/issues/380448311)]:

_As of 9/1/2024 data from Play Store users as shown in Android Studio, API 23+ accounts for 99.1% of users, API 24+ is 98.0% of users. Our desired support level is 99%, so we'll be picking API 23 as our next minSdk version._

API 21 is supported by all Android 5 (a.k.a. [Android Lollipop](https://en.wikipedia.org/wiki/Android_Lollipop)) devices and newer. API 23 is supported by all Android 6 (a.k.a. [Android Marshmallow](https://en.wikipedia.org/wiki/Android_Marshmallow)) devices and newer[[3](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels)]. Android Lollipop was released in November 2014. Android Marshmallow was released in September 2015[[4](https://en.wikipedia.org/wiki/Android_version_history)]. Therefore, increasing the minimum SDK supported from 21 to 23 will only affect devices released between these dates 11 and 12 years ago!

Although increasing the minimum SDK will reduce the number of users that can use Android games created with Rebel, the creators of the AndroidX libraries indicate that this will be insignificant. To enable us to continue to receive the latest updates to the AndroidX libraries, and to keep your Rebel games as secure and stable as possible for the vast majority of your users, this PR updates the the minimum SDK to 23 too.

References:
1. https://developer.android.com/jetpack/androidx/versions/all-channel
2. https://issuetracker.google.com/issues/380448311
3. https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels
4. https://en.wikipedia.org/wiki/Android_version_history

This PR increases the Android minimum SDK version from 21 to 23.
