### PR TITLE
Use empty() instead of comparing with a zero length object

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -115,7 +115,7 @@ public:                                                                        \
     static String get_category_static() {                                      \
         String category = m_inherits::get_category_static();                   \
         if (_get_category != m_inherits::_get_category) {                      \
-            if (category != "") category += "/";                               \
+            if (!category.empty()) category += "/";                            \
             category += _get_category();                                       \
         }                                                                      \
         return category;                                                       \


### PR DESCRIPTION
Currently, the macro used to declare common methods for all child classes of object compares `category` with `""`. The `empty()` method should be used to check for emptiness instead of comparing to an empty object.

This PR updates the macro to use `empty()`.