### PR TITLE
Fix operator=() does not handle self-assignment properly

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -95,7 +95,7 @@ private:
 #define GDCLASS(m_class, m_inherits)                                           \
                                                                                \
 private:                                                                       \
-    void operator=(const m_class& p_rval) {}                                   \
+    void operator=(const m_class&) = delete;                                   \
     mutable StringName _class_name;                                            \
     friend class ClassDB;                                                      \
                                                                                \


### PR DESCRIPTION
Currently, all classes that derive from Object and use the GDCLASS macro do not implement the assignment operator `operator=` properly. Since the intention is to disable the assignment operator, this PR correctly deletes the assignment operator instead of it doing nothing.

**Note:** This does not actually prevent assignment, because the default copy constructor is being used instead, but that is for another PR.