### PR TITLE
Update release.yaml

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,12 +1,11 @@
 changelog:
-  exclude:
-    authors:
-      - dependabot
-      - github-actions
   categories:
     - title: Exciting New Features ✨
       labels:
         - "PR Type: New Feature"
+    - title: Breaking Changes ⚠️
+      labels:
+        - "PR Type: Breaking Change"
     - title: Bug Fixes 🐛
       labels:
         - "PR Type: Bug Fix"
@@ -16,9 +15,6 @@ changelog:
     - title: Maintenance Updates 🔧
       labels:
         - "PR Type: Maintenance"
-    - title: Breaking Changes ⚠️
-      labels:
-        - "PR Type: Breaking Change"
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
Currently, PRs with breaking changes have the [`PR Type: Breaking Change`](https://github.com/RebelToolbox/RebelEngine/issues?q=label%3A%22PR%20Type%3A%20Breaking%20Change%22) label. However, they are not all being listed under "Breaking Changes" in the automated release notes. This occurs when a PR has multiple labels. It will only be listed once, and it will appear in the first category that has a matching label.

In addition, the automatically generated release notes are not excluding PRs created by `dependabot` and `github-actions`. Although this is desired, the `release.yaml` file suggests that it isn't.

This PR updates the `release.yaml` file to move the "Breaking Changes" category higher in the list i.e. to increase its priority. The new order and priority will be:
- Exciting New Features ✨
- Breaking Changes ⚠️
- Bug Fixes 🐛
- Enhancements 🚀
- Maintenance Updates 🔧
- Other Changes

In addition, it removes the failing exclusions to match the behaviour, which is desired.