### PR TITLE
Remove unused private fields

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1214,7 +1214,7 @@ NativeScriptLanguage::NativeScriptLanguage() {
     NativeScriptLanguage::singleton = this;
 
 #ifdef DEBUG_ENABLED
-    profiling = false;
+
 #endif
 
     _init_call_type      = "nativescript_init";
@@ -1451,7 +1451,6 @@ void NativeScriptLanguage::profiling_start() {
 #endif
 
     profile_data.clear();
-    profiling = true;
 #endif
 }
 
@@ -1461,7 +1460,6 @@ void NativeScriptLanguage::profiling_stop() {
     MutexLock lock(mutex);
 #endif
 
-    profiling = false;
 #endif
 }
 

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -280,7 +280,6 @@ private:
     };
 
     Map<StringName, ProfileData> profile_data;
-    bool profiling;
 
 public:
     // These two maps must only be touched on the main thread

--- a/platforms/android/android_audio_driver.h
+++ b/platforms/android/android_audio_driver.h
@@ -35,7 +35,6 @@ class AndroidAudioDriver : public AudioDriver {
     SLObjectItf sl;
     SLEngineItf EngineItf;
     SLObjectItf OutputMix;
-    SLVolumeItf volumeItf;
     SLObjectItf player;
     SLObjectItf recorder;
     SLAndroidSimpleBufferQueueItf bufferQueueItf;
@@ -44,7 +43,6 @@ class AndroidAudioDriver : public AudioDriver {
     SLDataFormat_PCM pcm;
     SLDataSink audioSink;
     SLDataLocator_OutputMix locator_outputmix;
-    SLBufferQueueState state;
 
     void _buffer_callback(SLAndroidSimpleBufferQueueItf queueItf);
 


### PR DESCRIPTION
With some versions of the [Clang](https://clang.llvm.org/) compiler, we are getting new unused private field warnings, for example:
```
  modules/gdnative/nativescript/nativescript.h:280:10: error: private field 'profiling' is not used [-Werror,-Wunused-private-field,44]
    280 |      bool profiling;
        |           ^
  1 error generated.
```
Since we treat warnings as errors, this PR removes these unused private fields.