### PR TITLE
Refactor SelfList

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1008,11 +1008,11 @@ void ResourceLoader::reload_translation_remaps() {
     ResourceCache::lock.read_lock();
 
     List<Resource*> to_reload;
-    SelfList<Resource>* E = remapped_list.first();
+    SelfList<Resource>* E = remapped_list.get_first();
 
     while (E) {
-        to_reload.push_back(E->self());
-        E = E->next();
+        to_reload.push_back(E->get_self());
+        E = E->get_next();
     }
 
     ResourceCache::lock.read_unlock();
@@ -1050,8 +1050,8 @@ void ResourceLoader::load_translation_remaps() {
 
 void ResourceLoader::clear_translation_remaps() {
     translation_remaps.clear();
-    while (remapped_list.first() != nullptr) {
-        remapped_list.remove(remapped_list.first());
+    while (remapped_list.get_first() != nullptr) {
+        remapped_list.remove(remapped_list.get_first());
     }
 }
 

--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -312,7 +312,7 @@ void Resource::setup_local_to_scene() {
 Node* (*Resource::_get_local_scene_func)() = nullptr;
 
 void Resource::set_as_translation_remapped(bool p_remapped) {
-    if (remapped_list.in_list() == p_remapped) {
+    if (remapped_list.is_in_list() == p_remapped) {
         return;
     }
 
@@ -328,7 +328,7 @@ void Resource::set_as_translation_remapped(bool p_remapped) {
 }
 
 bool Resource::is_translation_remapped() const {
-    return remapped_list.in_list();
+    return remapped_list.is_in_list();
 }
 
 #ifdef TOOLS_ENABLED

--- a/core/self_list.h
+++ b/core/self_list.h
@@ -10,138 +10,156 @@
 #include "core/error_macros.h"
 #include "core/typedefs.h"
 
+// SelfList is an item that can be added to a SelfList::List.
+// If added, it will remove itself from the list when it is destroyed.
+
 template <class T>
 class SelfList {
 public:
     class List {
-        SelfList<T>* _first;
-        SelfList<T>* _last;
-
     public:
-        void add(SelfList<T>* p_elem) {
-            ERR_FAIL_COND(p_elem->_root);
+        constexpr List() = default;
+        ~List();
 
-            p_elem->_root = this;
-            p_elem->_next = _first;
-            p_elem->_prev = nullptr;
+        constexpr SelfList* get_first();
+        constexpr const SelfList* get_first() const;
 
-            if (_first) {
-                _first->_prev = p_elem;
+        constexpr void add(SelfList* item);
+        constexpr void add_last(SelfList* item);
+        constexpr void remove(SelfList* item);
 
-            } else {
-                _last = p_elem;
-            }
-
-            _first = p_elem;
-        }
-
-        void add_last(SelfList<T>* p_elem) {
-            ERR_FAIL_COND(p_elem->_root);
-
-            p_elem->_root = this;
-            p_elem->_next = nullptr;
-            p_elem->_prev = _last;
-
-            if (_last) {
-                _last->_next = p_elem;
-
-            } else {
-                _first = p_elem;
-            }
-
-            _last = p_elem;
-        }
-
-        void remove(SelfList<T>* p_elem) {
-            ERR_FAIL_COND(p_elem->_root != this);
-            if (p_elem->_next) {
-                p_elem->_next->_prev = p_elem->_prev;
-            }
-
-            if (p_elem->_prev) {
-                p_elem->_prev->_next = p_elem->_next;
-            }
-
-            if (_first == p_elem) {
-                _first = p_elem->_next;
-            }
-
-            if (_last == p_elem) {
-                _last = p_elem->_prev;
-            }
-
-            p_elem->_next = nullptr;
-            p_elem->_prev = nullptr;
-            p_elem->_root = nullptr;
-        }
-
-        _FORCE_INLINE_ SelfList<T>* first() {
-            return _first;
-        }
-
-        _FORCE_INLINE_ const SelfList<T>* first() const {
-            return _first;
-        }
-
-        _FORCE_INLINE_ List() {
-            _first = nullptr;
-            _last  = nullptr;
-        }
-
-        _FORCE_INLINE_ ~List() {
-            ERR_FAIL_COND(_first != nullptr);
-        }
+    private:
+        SelfList* first = nullptr;
+        SelfList* last  = nullptr;
     };
 
+    constexpr explicit SelfList(T* self);
+    ~SelfList();
+
+    constexpr T* get_self() const;
+    constexpr SelfList* get_next();
+    constexpr const SelfList* get_next() const;
+    constexpr SelfList* get_previous();
+    constexpr const SelfList* get_previous() const;
+    [[nodiscard]]
+    constexpr bool is_in_list() const;
+    constexpr void remove_from_list();
+
 private:
-    List* _root;
-    T* _self;
-    SelfList<T>* _next;
-    SelfList<T>* _prev;
-
-public:
-    _FORCE_INLINE_ bool in_list() const {
-        return _root;
-    }
-
-    _FORCE_INLINE_ void remove_from_list() {
-        if (_root) {
-            _root->remove(this);
-        }
-    }
-
-    _FORCE_INLINE_ SelfList<T>* next() {
-        return _next;
-    }
-
-    _FORCE_INLINE_ SelfList<T>* prev() {
-        return _prev;
-    }
-
-    _FORCE_INLINE_ const SelfList<T>* next() const {
-        return _next;
-    }
-
-    _FORCE_INLINE_ const SelfList<T>* prev() const {
-        return _prev;
-    }
-
-    _FORCE_INLINE_ T* self() const {
-        return _self;
-    }
-
-    _FORCE_INLINE_ SelfList(T* p_self) {
-        _self = p_self;
-        _next = nullptr;
-        _prev = nullptr;
-        _root = nullptr;
-    }
-
-    _FORCE_INLINE_ ~SelfList() {
-        if (_root) {
-            _root->remove(this);
-        }
-    }
+    T* self;
+    List* list         = nullptr;
+    SelfList* next     = nullptr;
+    SelfList* previous = nullptr;
 };
+
+template <class T>
+SelfList<T>::List::~List() {
+    ERR_FAIL_COND(first != nullptr);
+}
+
+template <class T>
+constexpr SelfList<T>* SelfList<T>::List::get_first() {
+    return first;
+}
+
+template <class T>
+constexpr const SelfList<T>* SelfList<T>::List::get_first() const {
+    return first;
+}
+
+template <class T>
+constexpr void SelfList<T>::List::add(SelfList* item) {
+    ERR_FAIL_COND(item->list);
+    item->list     = this;
+    item->next     = first;
+    item->previous = nullptr;
+    if (first) {
+        first->previous = item;
+    } else {
+        last = item;
+    }
+    first = item;
+}
+
+template <class T>
+constexpr void SelfList<T>::List::add_last(SelfList* item) {
+    ERR_FAIL_COND(item->list);
+    item->list     = this;
+    item->next     = nullptr;
+    item->previous = last;
+    if (last) {
+        last->next = item;
+    } else {
+        first = item;
+    }
+    last = item;
+}
+
+template <class T>
+constexpr void SelfList<T>::List::remove(SelfList* item) {
+    ERR_FAIL_COND(item->list != this);
+    if (item->next) {
+        item->next->previous = item->previous;
+    }
+    if (item->previous) {
+        item->previous->next = item->next;
+    }
+    if (first == item) {
+        first = item->next;
+    }
+    if (last == item) {
+        last = item->previous;
+    }
+    item->next     = nullptr;
+    item->previous = nullptr;
+    item->list     = nullptr;
+}
+
+template <class T>
+constexpr SelfList<T>::SelfList(T* self) : self(self) {}
+
+template <class T>
+SelfList<T>::~SelfList() {
+    if (list) {
+        list->remove(this);
+    }
+}
+
+template <class T>
+constexpr T* SelfList<T>::get_self() const {
+    return self;
+}
+
+template <class T>
+constexpr SelfList<T>* SelfList<T>::get_next() {
+    return next;
+}
+
+template <class T>
+constexpr const SelfList<T>* SelfList<T>::get_next() const {
+    return next;
+}
+
+template <class T>
+constexpr SelfList<T>* SelfList<T>::get_previous() {
+    return previous;
+}
+
+template <class T>
+constexpr const SelfList<T>* SelfList<T>::get_previous() const {
+    return previous;
+}
+
+template <class T>
+constexpr bool SelfList<T>::is_in_list() const {
+    return list;
+}
+
+template <class T>
+constexpr void SelfList<T>::remove_from_list() {
+    if (list) {
+        list->remove(this);
+    }
+}
 
 #endif // SELF_LIST_H

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -1312,20 +1312,20 @@ public:
             bool p_materials = true
         ) {
             SelfList<RasterizerScene::InstanceBase>* instances =
-                instance_list.first();
+                instance_list.get_first();
             while (instances) {
-                instances->self()->base_changed(p_aabb, p_materials);
-                instances = instances->next();
+                instances->get_self()->base_changed(p_aabb, p_materials);
+                instances = instances->get_next();
             }
         }
 
         _FORCE_INLINE_ void instance_remove_deps() {
             SelfList<RasterizerScene::InstanceBase>* instances =
-                instance_list.first();
+                instance_list.get_first();
             while (instances) {
                 SelfList<RasterizerScene::InstanceBase>* next =
-                    instances->next();
-                instances->self()->base_removed();
+                    instances->get_next();
+                instances->get_self()->base_removed();
                 instances = next;
             }
         }

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1694,7 +1694,7 @@ RID RasterizerStorageGLES2::shader_create() {
 }
 
 void RasterizerStorageGLES2::_shader_make_dirty(Shader* p_shader) {
-    if (p_shader->dirty_list.in_list()) {
+    if (p_shader->dirty_list.is_in_list()) {
         return;
     }
 
@@ -2056,9 +2056,9 @@ void RasterizerStorageGLES2::_update_shader(Shader* p_shader) const {
 
     // cache uniform locations
 
-    for (SelfList<Material>* E = p_shader->materials.first(); E;
-         E                     = E->next()) {
-        _material_make_dirty(E->self());
+    for (SelfList<Material>* E = p_shader->materials.get_first(); E;
+         E                     = E->get_next()) {
+        _material_make_dirty(E->get_self());
     }
 
     p_shader->valid = true;
@@ -2066,8 +2066,8 @@ void RasterizerStorageGLES2::_update_shader(Shader* p_shader) const {
 }
 
 void RasterizerStorageGLES2::update_dirty_shaders() {
-    while (_shader_dirty_list.first()) {
-        _update_shader(_shader_dirty_list.first()->self());
+    while (_shader_dirty_list.get_first()) {
+        _update_shader(_shader_dirty_list.get_first()->get_self());
     }
 }
 
@@ -2078,7 +2078,7 @@ void RasterizerStorageGLES2::shader_get_param_list(
     Shader* shader = shader_owner.get(p_shader);
     ERR_FAIL_COND(!shader);
 
-    if (shader->dirty_list.in_list()) {
+    if (shader->dirty_list.is_in_list()) {
         _update_shader(shader);
     }
 
@@ -2290,7 +2290,7 @@ void RasterizerStorageGLES2::shader_remove_custom_define(
 /* COMMON MATERIAL API */
 
 void RasterizerStorageGLES2::_material_make_dirty(Material* p_material) const {
-    if (p_material->dirty_list.in_list()) {
+    if (p_material->dirty_list.is_in_list()) {
         return;
     }
 
@@ -2411,7 +2411,7 @@ void RasterizerStorageGLES2::material_set_next_pass(
 bool RasterizerStorageGLES2::material_is_animated(RID p_material) {
     Material* material = material_owner.get(p_material);
     ERR_FAIL_COND_V(!material, false);
-    if (material->dirty_list.in_list()) {
+    if (material->dirty_list.is_in_list()) {
         _update_material(material);
     }
 
@@ -2425,7 +2425,7 @@ bool RasterizerStorageGLES2::material_is_animated(RID p_material) {
 bool RasterizerStorageGLES2::material_casts_shadows(RID p_material) {
     Material* material = material_owner.get(p_material);
     ERR_FAIL_COND_V(!material, false);
-    if (material->dirty_list.in_list()) {
+    if (material->dirty_list.is_in_list()) {
         _update_material(material);
     }
 
@@ -2446,7 +2446,7 @@ bool RasterizerStorageGLES2::material_uses_tangents(RID p_material) {
         return false;
     }
 
-    if (material->shader->dirty_list.in_list()) {
+    if (material->shader->dirty_list.is_in_list()) {
         _update_shader(material->shader);
     }
 
@@ -2462,7 +2462,7 @@ bool RasterizerStorageGLES2::material_uses_ensure_correct_normals(RID p_material
         return false;
     }
 
-    if (material->shader->dirty_list.in_list()) {
+    if (material->shader->dirty_list.is_in_list()) {
         _update_shader(material->shader);
     }
 
@@ -2517,11 +2517,11 @@ void RasterizerStorageGLES2::material_set_render_priority(
 }
 
 void RasterizerStorageGLES2::_update_material(Material* p_material) {
-    if (p_material->dirty_list.in_list()) {
+    if (p_material->dirty_list.is_in_list()) {
         _material_dirty_list.remove(&p_material->dirty_list);
     }
 
-    if (p_material->shader && p_material->shader->dirty_list.in_list()) {
+    if (p_material->shader && p_material->shader->dirty_list.is_in_list()) {
         _update_shader(p_material->shader);
     }
 
@@ -2652,8 +2652,8 @@ void RasterizerStorageGLES2::_material_remove_geometry(
 }
 
 void RasterizerStorageGLES2::update_dirty_materials() {
-    while (_material_dirty_list.first()) {
-        Material* material = _material_dirty_list.first()->self();
+    while (_material_dirty_list.get_first()) {
+        Material* material = _material_dirty_list.get_first()->get_self();
         _update_material(material);
     }
 }
@@ -3267,7 +3267,7 @@ void RasterizerStorageGLES2::mesh_set_blend_shape_count(
 
     mesh->blend_shape_count = p_amount;
     mesh->instance_change_notify(true, false);
-    if (!mesh->update_list.in_list()) {
+    if (!mesh->update_list.is_in_list()) {
         blend_shapes_update_list.add(&mesh->update_list);
     }
 }
@@ -3286,7 +3286,7 @@ void RasterizerStorageGLES2::mesh_set_blend_shape_mode(
     ERR_FAIL_COND(!mesh);
 
     mesh->blend_shape_mode = p_mode;
-    if (!mesh->update_list.in_list()) {
+    if (!mesh->update_list.is_in_list()) {
         blend_shapes_update_list.add(&mesh->update_list);
     }
 }
@@ -3307,7 +3307,7 @@ void RasterizerStorageGLES2::mesh_set_blend_shape_values(
     ERR_FAIL_COND(!mesh);
 
     mesh->blend_shape_values = p_values;
-    if (!mesh->update_list.in_list()) {
+    if (!mesh->update_list.is_in_list()) {
         blend_shapes_update_list.add(&mesh->update_list);
     }
 }
@@ -3795,7 +3795,7 @@ void RasterizerStorageGLES2::multimesh_allocate(
     multimesh->dirty_aabb = true;
     multimesh->dirty_data = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -3830,7 +3830,7 @@ void RasterizerStorageGLES2::multimesh_set_mesh(RID p_multimesh, RID p_mesh) {
 
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -3866,7 +3866,7 @@ void RasterizerStorageGLES2::multimesh_instance_set_transform(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -3897,7 +3897,7 @@ void RasterizerStorageGLES2::multimesh_instance_set_transform_2d(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -3935,7 +3935,7 @@ void RasterizerStorageGLES2::multimesh_instance_set_color(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -3980,7 +3980,7 @@ void RasterizerStorageGLES2::multimesh_instance_set_custom_data(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -4161,7 +4161,7 @@ void RasterizerStorageGLES2::multimesh_set_as_bulk_array(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -4194,8 +4194,8 @@ AABB RasterizerStorageGLES2::multimesh_get_aabb(RID p_multimesh) const {
 }
 
 void RasterizerStorageGLES2::update_dirty_multimeshes() {
-    while (multimesh_update_list.first()) {
-        MultiMesh* multimesh = multimesh_update_list.first()->self();
+    while (multimesh_update_list.get_first()) {
+        MultiMesh* multimesh = multimesh_update_list.get_first()->get_self();
 
         if (multimesh->size && multimesh->dirty_aabb) {
             AABB mesh_aabb;
@@ -4274,7 +4274,7 @@ void RasterizerStorageGLES2::update_dirty_multimeshes() {
 
         multimesh->instance_change_notify(true, false);
 
-        multimesh_update_list.remove(multimesh_update_list.first());
+        multimesh_update_list.remove(multimesh_update_list.get_first());
     }
 }
 
@@ -4546,7 +4546,7 @@ void RasterizerStorageGLES2::skeleton_bone_set_transform(
     bone_data[base_offset + 10] = p_transform.basis[2].z;
     bone_data[base_offset + 11] = p_transform.origin.z;
 
-    if (!skeleton->update_list.in_list()) {
+    if (!skeleton->update_list.is_in_list()) {
         skeleton_update_list.add(&skeleton->update_list);
     }
 }
@@ -4609,7 +4609,7 @@ void RasterizerStorageGLES2::skeleton_bone_set_transform_2d(
     bone_data[base_offset + 6] = 0;
     bone_data[base_offset + 7] = p_transform[2][1];
 
-    if (!skeleton->update_list.in_list()) {
+    if (!skeleton->update_list.is_in_list()) {
         skeleton_update_list.add(&skeleton->update_list);
     }
 }
@@ -4651,8 +4651,8 @@ void RasterizerStorageGLES2::skeleton_set_base_transform_2d(
 }
 
 void RasterizerStorageGLES2::update_dirty_blend_shapes() {
-    while (blend_shapes_update_list.first()) {
-        Mesh* mesh = blend_shapes_update_list.first()->self();
+    while (blend_shapes_update_list.get_first()) {
+        Mesh* mesh = blend_shapes_update_list.get_first()->get_self();
         for (int is = 0; is < mesh->surfaces.size(); is++) {
             RasterizerStorageGLES2::Surface* s = mesh->surfaces[is];
             if (!s->blend_shape_data.empty()) {
@@ -5145,7 +5145,7 @@ void RasterizerStorageGLES2::update_dirty_blend_shapes() {
                 glBindBuffer(GL_ARRAY_BUFFER, 0);
             }
         }
-        blend_shapes_update_list.remove(blend_shapes_update_list.first());
+        blend_shapes_update_list.remove(blend_shapes_update_list.get_first());
     }
 }
 
@@ -5191,8 +5191,8 @@ void RasterizerStorageGLES2::update_dirty_skeletons() {
 
     glActiveTexture(GL_TEXTURE0);
 
-    while (skeleton_update_list.first()) {
-        Skeleton* skeleton = skeleton_update_list.first()->self();
+    while (skeleton_update_list.get_first()) {
+        Skeleton* skeleton = skeleton_update_list.get_first()->get_self();
 
         if (skeleton->size) {
             glBindTexture(GL_TEXTURE_2D, skeleton->tex_id);
@@ -5217,7 +5217,7 @@ void RasterizerStorageGLES2::update_dirty_skeletons() {
             E->get()->base_changed(true, false);
         }
 
-        skeleton_update_list.remove(skeleton_update_list.first());
+        skeleton_update_list.remove(skeleton_update_list.get_first());
     }
 }
 
@@ -6026,7 +6026,7 @@ void RasterizerStorageGLES2::lightmap_capture_set_energy(
     ERR_FAIL_COND(!capture);
     capture->energy = p_energy;
 
-    if (!capture->update_list.in_list()) {
+    if (!capture->update_list.is_in_list()) {
         capture_update_list.add(&capture->update_list);
     }
 }
@@ -6046,7 +6046,7 @@ void RasterizerStorageGLES2::lightmap_capture_set_interior(
     ERR_FAIL_COND(!capture);
     capture->interior = p_interior;
 
-    if (!capture->update_list.in_list()) {
+    if (!capture->update_list.is_in_list()) {
         capture_update_list.add(&capture->update_list);
     }
 }
@@ -6059,10 +6059,10 @@ bool RasterizerStorageGLES2::lightmap_capture_is_interior(RID p_capture) const {
 }
 
 void RasterizerStorageGLES2::update_dirty_captures() {
-    while (capture_update_list.first()) {
-        LightmapCapture* capture = capture_update_list.first()->self();
+    while (capture_update_list.get_first()) {
+        LightmapCapture* capture = capture_update_list.get_first()->get_self();
         capture->instance_change_notify(false, true);
-        capture_update_list.remove(capture_update_list.first());
+        capture_update_list.remove(capture_update_list.get_first());
     }
 }
 
@@ -7673,17 +7673,17 @@ bool RasterizerStorageGLES2::free(RID p_rid) {
             shader->shader->free_custom_shader(shader->custom_code_id);
         }
 
-        if (shader->dirty_list.in_list()) {
+        if (shader->dirty_list.is_in_list()) {
             _shader_dirty_list.remove(&shader->dirty_list);
         }
 
-        while (shader->materials.first()) {
-            Material* m = shader->materials.first()->self();
+        while (shader->materials.get_first()) {
+            Material* m = shader->materials.get_first()->get_self();
 
             m->shader = nullptr;
             _material_make_dirty(m);
 
-            shader->materials.remove(shader->materials.first());
+            shader->materials.remove(shader->materials.get_first());
         }
 
         shader_owner.free(p_rid);
@@ -7727,7 +7727,7 @@ bool RasterizerStorageGLES2::free(RID p_rid) {
     } else if (skeleton_owner.owns(p_rid)) {
         Skeleton* s = skeleton_owner.get(p_rid);
 
-        if (s->update_list.in_list()) {
+        if (s->update_list.is_in_list()) {
             skeleton_update_list.remove(&s->update_list);
         }
 
@@ -7754,14 +7754,14 @@ bool RasterizerStorageGLES2::free(RID p_rid) {
         mesh->instance_remove_deps();
         mesh_clear(p_rid);
 
-        while (mesh->multimeshes.first()) {
-            MultiMesh* multimesh  = mesh->multimeshes.first()->self();
+        while (mesh->multimeshes.get_first()) {
+            MultiMesh* multimesh  = mesh->multimeshes.get_first()->get_self();
             multimesh->mesh       = RID();
             multimesh->dirty_aabb = true;
 
-            mesh->multimeshes.remove(mesh->multimeshes.first());
+            mesh->multimeshes.remove(mesh->multimeshes.get_first());
 
-            if (!multimesh->update_list.in_list()) {
+            if (!multimesh->update_list.is_in_list()) {
                 multimesh_update_list.add(&multimesh->update_list);
             }
         }

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -164,20 +164,20 @@ public:
             bool p_materials
         ) {
             SelfList<RasterizerScene::InstanceBase>* instances =
-                instance_list.first();
+                instance_list.get_first();
             while (instances) {
-                instances->self()->base_changed(p_aabb, p_materials);
-                instances = instances->next();
+                instances->get_self()->base_changed(p_aabb, p_materials);
+                instances = instances->get_next();
             }
         }
 
         _FORCE_INLINE_ void instance_remove_deps() {
             SelfList<RasterizerScene::InstanceBase>* instances =
-                instance_list.first();
+                instance_list.get_first();
 
             while (instances) {
-                instances->self()->base_removed();
-                instances = instances->next();
+                instances->get_self()->base_removed();
+                instances = instances->get_next();
             }
         }
 
@@ -747,11 +747,11 @@ public:
         SelfList<MultiMesh>::List multimeshes;
 
         _FORCE_INLINE_ void update_multimeshes() {
-            SelfList<MultiMesh>* mm = multimeshes.first();
+            SelfList<MultiMesh>* mm = multimeshes.get_first();
 
             while (mm) {
-                mm->self()->instance_change_notify(false, true);
-                mm = mm->next();
+                mm->get_self()->instance_change_notify(false, true);
+                mm = mm->get_next();
             }
         }
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2955,7 +2955,7 @@ RID RasterizerStorageGLES3::shader_create() {
 }
 
 void RasterizerStorageGLES3::_shader_make_dirty(Shader* p_shader) {
-    if (p_shader->dirty_list.in_list()) {
+    if (p_shader->dirty_list.is_in_list()) {
         return;
     }
 
@@ -3310,9 +3310,9 @@ void RasterizerStorageGLES3::_update_shader(Shader* p_shader) const {
     // all materials using this shader will have to be invalidated,
     // unfortunately
 
-    for (SelfList<Material>* E = p_shader->materials.first(); E;
-         E                     = E->next()) {
-        _material_make_dirty(E->self());
+    for (SelfList<Material>* E = p_shader->materials.get_first(); E;
+         E                     = E->get_next()) {
+        _material_make_dirty(E->get_self());
     }
 
     p_shader->valid = true;
@@ -3320,8 +3320,8 @@ void RasterizerStorageGLES3::_update_shader(Shader* p_shader) const {
 }
 
 void RasterizerStorageGLES3::update_dirty_shaders() {
-    while (_shader_dirty_list.first()) {
-        _update_shader(_shader_dirty_list.first()->self());
+    while (_shader_dirty_list.get_first()) {
+        _update_shader(_shader_dirty_list.get_first()->get_self());
     }
 }
 
@@ -3332,7 +3332,7 @@ void RasterizerStorageGLES3::shader_get_param_list(
     Shader* shader = shader_owner.get(p_shader);
     ERR_FAIL_COND(!shader);
 
-    if (shader->dirty_list.in_list()) {
+    if (shader->dirty_list.is_in_list()) {
         _update_shader(shader); // ok should be not anymore dirty
     }
 
@@ -3532,7 +3532,7 @@ void RasterizerStorageGLES3::shader_remove_custom_define(
 /* COMMON MATERIAL API */
 
 void RasterizerStorageGLES3::_material_make_dirty(Material* p_material) const {
-    if (p_material->dirty_list.in_list()) {
+    if (p_material->dirty_list.is_in_list()) {
         return;
     }
 
@@ -3652,7 +3652,7 @@ void RasterizerStorageGLES3::material_set_next_pass(
 bool RasterizerStorageGLES3::material_is_animated(RID p_material) {
     Material* material = material_owner.get(p_material);
     ERR_FAIL_COND_V(!material, false);
-    if (material->dirty_list.in_list()) {
+    if (material->dirty_list.is_in_list()) {
         _update_material(material);
     }
 
@@ -3666,7 +3666,7 @@ bool RasterizerStorageGLES3::material_is_animated(RID p_material) {
 bool RasterizerStorageGLES3::material_casts_shadows(RID p_material) {
     Material* material = material_owner.get(p_material);
     ERR_FAIL_COND_V(!material, false);
-    if (material->dirty_list.in_list()) {
+    if (material->dirty_list.is_in_list()) {
         _update_material(material);
     }
 
@@ -3687,7 +3687,7 @@ bool RasterizerStorageGLES3::material_uses_tangents(RID p_material) {
         return false;
     }
 
-    if (material->shader->dirty_list.in_list()) {
+    if (material->shader->dirty_list.is_in_list()) {
         _update_shader(material->shader);
     }
 
@@ -3703,7 +3703,7 @@ bool RasterizerStorageGLES3::material_uses_ensure_correct_normals(RID p_material
         return false;
     }
 
-    if (material->shader->dirty_list.in_list()) {
+    if (material->shader->dirty_list.is_in_list()) {
         _update_shader(material->shader);
     }
 
@@ -4213,11 +4213,11 @@ _FORCE_INLINE_ static void _fill_std140_ubo_empty(
 }
 
 void RasterizerStorageGLES3::_update_material(Material* material) {
-    if (material->dirty_list.in_list()) {
+    if (material->dirty_list.is_in_list()) {
         _material_dirty_list.remove(&material->dirty_list);
     }
 
-    if (material->shader && material->shader->dirty_list.in_list()) {
+    if (material->shader && material->shader->dirty_list.is_in_list()) {
         _update_shader(material->shader);
     }
 
@@ -4449,8 +4449,8 @@ void RasterizerStorageGLES3::_material_remove_geometry(
 }
 
 void RasterizerStorageGLES3::update_dirty_materials() {
-    while (_material_dirty_list.first()) {
-        Material* material = _material_dirty_list.first()->self();
+    while (_material_dirty_list.get_first()) {
+        Material* material = _material_dirty_list.get_first()->get_self();
 
         _update_material(material);
     }
@@ -6068,7 +6068,7 @@ void RasterizerStorageGLES3::multimesh_allocate(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -6103,7 +6103,7 @@ void RasterizerStorageGLES3::multimesh_set_mesh(RID p_multimesh, RID p_mesh) {
 
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -6138,7 +6138,7 @@ void RasterizerStorageGLES3::multimesh_instance_set_transform(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -6169,7 +6169,7 @@ void RasterizerStorageGLES3::multimesh_instance_set_transform_2d(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -6207,7 +6207,7 @@ void RasterizerStorageGLES3::multimesh_instance_set_color(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -6252,7 +6252,7 @@ void RasterizerStorageGLES3::multimesh_instance_set_custom_data(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -6432,7 +6432,7 @@ void RasterizerStorageGLES3::multimesh_set_as_bulk_array(
     multimesh->dirty_data = true;
     multimesh->dirty_aabb = true;
 
-    if (!multimesh->update_list.in_list()) {
+    if (!multimesh->update_list.is_in_list()) {
         multimesh_update_list.add(&multimesh->update_list);
     }
 }
@@ -6466,8 +6466,8 @@ AABB RasterizerStorageGLES3::multimesh_get_aabb(RID p_multimesh) const {
 }
 
 void RasterizerStorageGLES3::update_dirty_multimeshes() {
-    while (multimesh_update_list.first()) {
-        MultiMesh* multimesh = multimesh_update_list.first()->self();
+    while (multimesh_update_list.get_first()) {
+        MultiMesh* multimesh = multimesh_update_list.get_first()->get_self();
 
         if (multimesh->size && multimesh->dirty_data) {
             glBindBuffer(GL_ARRAY_BUFFER, multimesh->buffer);
@@ -6556,7 +6556,7 @@ void RasterizerStorageGLES3::update_dirty_multimeshes() {
 
         multimesh->instance_change_notify(true, false);
 
-        multimesh_update_list.remove(multimesh_update_list.first());
+        multimesh_update_list.remove(multimesh_update_list.get_first());
     }
 }
 
@@ -6789,7 +6789,7 @@ void RasterizerStorageGLES3::skeleton_allocate(
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!skeleton->update_list.in_list()) {
+    if (!skeleton->update_list.is_in_list()) {
         skeleton_update_list.add(&skeleton->update_list);
     }
 }
@@ -6831,7 +6831,7 @@ void RasterizerStorageGLES3::skeleton_bone_set_transform(
     texture[base_ofs + 2]  = p_transform.basis[2].z;
     texture[base_ofs + 3]  = p_transform.origin.z;
 
-    if (!skeleton->update_list.in_list()) {
+    if (!skeleton->update_list.is_in_list()) {
         skeleton_update_list.add(&skeleton->update_list);
     }
 }
@@ -6895,7 +6895,7 @@ void RasterizerStorageGLES3::skeleton_bone_set_transform_2d(
     texture[base_ofs + 2]  = 0;
     texture[base_ofs + 3]  = p_transform[2][1];
 
-    if (!skeleton->update_list.in_list()) {
+    if (!skeleton->update_list.is_in_list()) {
         skeleton_update_list.add(&skeleton->update_list);
     }
 }
@@ -6941,8 +6941,8 @@ void RasterizerStorageGLES3::skeleton_set_base_transform_2d(
 void RasterizerStorageGLES3::update_dirty_skeletons() {
     glActiveTexture(GL_TEXTURE0);
 
-    while (skeleton_update_list.first()) {
-        Skeleton* skeleton = skeleton_update_list.first()->self();
+    while (skeleton_update_list.get_first()) {
+        Skeleton* skeleton = skeleton_update_list.get_first()->get_self();
         if (skeleton->size) {
             int height = skeleton->size / 256;
             if (skeleton->size % 256) {
@@ -6970,7 +6970,7 @@ void RasterizerStorageGLES3::update_dirty_skeletons() {
             E->get()->base_changed(true, false);
         }
 
-        skeleton_update_list.remove(skeleton_update_list.first());
+        skeleton_update_list.remove(skeleton_update_list.get_first());
     }
 }
 
@@ -7965,7 +7965,7 @@ void RasterizerStorageGLES3::lightmap_capture_set_energy(
     ERR_FAIL_COND(!capture);
     capture->energy = p_energy;
 
-    if (!capture->update_list.in_list()) {
+    if (!capture->update_list.is_in_list()) {
         capture_update_list.add(&capture->update_list);
     }
 }
@@ -7984,7 +7984,7 @@ void RasterizerStorageGLES3::lightmap_capture_set_interior(
     LightmapCapture* capture = lightmap_capture_data_owner.getornull(p_capture);
     ERR_FAIL_COND(!capture);
     capture->interior = p_interior;
-    if (!capture->update_list.in_list()) {
+    if (!capture->update_list.is_in_list()) {
         capture_update_list.add(&capture->update_list);
     }
 }
@@ -8005,10 +8005,10 @@ RasterizerStorageGLES3::lightmap_capture_get_octree_ptr(RID p_capture) const {
 }
 
 void RasterizerStorageGLES3::update_dirty_captures() {
-    while (capture_update_list.first()) {
-        LightmapCapture* capture = capture_update_list.first()->self();
+    while (capture_update_list.get_first()) {
+        LightmapCapture* capture = capture_update_list.get_first()->get_self();
         capture->instance_change_notify(false, true);
-        capture_update_list.remove(capture_update_list.first());
+        capture_update_list.remove(capture_update_list.get_first());
     }
 }
 
@@ -8319,7 +8319,7 @@ void RasterizerStorageGLES3::particles_request_process(RID p_particles) {
     Particles* particles = particles_owner.getornull(p_particles);
     ERR_FAIL_COND(!particles);
 
-    if (!particles->particle_element.in_list()) {
+    if (!particles->particle_element.is_in_list()) {
         particle_update_list.add(&particles->particle_element);
     }
 }
@@ -8540,10 +8540,10 @@ void RasterizerStorageGLES3::_particles_process(
 void RasterizerStorageGLES3::update_particles() {
     glEnable(GL_RASTERIZER_DISCARD);
 
-    while (particle_update_list.first()) {
+    while (particle_update_list.get_first()) {
         // use transform feedback to process particles
 
-        Particles* particles = particle_update_list.first()->self();
+        Particles* particles = particle_update_list.get_first()->get_self();
 
         if (particles->restart_request) {
             particles->prev_ticks                  = 0;
@@ -8556,7 +8556,7 @@ void RasterizerStorageGLES3::update_particles() {
         }
 
         if (particles->inactive && !particles->emitting) {
-            particle_update_list.remove(particle_update_list.first());
+            particle_update_list.remove(particle_update_list.get_first());
             continue;
         }
 
@@ -8576,7 +8576,7 @@ void RasterizerStorageGLES3::update_particles() {
             particles->inactive_time += particles->speed_scale * frame.delta;
             if (particles->inactive_time > particles->lifetime * 1.2) {
                 particles->inactive = true;
-                particle_update_list.remove(particle_update_list.first());
+                particle_update_list.remove(particle_update_list.get_first());
                 continue;
             }
         }
@@ -8722,7 +8722,7 @@ void RasterizerStorageGLES3::update_particles() {
             }
         }
 
-        particle_update_list.remove(particle_update_list.first());
+        particle_update_list.remove(particle_update_list.get_first());
 
         if (particles->histories_enabled) {
             SWAP(
@@ -10242,17 +10242,17 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
             shader->shader->free_custom_shader(shader->custom_code_id);
         }
 
-        if (shader->dirty_list.in_list()) {
+        if (shader->dirty_list.is_in_list()) {
             _shader_dirty_list.remove(&shader->dirty_list);
         }
 
-        while (shader->materials.first()) {
-            Material* mat = shader->materials.first()->self();
+        while (shader->materials.get_first()) {
+            Material* mat = shader->materials.get_first()->get_self();
 
             mat->shader = nullptr;
             _material_make_dirty(mat);
 
-            shader->materials.remove(shader->materials.first());
+            shader->materials.remove(shader->materials.get_first());
         }
 
         // material_shader.free_custom_shader(shader->custom_code_id);
@@ -10301,7 +10301,7 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
     } else if (skeleton_owner.owns(p_rid)) {
         // delete the texture
         Skeleton* skeleton = skeleton_owner.get(p_rid);
-        if (skeleton->update_list.in_list()) {
+        if (skeleton->update_list.is_in_list()) {
             skeleton_update_list.remove(&skeleton->update_list);
         }
 
@@ -10324,13 +10324,13 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
         mesh->instance_remove_deps();
         mesh_clear(p_rid);
 
-        while (mesh->multimeshes.first()) {
-            MultiMesh* multimesh  = mesh->multimeshes.first()->self();
+        while (mesh->multimeshes.get_first()) {
+            MultiMesh* multimesh  = mesh->multimeshes.get_first()->get_self();
             multimesh->mesh       = RID();
             multimesh->dirty_aabb = true;
-            mesh->multimeshes.remove(mesh->multimeshes.first());
+            mesh->multimeshes.remove(mesh->multimeshes.get_first());
 
-            if (!multimesh->update_list.in_list()) {
+            if (!multimesh->update_list.is_in_list()) {
                 multimesh_update_list.add(&multimesh->update_list);
             }
         }

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -174,20 +174,20 @@ public:
             bool p_materials
         ) {
             SelfList<RasterizerScene::InstanceBase>* instances =
-                instance_list.first();
+                instance_list.get_first();
             while (instances) {
-                instances->self()->base_changed(p_aabb, p_materials);
-                instances = instances->next();
+                instances->get_self()->base_changed(p_aabb, p_materials);
+                instances = instances->get_next();
             }
         }
 
         _FORCE_INLINE_ void instance_remove_deps() {
             SelfList<RasterizerScene::InstanceBase>* instances =
-                instance_list.first();
+                instance_list.get_first();
             while (instances) {
                 SelfList<RasterizerScene::InstanceBase>* next =
-                    instances->next();
-                instances->self()->base_removed();
+                    instances->get_next();
+                instances->get_self()->base_removed();
                 instances = next;
             }
         }
@@ -782,10 +782,10 @@ public:
         SelfList<MultiMesh>::List multimeshes;
 
         _FORCE_INLINE_ void update_multimeshes() {
-            SelfList<MultiMesh>* mm = multimeshes.first();
+            SelfList<MultiMesh>* mm = multimeshes.get_first();
             while (mm) {
-                mm->self()->instance_change_notify(false, true);
-                mm = mm->next();
+                mm->get_self()->instance_change_notify(false, true);
+                mm = mm->get_next();
             }
         }
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -59,12 +59,13 @@ Object* GDScriptNativeClass::instance() {
 
 void GDScript::_clear_pending_func_states() {
     GDScriptLanguage::get_singleton()->lock.lock();
-    while (SelfList<GDScriptFunctionState>* E = pending_func_states.first()) {
+    while (SelfList<GDScriptFunctionState>* E =
+               pending_func_states.get_first()) {
         // Order matters since clearing the stack may already cause
         // the GDSCriptFunctionState to be destroyed and thus removed from the
         // list.
         pending_func_states.remove(E);
-        E->self()->_clear_stack();
+        E->get_self()->_clear_stack();
     }
     GDScriptLanguage::get_singleton()->lock.unlock();
 }
@@ -1586,12 +1587,13 @@ GDScriptInstance::GDScriptInstance() {
 GDScriptInstance::~GDScriptInstance() {
     GDScriptLanguage::singleton->lock.lock();
 
-    while (SelfList<GDScriptFunctionState>* E = pending_func_states.first()) {
+    while (SelfList<GDScriptFunctionState>* E =
+               pending_func_states.get_first()) {
         // Order matters since clearing the stack may already cause
         // the GDSCriptFunctionState to be destroyed and thus removed from the
         // list.
         pending_func_states.remove(E);
-        E->self()->_clear_stack();
+        E->get_self()->_clear_stack();
     }
 
     if (script.is_valid() && owner) {
@@ -1706,18 +1708,18 @@ void GDScriptLanguage::profiling_start() {
 #ifdef DEBUG_ENABLED
     lock.lock();
 
-    SelfList<GDScriptFunction>* elem = function_list.first();
+    SelfList<GDScriptFunction>* elem = function_list.get_first();
     while (elem) {
-        elem->self()->profile.call_count            = 0;
-        elem->self()->profile.self_time             = 0;
-        elem->self()->profile.total_time            = 0;
-        elem->self()->profile.frame_call_count      = 0;
-        elem->self()->profile.frame_self_time       = 0;
-        elem->self()->profile.frame_total_time      = 0;
-        elem->self()->profile.last_frame_call_count = 0;
-        elem->self()->profile.last_frame_self_time  = 0;
-        elem->self()->profile.last_frame_total_time = 0;
-        elem                                        = elem->next();
+        elem->get_self()->profile.call_count            = 0;
+        elem->get_self()->profile.self_time             = 0;
+        elem->get_self()->profile.total_time            = 0;
+        elem->get_self()->profile.frame_call_count      = 0;
+        elem->get_self()->profile.frame_self_time       = 0;
+        elem->get_self()->profile.frame_total_time      = 0;
+        elem->get_self()->profile.last_frame_call_count = 0;
+        elem->get_self()->profile.last_frame_self_time  = 0;
+        elem->get_self()->profile.last_frame_total_time = 0;
+        elem                                            = elem->get_next();
     }
 
     profiling = true;
@@ -1741,16 +1743,16 @@ int GDScriptLanguage::profiling_get_accumulated_data(
 #ifdef DEBUG_ENABLED
     lock.lock();
 
-    SelfList<GDScriptFunction>* elem = function_list.first();
+    SelfList<GDScriptFunction>* elem = function_list.get_first();
     while (elem) {
         if (current >= p_info_max) {
             break;
         }
-        p_info_arr[current].call_count = elem->self()->profile.call_count;
-        p_info_arr[current].self_time  = elem->self()->profile.self_time;
-        p_info_arr[current].total_time = elem->self()->profile.total_time;
-        p_info_arr[current].signature  = elem->self()->profile.signature;
-        elem                           = elem->next();
+        p_info_arr[current].call_count = elem->get_self()->profile.call_count;
+        p_info_arr[current].self_time  = elem->get_self()->profile.self_time;
+        p_info_arr[current].total_time = elem->get_self()->profile.total_time;
+        p_info_arr[current].signature  = elem->get_self()->profile.signature;
+        elem                           = elem->get_next();
         current++;
     }
 
@@ -1769,22 +1771,22 @@ int GDScriptLanguage::profiling_get_frame_data(
 #ifdef DEBUG_ENABLED
     lock.lock();
 
-    SelfList<GDScriptFunction>* elem = function_list.first();
+    SelfList<GDScriptFunction>* elem = function_list.get_first();
     while (elem) {
         if (current >= p_info_max) {
             break;
         }
-        if (elem->self()->profile.last_frame_call_count > 0) {
+        if (elem->get_self()->profile.last_frame_call_count > 0) {
             p_info_arr[current].call_count =
-                elem->self()->profile.last_frame_call_count;
+                elem->get_self()->profile.last_frame_call_count;
             p_info_arr[current].self_time =
-                elem->self()->profile.last_frame_self_time;
+                elem->get_self()->profile.last_frame_self_time;
             p_info_arr[current].total_time =
-                elem->self()->profile.last_frame_total_time;
-            p_info_arr[current].signature = elem->self()->profile.signature;
+                elem->get_self()->profile.last_frame_total_time;
+            p_info_arr[current].signature = elem->get_self()->profile.signature;
             current++;
         }
-        elem = elem->next();
+        elem = elem->get_next();
     }
 
     lock.unlock();
@@ -1821,14 +1823,14 @@ void GDScriptLanguage::reload_all_scripts() {
 
     List<Ref<GDScript>> scripts;
 
-    SelfList<GDScript>* elem = script_list.first();
+    SelfList<GDScript>* elem = script_list.get_first();
     while (elem) {
-        if (elem->self()->get_path().is_resource_file()) {
-            print_verbose("GDScript: Found: " + elem->self()->get_path());
-            scripts.push_back(Ref<GDScript>(elem->self())
+        if (elem->get_self()->get_path().is_resource_file()) {
+            print_verbose("GDScript: Found: " + elem->get_self()->get_path());
+            scripts.push_back(Ref<GDScript>(elem->get_self())
             ); // cast to gdscript to avoid being erased by accident
         }
-        elem = elem->next();
+        elem = elem->get_next();
     }
 
     lock.unlock();
@@ -1856,13 +1858,13 @@ void GDScriptLanguage::reload_tool_script(
 
     List<Ref<GDScript>> scripts;
 
-    SelfList<GDScript>* elem = script_list.first();
+    SelfList<GDScript>* elem = script_list.get_first();
     while (elem) {
-        if (elem->self()->get_path().is_resource_file()) {
-            scripts.push_back(Ref<GDScript>(elem->self())
+        if (elem->get_self()->get_path().is_resource_file()) {
+            scripts.push_back(Ref<GDScript>(elem->get_self())
             ); // cast to gdscript to avoid being erased by accident
         }
-        elem = elem->next();
+        elem = elem->get_next();
     }
 
     lock.unlock();
@@ -2021,18 +2023,18 @@ void GDScriptLanguage::frame() {
     if (profiling) {
         lock.lock();
 
-        SelfList<GDScriptFunction>* elem = function_list.first();
+        SelfList<GDScriptFunction>* elem = function_list.get_first();
         while (elem) {
-            elem->self()->profile.last_frame_call_count =
-                elem->self()->profile.frame_call_count;
-            elem->self()->profile.last_frame_self_time =
-                elem->self()->profile.frame_self_time;
-            elem->self()->profile.last_frame_total_time =
-                elem->self()->profile.frame_total_time;
-            elem->self()->profile.frame_call_count = 0;
-            elem->self()->profile.frame_self_time  = 0;
-            elem->self()->profile.frame_total_time = 0;
-            elem                                   = elem->next();
+            elem->get_self()->profile.last_frame_call_count =
+                elem->get_self()->profile.frame_call_count;
+            elem->get_self()->profile.last_frame_self_time =
+                elem->get_self()->profile.frame_self_time;
+            elem->get_self()->profile.last_frame_total_time =
+                elem->get_self()->profile.frame_total_time;
+            elem->get_self()->profile.frame_call_count = 0;
+            elem->get_self()->profile.frame_self_time  = 0;
+            elem->get_self()->profile.frame_total_time = 0;
+            elem                                       = elem->get_next();
         }
 
         lock.unlock();
@@ -2546,9 +2548,9 @@ GDScriptLanguage::~GDScriptLanguage() {
 
     // Clear dependencies between scripts, to ensure cyclic references are
     // broken (to avoid leaks at exit).
-    SelfList<GDScript>* s = script_list.first();
+    SelfList<GDScript>* s = script_list.get_first();
     while (s) {
-        GDScript* script = s->self();
+        GDScript* script = s->get_self();
         // This ensures the current script is not released before we can check
         // what's the next one in the list (we can't get the next upfront
         // because we don't know if the reference breaking will cause it -or any
@@ -2573,7 +2575,7 @@ GDScriptLanguage::~GDScriptLanguage() {
             E->get().data_type.script_type_ref = Ref<Script>();
         }
 
-        s = s->next();
+        s = s->get_next();
         script->unreference();
     }
 

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -2061,11 +2061,11 @@ bool GDScriptFunctionState::is_valid(bool p_extended_check) const {
         MutexLock lock(GDScriptLanguage::get_singleton()->lock);
 #endif
         // Script gone?
-        if (!scripts_list.in_list()) {
+        if (!scripts_list.is_in_list()) {
             return false;
         }
         // Class instance gone? (if not static function)
-        if (state.instance && !instances_list.in_list()) {
+        if (state.instance && !instances_list.is_in_list()) {
             return false;
         }
     }
@@ -2079,7 +2079,7 @@ Variant GDScriptFunctionState::resume(const Variant& p_arg) {
 #ifndef NO_THREADS
         MutexLock lock(GDScriptLanguage::singleton->lock);
 #endif
-        if (!scripts_list.in_list()) {
+        if (!scripts_list.is_in_list()) {
 #ifdef DEBUG_ENABLED
             ERR_FAIL_V_MSG(
                 Variant(),
@@ -2091,7 +2091,7 @@ Variant GDScriptFunctionState::resume(const Variant& p_arg) {
             return Variant();
 #endif
         }
-        if (state.instance && !instances_list.in_list()) {
+        if (state.instance && !instances_list.is_in_list()) {
 #ifdef DEBUG_ENABLED
             ERR_FAIL_V_MSG(
                 Variant(),

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -827,10 +827,10 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
     {
         MutexLock lock(script_instances_mutex);
 
-        for (SelfList<CSharpScript>* elem = script_list.first(); elem;
-             elem                         = elem->next()) {
+        for (SelfList<CSharpScript>* elem = script_list.get_first(); elem;
+             elem                         = elem->get_next()) {
             // Cast to CSharpScript to avoid being erased by accident
-            scripts.push_back(Ref<CSharpScript>(elem->self()));
+            scripts.push_back(Ref<CSharpScript>(elem->get_self()));
         }
     }
 

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -164,8 +164,8 @@ void CanvasItemMaterial::_update_shader() {
 void CanvasItemMaterial::flush_changes() {
     material_mutex.lock();
 
-    while (dirty_materials->first()) {
-        dirty_materials->first()->self()->_update_shader();
+    while (dirty_materials->get_first()) {
+        dirty_materials->get_first()->get_self()->_update_shader();
     }
 
     material_mutex.unlock();
@@ -174,7 +174,7 @@ void CanvasItemMaterial::flush_changes() {
 void CanvasItemMaterial::_queue_shader_change() {
     material_mutex.lock();
 
-    if (is_initialized && !element.in_list()) {
+    if (is_initialized && !element.is_in_list()) {
         dirty_materials->add(&element);
     }
 
@@ -186,7 +186,7 @@ bool CanvasItemMaterial::_is_shader_dirty() const {
 
     material_mutex.lock();
 
-    dirty = element.in_list();
+    dirty = element.is_in_list();
 
     material_mutex.unlock();
 
@@ -685,7 +685,7 @@ void CanvasItem::_notification(int p_what) {
                 }
             }
             _enter_canvas();
-            if (!block_transform_notify && !xform_change.in_list()) {
+            if (!block_transform_notify && !xform_change.is_in_list()) {
                 get_tree()->xform_change_list.add(&xform_change);
             }
         } break;
@@ -711,7 +711,7 @@ void CanvasItem::_notification(int p_what) {
 
         } break;
         case NOTIFICATION_EXIT_TREE: {
-            if (xform_change.in_list()) {
+            if (xform_change.is_in_list()) {
                 get_tree()->xform_change_list.remove(&xform_change);
             }
             _exit_canvas();
@@ -1372,7 +1372,7 @@ void CanvasItem::_notify_transform(CanvasItem* p_node) {
 
     p_node->global_invalid = true;
 
-    if (p_node->notify_transform && !p_node->xform_change.in_list()) {
+    if (p_node->notify_transform && !p_node->xform_change.is_in_list()) {
         if (!p_node->block_transform_notify) {
             if (p_node->is_inside_tree()) {
                 get_tree()->xform_change_list.add(&p_node->xform_change);
@@ -1525,7 +1525,7 @@ Vector2 CanvasItem::get_local_mouse_position() const {
 
 void CanvasItem::force_update_transform() {
     ERR_FAIL_COND(!is_inside_tree());
-    if (!xform_change.in_list()) {
+    if (!xform_change.is_in_list()) {
         return;
     }
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -402,8 +402,8 @@ void TileMap::update_dirty_quadrants() {
         debug_navigation_color = st->get_debug_navigation_color();
     }
 
-    while (dirty_quadrant_list.first()) {
-        Quadrant& q = *dirty_quadrant_list.first()->self();
+    while (dirty_quadrant_list.get_first()) {
+        Quadrant& q = *dirty_quadrant_list.get_first()->get_self();
 
         for (List<RID>::Element* E = q.canvas_items.front(); E; E = E->next()) {
             if (E->get().is_valid()) {
@@ -862,7 +862,7 @@ void TileMap::update_dirty_quadrants() {
             }
         }
 
-        dirty_quadrant_list.remove(dirty_quadrant_list.first());
+        dirty_quadrant_list.remove(dirty_quadrant_list.get_first());
         quadrant_order_dirty = true;
     }
 
@@ -1020,7 +1020,7 @@ void TileMap::_erase_quadrant(Map<PosKey, Quadrant>::Element* Q) {
         }
     }
     q.canvas_items.clear();
-    if (q.dirty_list.in_list()) {
+    if (q.dirty_list.is_in_list()) {
         dirty_quadrant_list.remove(&q.dirty_list);
     }
 
@@ -1052,7 +1052,7 @@ void TileMap::_make_quadrant_dirty(
     bool update
 ) {
     Quadrant& q = Q->get();
-    if (!q.dirty_list.in_list()) {
+    if (!q.dirty_list.is_in_list()) {
         dirty_quadrant_list.add(&q.dirty_list);
     }
 

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -52,10 +52,10 @@ future: no idea
 void Spatial::_notify_dirty() {
 #ifdef TOOLS_ENABLED
     if ((data.gizmo.is_valid() || data.notify_transform)
-        && !data.ignore_notification && !xform_change.in_list()) {
+        && !data.ignore_notification && !xform_change.is_in_list()) {
 #else
     if (data.notify_transform && !data.ignore_notification
-        && !xform_change.in_list()) {
+        && !xform_change.is_in_list()) {
 
 #endif
         get_tree()->xform_change_list.add(&xform_change);
@@ -88,10 +88,10 @@ void Spatial::_propagate_transform_changed(Spatial* p_origin) {
     }
 #ifdef TOOLS_ENABLED
     if ((data.gizmo.is_valid() || data.notify_transform)
-        && !data.ignore_notification && !xform_change.in_list()) {
+        && !data.ignore_notification && !xform_change.is_in_list()) {
 #else
     if (data.notify_transform && !data.ignore_notification
-        && !xform_change.in_list()) {
+        && !xform_change.is_in_list()) {
 #endif
         get_tree()->xform_change_list.add(&xform_change);
     }
@@ -154,7 +154,7 @@ void Spatial::_notification(int p_what) {
         } break;
         case NOTIFICATION_EXIT_TREE: {
             notification(NOTIFICATION_EXIT_WORLD, true);
-            if (xform_change.in_list()) {
+            if (xform_change.is_in_list()) {
                 get_tree()->xform_change_list.remove(&xform_change);
             }
             if (data.C) {
@@ -732,7 +732,7 @@ bool Spatial::is_local_transform_notification_enabled() const {
 
 void Spatial::force_update_transform() {
     ERR_FAIL_COND(!is_inside_tree());
-    if (!xform_change.in_list()) {
+    if (!xform_change.is_in_list()) {
         return; // nothing to update
     }
     get_tree()->xform_change_list.remove(&xform_change);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -149,10 +149,10 @@ void SceneTree::make_group_changed(const StringName& p_group) {
 }
 
 void SceneTree::flush_transform_notifications() {
-    SelfList<Node>* n = xform_change_list.first();
+    SelfList<Node>* n = xform_change_list.get_first();
     while (n) {
-        Node* node         = n->self();
-        SelfList<Node>* nx = n->next();
+        Node* node         = n->get_self();
+        SelfList<Node>* nx = n->get_next();
         xform_change_list.remove(n);
         n = nx;
         node->notification(NOTIFICATION_TRANSFORM_CHANGED);

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -1426,35 +1426,37 @@ void DynamicFont::update_oversampling() {
 
     dynamic_font_mutex.lock();
 
-    SelfList<DynamicFont>* E = dynamic_fonts->first();
+    SelfList<DynamicFont>* E = dynamic_fonts->get_first();
     while (E) {
-        if (E->self()->data_at_size.is_valid()) {
-            E->self()->data_at_size->update_oversampling();
+        if (E->get_self()->data_at_size.is_valid()) {
+            E->get_self()->data_at_size->update_oversampling();
 
-            if (E->self()->outline_data_at_size.is_valid()) {
-                E->self()->outline_data_at_size->update_oversampling();
+            if (E->get_self()->outline_data_at_size.is_valid()) {
+                E->get_self()->outline_data_at_size->update_oversampling();
             }
 
-            for (int i = 0; i < E->self()->fallback_data_at_size.size(); i++) {
-                if (E->self()->fallback_data_at_size[i].is_valid()) {
-                    E->self()
+            for (int i = 0; i < E->get_self()->fallback_data_at_size.size();
+                 i++) {
+                if (E->get_self()->fallback_data_at_size[i].is_valid()) {
+                    E->get_self()
                         ->fallback_data_at_size.write[i]
                         ->update_oversampling();
 
-                    if (E->self()->has_outline()
-                        && E->self()->fallback_outline_data_at_size[i].is_valid(
-                        )) {
-                        E->self()
+                    if (E->get_self()->has_outline()
+                        && E->get_self()
+                               ->fallback_outline_data_at_size[i]
+                               .is_valid()) {
+                        E->get_self()
                             ->fallback_outline_data_at_size.write[i]
                             ->update_oversampling();
                     }
                 }
             }
 
-            changed.push_back(Ref<DynamicFont>(E->self()));
+            changed.push_back(Ref<DynamicFont>(E->get_self()));
         }
 
-        E = E->next();
+        E = E->get_next();
     }
 
     dynamic_font_mutex.unlock();

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1328,8 +1328,8 @@ void SpatialMaterial::_update_shader() {
 void SpatialMaterial::flush_changes() {
     material_mutex.lock();
 
-    while (dirty_materials->first()) {
-        dirty_materials->first()->self()->_update_shader();
+    while (dirty_materials->get_first()) {
+        dirty_materials->get_first()->get_self()->_update_shader();
     }
 
     material_mutex.unlock();
@@ -1338,7 +1338,7 @@ void SpatialMaterial::flush_changes() {
 void SpatialMaterial::_queue_shader_change() {
     material_mutex.lock();
 
-    if (is_initialized && !element.in_list()) {
+    if (is_initialized && !element.is_in_list()) {
         dirty_materials->add(&element);
     }
 
@@ -1350,7 +1350,7 @@ bool SpatialMaterial::_is_shader_dirty() const {
 
     material_mutex.lock();
 
-    dirty = element.in_list();
+    dirty = element.is_in_list();
 
     material_mutex.unlock();
 

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -867,8 +867,8 @@ void ParticlesMaterial::_update_shader() {
 void ParticlesMaterial::flush_changes() {
     material_mutex.lock();
 
-    while (dirty_materials->first()) {
-        dirty_materials->first()->self()->_update_shader();
+    while (dirty_materials->get_first()) {
+        dirty_materials->get_first()->get_self()->_update_shader();
     }
 
     material_mutex.unlock();
@@ -877,7 +877,7 @@ void ParticlesMaterial::flush_changes() {
 void ParticlesMaterial::_queue_shader_change() {
     material_mutex.lock();
 
-    if (is_initialized && !element.in_list()) {
+    if (is_initialized && !element.is_in_list()) {
         dirty_materials->add(&element);
     }
 
@@ -889,7 +889,7 @@ bool ParticlesMaterial::_is_shader_dirty() const {
 
     material_mutex.lock();
 
-    dirty = element.in_list();
+    dirty = element.is_in_list();
 
     material_mutex.unlock();
 

--- a/servers/physics/area_sw.cpp
+++ b/servers/physics/area_sw.cpp
@@ -32,13 +32,13 @@ AreaSW::BodyKey::BodyKey(
 }
 
 void AreaSW::_shapes_changed() {
-    if (!moved_list.in_list() && get_space()) {
+    if (!moved_list.is_in_list() && get_space()) {
         get_space()->area_add_to_moved_list(&moved_list);
     }
 }
 
 void AreaSW::set_transform(const Transform& p_transform) {
-    if (!moved_list.in_list() && get_space()) {
+    if (!moved_list.is_in_list() && get_space()) {
         get_space()->area_add_to_moved_list(&moved_list);
     }
 
@@ -48,11 +48,11 @@ void AreaSW::set_transform(const Transform& p_transform) {
 
 void AreaSW::set_space(SpaceSW* p_space) {
     if (get_space()) {
-        if (monitor_query_list.in_list()) {
+        if (monitor_query_list.is_in_list()) {
             get_space()->area_remove_from_monitor_query_list(&monitor_query_list
             );
         }
-        if (moved_list.in_list()) {
+        if (moved_list.is_in_list()) {
             get_space()->area_remove_from_moved_list(&moved_list);
         }
     }
@@ -79,7 +79,7 @@ void AreaSW::set_monitor_callback(ObjectID p_id, const StringName& p_method) {
 
     _shape_changed();
 
-    if (!moved_list.in_list() && get_space()) {
+    if (!moved_list.is_in_list() && get_space()) {
         get_space()->area_add_to_moved_list(&moved_list);
     }
 }
@@ -103,7 +103,7 @@ void AreaSW::set_area_monitor_callback(
 
     _shape_changed();
 
-    if (!moved_list.in_list() && get_space()) {
+    if (!moved_list.is_in_list() && get_space()) {
         get_space()->area_add_to_moved_list(&moved_list);
     }
 }
@@ -179,7 +179,7 @@ Variant AreaSW::get_param(PhysicsServer::AreaParameter p_param) const {
 void AreaSW::_queue_monitor_update() {
     ERR_FAIL_COND(!get_space());
 
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         get_space()->area_add_to_monitor_query_list(&monitor_query_list);
     }
 }

--- a/servers/physics/area_sw.h
+++ b/servers/physics/area_sw.h
@@ -242,7 +242,7 @@ void AreaSW::add_body_to_query(
 ) {
     BodyKey bk(p_body, p_body_shape, p_area_shape);
     monitored_bodies[bk].inc();
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         _queue_monitor_update();
     }
 }
@@ -254,7 +254,7 @@ void AreaSW::remove_body_from_query(
 ) {
     BodyKey bk(p_body, p_body_shape, p_area_shape);
     monitored_bodies[bk].dec();
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         _queue_monitor_update();
     }
 }
@@ -266,7 +266,7 @@ void AreaSW::add_area_to_query(
 ) {
     BodyKey bk(p_area, p_area_shape, p_self_shape);
     monitored_areas[bk].inc();
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         _queue_monitor_update();
     }
 }
@@ -278,7 +278,7 @@ void AreaSW::remove_area_from_query(
 ) {
     BodyKey bk(p_area, p_area_shape, p_self_shape);
     monitored_areas[bk].dec();
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         _queue_monitor_update();
     }
 }

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -10,7 +10,7 @@
 #include "space_sw.h"
 
 void BodySW::_update_inertia() {
-    if (get_space() && !inertia_update_list.in_list()) {
+    if (get_space() && !inertia_update_list.is_in_list()) {
         get_space()->body_add_to_inertia_update_list(&inertia_update_list);
     }
 }
@@ -384,15 +384,15 @@ Variant BodySW::get_state(PhysicsServer::BodyState p_state) const {
 
 void BodySW::set_space(SpaceSW* p_space) {
     if (get_space()) {
-        if (inertia_update_list.in_list()) {
+        if (inertia_update_list.is_in_list()) {
             get_space()->body_remove_from_inertia_update_list(
                 &inertia_update_list
             );
         }
-        if (active_list.in_list()) {
+        if (active_list.is_in_list()) {
             get_space()->body_remove_from_active_list(&active_list);
         }
-        if (direct_state_query_list.in_list()) {
+        if (direct_state_query_list.is_in_list()) {
             get_space()->body_remove_from_state_query_list(
                 &direct_state_query_list
             );

--- a/servers/physics/collision_object_sw.cpp
+++ b/servers/physics/collision_object_sw.cpp
@@ -23,7 +23,7 @@ void CollisionObjectSW::add_shape(
     shapes.push_back(s);
     p_shape->add_owner(this);
 
-    if (!pending_shape_update_list.in_list()) {
+    if (!pending_shape_update_list.is_in_list()) {
         PhysicsServerSW::singleton->pending_shape_update_list.add(
             &pending_shape_update_list
         );
@@ -36,7 +36,7 @@ void CollisionObjectSW::set_shape(int p_index, ShapeSW* p_shape) {
     shapes.write[p_index].shape = p_shape;
 
     p_shape->add_owner(this);
-    if (!pending_shape_update_list.in_list()) {
+    if (!pending_shape_update_list.is_in_list()) {
         PhysicsServerSW::singleton->pending_shape_update_list.add(
             &pending_shape_update_list
         );
@@ -51,7 +51,7 @@ void CollisionObjectSW::set_shape_transform(
 
     shapes.write[p_index].xform     = p_transform;
     shapes.write[p_index].xform_inv = p_transform.affine_inverse();
-    if (!pending_shape_update_list.in_list()) {
+    if (!pending_shape_update_list.is_in_list()) {
         PhysicsServerSW::singleton->pending_shape_update_list.add(
             &pending_shape_update_list
         );
@@ -75,13 +75,13 @@ void CollisionObjectSW::set_shape_disabled(int p_idx, bool p_disabled) {
     if (p_disabled && shape.bpid != 0) {
         space->get_broadphase()->remove(shape.bpid);
         shape.bpid = 0;
-        if (!pending_shape_update_list.in_list()) {
+        if (!pending_shape_update_list.is_in_list()) {
             PhysicsServerSW::singleton->pending_shape_update_list.add(
                 &pending_shape_update_list
             );
         }
     } else if (!p_disabled && shape.bpid == 0) {
-        if (!pending_shape_update_list.in_list()) {
+        if (!pending_shape_update_list.is_in_list()) {
             PhysicsServerSW::singleton->pending_shape_update_list.add(
                 &pending_shape_update_list
             );
@@ -114,7 +114,7 @@ void CollisionObjectSW::remove_shape(int p_index) {
     shapes[p_index].shape->remove_owner(this);
     shapes.remove(p_index);
 
-    if (!pending_shape_update_list.in_list()) {
+    if (!pending_shape_update_list.is_in_list()) {
         PhysicsServerSW::singleton->pending_shape_update_list.add(
             &pending_shape_update_list
         );

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -1687,9 +1687,9 @@ int PhysicsServerSW::get_process_info(ProcessInfo p_info) {
 }
 
 void PhysicsServerSW::_update_shapes() {
-    while (pending_shape_update_list.first()) {
-        pending_shape_update_list.first()->self()->_shape_changed();
-        pending_shape_update_list.remove(pending_shape_update_list.first());
+    while (pending_shape_update_list.get_first()) {
+        pending_shape_update_list.get_first()->get_self()->_shape_changed();
+        pending_shape_update_list.remove(pending_shape_update_list.get_first());
     }
 }
 

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -1590,24 +1590,24 @@ const SelfList<AreaSW>::List& SpaceSW::get_moved_area_list() const {
 }
 
 void SpaceSW::call_queries() {
-    while (state_query_list.first()) {
-        BodySW* b = state_query_list.first()->self();
-        state_query_list.remove(state_query_list.first());
+    while (state_query_list.get_first()) {
+        BodySW* b = state_query_list.get_first()->get_self();
+        state_query_list.remove(state_query_list.get_first());
         b->call_queries();
     }
 
-    while (monitor_query_list.first()) {
-        AreaSW* a = monitor_query_list.first()->self();
-        monitor_query_list.remove(monitor_query_list.first());
+    while (monitor_query_list.get_first()) {
+        AreaSW* a = monitor_query_list.get_first()->get_self();
+        monitor_query_list.remove(monitor_query_list.get_first());
         a->call_queries();
     }
 }
 
 void SpaceSW::setup() {
     contact_debug_count = 0;
-    while (inertia_update_list.first()) {
-        inertia_update_list.first()->self()->update_inertias();
-        inertia_update_list.remove(inertia_update_list.first());
+    while (inertia_update_list.get_first()) {
+        inertia_update_list.get_first()->get_self()->update_inertias();
+        inertia_update_list.remove(inertia_update_list.get_first());
     }
 }
 

--- a/servers/physics/step_sw.cpp
+++ b/servers/physics/step_sw.cpp
@@ -148,10 +148,10 @@ void StepSW::step(SpaceSW* p_space, real_t p_delta, int p_iterations) {
 
     int active_count = 0;
 
-    const SelfList<BodySW>* b = body_list->first();
+    const SelfList<BodySW>* b = body_list->get_first();
     while (b) {
-        b->self()->integrate_forces(p_delta);
-        b = b->next();
+        b->get_self()->integrate_forces(p_delta);
+        b = b->get_next();
         active_count++;
     }
 
@@ -173,12 +173,12 @@ void StepSW::step(SpaceSW* p_space, real_t p_delta, int p_iterations) {
 
     BodySW* island_list                  = nullptr;
     ConstraintSW* constraint_island_list = nullptr;
-    b                                    = body_list->first();
+    b                                    = body_list->get_first();
 
     int island_count = 0;
 
     while (b) {
-        BodySW* body = b->self();
+        BodySW* body = b->get_self();
 
         if (body->get_island_step() != _step) {
             BodySW* island                  = nullptr;
@@ -194,16 +194,16 @@ void StepSW::step(SpaceSW* p_space, real_t p_delta, int p_iterations) {
                 island_count++;
             }
         }
-        b = b->next();
+        b = b->get_next();
     }
 
     p_space->set_island_count(island_count);
 
     const SelfList<AreaSW>::List& aml = p_space->get_moved_area_list();
 
-    while (aml.first()) {
+    while (aml.get_first()) {
         for (const Set<ConstraintSW*>::Element* E =
-                 aml.first()->self()->get_constraints().front();
+                 aml.get_first()->get_self()->get_constraints().front();
              E;
              E = E->next()) {
             ConstraintSW* c = E->get();
@@ -215,7 +215,7 @@ void StepSW::step(SpaceSW* p_space, real_t p_delta, int p_iterations) {
             c->set_island_list_next(constraint_island_list);
             constraint_island_list = c;
         }
-        p_space->area_remove_from_moved_list((SelfList<AreaSW>*)aml.first()
+        p_space->area_remove_from_moved_list((SelfList<AreaSW>*)aml.get_first()
         ); // faster to remove here
     }
 
@@ -269,10 +269,10 @@ void StepSW::step(SpaceSW* p_space, real_t p_delta, int p_iterations) {
 
     /* INTEGRATE VELOCITIES */
 
-    b = body_list->first();
+    b = body_list->get_first();
     while (b) {
-        const SelfList<BodySW>* n = b->next();
-        b->self()->integrate_velocities(p_delta);
+        const SelfList<BodySW>* n = b->get_next();
+        b->get_self()->integrate_velocities(p_delta);
         b = n;
     }
 

--- a/servers/physics_2d/area_2d_sw.cpp
+++ b/servers/physics_2d/area_2d_sw.cpp
@@ -32,13 +32,13 @@ Area2DSW::BodyKey::BodyKey(
 }
 
 void Area2DSW::_shapes_changed() {
-    if (!moved_list.in_list() && get_space()) {
+    if (!moved_list.is_in_list() && get_space()) {
         get_space()->area_add_to_moved_list(&moved_list);
     }
 }
 
 void Area2DSW::set_transform(const Transform2D& p_transform) {
-    if (!moved_list.in_list() && get_space()) {
+    if (!moved_list.is_in_list() && get_space()) {
         get_space()->area_add_to_moved_list(&moved_list);
     }
 
@@ -48,11 +48,11 @@ void Area2DSW::set_transform(const Transform2D& p_transform) {
 
 void Area2DSW::set_space(Space2DSW* p_space) {
     if (get_space()) {
-        if (monitor_query_list.in_list()) {
+        if (monitor_query_list.is_in_list()) {
             get_space()->area_remove_from_monitor_query_list(&monitor_query_list
             );
         }
-        if (moved_list.in_list()) {
+        if (moved_list.is_in_list()) {
             get_space()->area_remove_from_moved_list(&moved_list);
         }
     }
@@ -79,7 +79,7 @@ void Area2DSW::set_monitor_callback(ObjectID p_id, const StringName& p_method) {
 
     _shape_changed();
 
-    if (!moved_list.in_list() && get_space()) {
+    if (!moved_list.is_in_list() && get_space()) {
         get_space()->area_add_to_moved_list(&moved_list);
     }
 }
@@ -103,7 +103,7 @@ void Area2DSW::set_area_monitor_callback(
 
     _shape_changed();
 
-    if (!moved_list.in_list() && get_space()) {
+    if (!moved_list.is_in_list() && get_space()) {
         get_space()->area_add_to_moved_list(&moved_list);
     }
 }
@@ -180,7 +180,7 @@ Variant Area2DSW::get_param(Physics2DServer::AreaParameter p_param) const {
 void Area2DSW::_queue_monitor_update() {
     ERR_FAIL_COND(!get_space());
 
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         get_space()->area_add_to_monitor_query_list(&monitor_query_list);
     }
 }

--- a/servers/physics_2d/area_2d_sw.h
+++ b/servers/physics_2d/area_2d_sw.h
@@ -241,7 +241,7 @@ void Area2DSW::add_body_to_query(
 ) {
     BodyKey bk(p_body, p_body_shape, p_area_shape);
     monitored_bodies[bk].inc();
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         _queue_monitor_update();
     }
 }
@@ -253,7 +253,7 @@ void Area2DSW::remove_body_from_query(
 ) {
     BodyKey bk(p_body, p_body_shape, p_area_shape);
     monitored_bodies[bk].dec();
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         _queue_monitor_update();
     }
 }
@@ -265,7 +265,7 @@ void Area2DSW::add_area_to_query(
 ) {
     BodyKey bk(p_area, p_area_shape, p_self_shape);
     monitored_areas[bk].inc();
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         _queue_monitor_update();
     }
 }
@@ -277,7 +277,7 @@ void Area2DSW::remove_area_from_query(
 ) {
     BodyKey bk(p_area, p_area_shape, p_self_shape);
     monitored_areas[bk].dec();
-    if (!monitor_query_list.in_list()) {
+    if (!monitor_query_list.is_in_list()) {
         _queue_monitor_update();
     }
 }

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -11,7 +11,7 @@
 #include "space_2d_sw.h"
 
 void Body2DSW::_update_inertia() {
-    if (!user_inertia && get_space() && !inertia_update_list.in_list()) {
+    if (!user_inertia && get_space() && !inertia_update_list.is_in_list()) {
         get_space()->body_add_to_inertia_update_list(&inertia_update_list);
     }
 }
@@ -347,15 +347,15 @@ void Body2DSW::set_space(Space2DSW* p_space) {
     if (get_space()) {
         wakeup_neighbours();
 
-        if (inertia_update_list.in_list()) {
+        if (inertia_update_list.is_in_list()) {
             get_space()->body_remove_from_inertia_update_list(
                 &inertia_update_list
             );
         }
-        if (active_list.in_list()) {
+        if (active_list.is_in_list()) {
             get_space()->body_remove_from_active_list(&active_list);
         }
-        if (direct_state_query_list.in_list()) {
+        if (direct_state_query_list.is_in_list()) {
             get_space()->body_remove_from_state_query_list(
                 &direct_state_query_list
             );

--- a/servers/physics_2d/collision_object_2d_sw.cpp
+++ b/servers/physics_2d/collision_object_2d_sw.cpp
@@ -25,7 +25,7 @@ void CollisionObject2DSW::add_shape(
     shapes.push_back(s);
     p_shape->add_owner(this);
 
-    if (!pending_shape_update_list.in_list()) {
+    if (!pending_shape_update_list.is_in_list()) {
         Physics2DServerSW::singletonsw->pending_shape_update_list.add(
             &pending_shape_update_list
         );
@@ -39,7 +39,7 @@ void CollisionObject2DSW::set_shape(int p_index, Shape2DSW* p_shape) {
 
     p_shape->add_owner(this);
 
-    if (!pending_shape_update_list.in_list()) {
+    if (!pending_shape_update_list.is_in_list()) {
         Physics2DServerSW::singletonsw->pending_shape_update_list.add(
             &pending_shape_update_list
         );
@@ -63,7 +63,7 @@ void CollisionObject2DSW::set_shape_transform(
     shapes.write[p_index].xform     = p_transform;
     shapes.write[p_index].xform_inv = p_transform.affine_inverse();
 
-    if (!pending_shape_update_list.in_list()) {
+    if (!pending_shape_update_list.is_in_list()) {
         Physics2DServerSW::singletonsw->pending_shape_update_list.add(
             &pending_shape_update_list
         );
@@ -87,13 +87,13 @@ void CollisionObject2DSW::set_shape_disabled(int p_idx, bool p_disabled) {
     if (p_disabled && shape.bpid != 0) {
         space->get_broadphase()->remove(shape.bpid);
         shape.bpid = 0;
-        if (!pending_shape_update_list.in_list()) {
+        if (!pending_shape_update_list.is_in_list()) {
             Physics2DServerSW::singletonsw->pending_shape_update_list.add(
                 &pending_shape_update_list
             );
         }
     } else if (!p_disabled && shape.bpid == 0) {
-        if (!pending_shape_update_list.in_list()) {
+        if (!pending_shape_update_list.is_in_list()) {
             Physics2DServerSW::singletonsw->pending_shape_update_list.add(
                 &pending_shape_update_list
             );
@@ -126,7 +126,7 @@ void CollisionObject2DSW::remove_shape(int p_index) {
     shapes[p_index].shape->remove_owner(this);
     shapes.remove(p_index);
 
-    if (!pending_shape_update_list.in_list()) {
+    if (!pending_shape_update_list.is_in_list()) {
         Physics2DServerSW::singletonsw->pending_shape_update_list.add(
             &pending_shape_update_list
         );

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -1616,9 +1616,9 @@ void Physics2DServerSW::finish() {
 };
 
 void Physics2DServerSW::_update_shapes() {
-    while (pending_shape_update_list.first()) {
-        pending_shape_update_list.first()->self()->_shape_changed();
-        pending_shape_update_list.remove(pending_shape_update_list.first());
+    while (pending_shape_update_list.get_first()) {
+        pending_shape_update_list.get_first()->get_self()->_shape_changed();
+        pending_shape_update_list.remove(pending_shape_update_list.get_first());
     }
 }
 

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -1840,15 +1840,15 @@ const SelfList<Area2DSW>::List& Space2DSW::get_moved_area_list() const {
 }
 
 void Space2DSW::call_queries() {
-    while (state_query_list.first()) {
-        Body2DSW* b = state_query_list.first()->self();
-        state_query_list.remove(state_query_list.first());
+    while (state_query_list.get_first()) {
+        Body2DSW* b = state_query_list.get_first()->get_self();
+        state_query_list.remove(state_query_list.get_first());
         b->call_queries();
     }
 
-    while (monitor_query_list.first()) {
-        Area2DSW* a = monitor_query_list.first()->self();
-        monitor_query_list.remove(monitor_query_list.first());
+    while (monitor_query_list.get_first()) {
+        Area2DSW* a = monitor_query_list.get_first()->get_self();
+        monitor_query_list.remove(monitor_query_list.get_first());
         a->call_queries();
     }
 }
@@ -1856,9 +1856,9 @@ void Space2DSW::call_queries() {
 void Space2DSW::setup() {
     contact_debug_count = 0;
 
-    while (inertia_update_list.first()) {
-        inertia_update_list.first()->self()->update_inertias();
-        inertia_update_list.remove(inertia_update_list.first());
+    while (inertia_update_list.get_first()) {
+        inertia_update_list.get_first()->get_self()->update_inertias();
+        inertia_update_list.remove(inertia_update_list.get_first());
     }
 }
 

--- a/servers/physics_2d/step_2d_sw.cpp
+++ b/servers/physics_2d/step_2d_sw.cpp
@@ -139,10 +139,10 @@ void Step2DSW::step(Space2DSW* p_space, real_t p_delta, int p_iterations) {
 
     int active_count = 0;
 
-    const SelfList<Body2DSW>* b = body_list->first();
+    const SelfList<Body2DSW>* b = body_list->get_first();
     while (b) {
-        b->self()->integrate_forces(p_delta);
-        b = b->next();
+        b->get_self()->integrate_forces(p_delta);
+        b = b->get_next();
         active_count++;
     }
 
@@ -164,12 +164,12 @@ void Step2DSW::step(Space2DSW* p_space, real_t p_delta, int p_iterations) {
 
     Body2DSW* island_list                  = nullptr;
     Constraint2DSW* constraint_island_list = nullptr;
-    b                                      = body_list->first();
+    b                                      = body_list->get_first();
 
     int island_count = 0;
 
     while (b) {
-        Body2DSW* body = b->self();
+        Body2DSW* body = b->get_self();
 
         if (body->get_island_step() != _step) {
             Body2DSW* island                  = nullptr;
@@ -185,16 +185,16 @@ void Step2DSW::step(Space2DSW* p_space, real_t p_delta, int p_iterations) {
                 island_count++;
             }
         }
-        b = b->next();
+        b = b->get_next();
     }
 
     p_space->set_island_count(island_count);
 
     const SelfList<Area2DSW>::List& aml = p_space->get_moved_area_list();
 
-    while (aml.first()) {
+    while (aml.get_first()) {
         for (const Set<Constraint2DSW*>::Element* E =
-                 aml.first()->self()->get_constraints().front();
+                 aml.get_first()->get_self()->get_constraints().front();
              E;
              E = E->next()) {
             Constraint2DSW* c = E->get();
@@ -206,8 +206,8 @@ void Step2DSW::step(Space2DSW* p_space, real_t p_delta, int p_iterations) {
             c->set_island_list_next(constraint_island_list);
             constraint_island_list = c;
         }
-        p_space->area_remove_from_moved_list((SelfList<Area2DSW>*)aml.first()
-        ); // faster to remove here
+        p_space->area_remove_from_moved_list((SelfList<Area2DSW>*)aml.get_first(
+        )); // faster to remove here
     }
 
     { // profile
@@ -290,10 +290,10 @@ void Step2DSW::step(Space2DSW* p_space, real_t p_delta, int p_iterations) {
 
     /* INTEGRATE VELOCITIES */
 
-    b = body_list->first();
+    b = body_list->get_first();
     while (b) {
-        const SelfList<Body2DSW>* n = b->next();
-        b->self()->integrate_velocities(p_delta);
+        const SelfList<Body2DSW>* n = b->get_next();
+        b->get_self()->integrate_velocities(p_delta);
         b = n; // in case it shuts itself down
     }
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -665,7 +665,7 @@ void VisualServerScene::_instance_queue_update(
         p_instance->update_materials = true;
     }
 
-    if (p_instance->update_item.in_list()) {
+    if (p_instance->update_item.is_in_list()) {
         return;
     }
 
@@ -734,7 +734,7 @@ void VisualServerScene::instance_set_base(RID p_instance, RID p_base) {
                         instance->base_data
                     );
                 VSG::scene_render->free(reflection_probe->instance);
-                if (reflection_probe->update_list.in_list()) {
+                if (reflection_probe->update_list.is_in_list()) {
                     reflection_probe_render_list.remove(
                         &reflection_probe->update_list
                     );
@@ -760,7 +760,7 @@ void VisualServerScene::instance_set_base(RID p_instance, RID p_base) {
                 InstanceGIProbeData* gi_probe =
                     static_cast<InstanceGIProbeData*>(instance->base_data);
 
-                if (gi_probe->update_element.in_list()) {
+                if (gi_probe->update_element.is_in_list()) {
                     gi_probe_update_list.remove(&gi_probe->update_element);
                 }
                 if (gi_probe->dynamic.probe_data.is_valid()) {
@@ -858,7 +858,7 @@ void VisualServerScene::instance_set_base(RID p_instance, RID p_base) {
                 instance->base_data           = gi_probe;
                 gi_probe->owner               = instance;
 
-                if (scenario && !gi_probe->update_element.in_list()) {
+                if (scenario && !gi_probe->update_element.is_in_list()) {
                     gi_probe_update_list.add(&gi_probe->update_element);
                 }
 
@@ -919,7 +919,7 @@ void VisualServerScene::instance_set_scenario(RID p_instance, RID p_scenario) {
             case VS::INSTANCE_GI_PROBE: {
                 InstanceGIProbeData* gi_probe =
                     static_cast<InstanceGIProbeData*>(instance->base_data);
-                if (gi_probe->update_element.in_list()) {
+                if (gi_probe->update_element.is_in_list()) {
                     gi_probe_update_list.remove(&gi_probe->update_element);
                 }
             } break;
@@ -951,7 +951,7 @@ void VisualServerScene::instance_set_scenario(RID p_instance, RID p_scenario) {
             case VS::INSTANCE_GI_PROBE: {
                 InstanceGIProbeData* gi_probe =
                     static_cast<InstanceGIProbeData*>(instance->base_data);
-                if (!gi_probe->update_element.in_list()) {
+                if (!gi_probe->update_element.is_in_list()) {
                     gi_probe_update_list.add(&gi_probe->update_element);
                 }
             } break;
@@ -1023,7 +1023,7 @@ void VisualServerScene::instance_set_blend_shape_weight(
     Instance* instance = instance_owner.get(p_instance);
     ERR_FAIL_COND(!instance);
 
-    if (instance->update_item.in_list()) {
+    if (instance->update_item.is_in_list()) {
         _update_dirty_instance(instance);
     }
 
@@ -3664,7 +3664,7 @@ void VisualServerScene::_prepare_scene(
                                    ->reflection_probe_instance_needs_redraw(
                                        reflection_probe->instance
                                    )) {
-                            if (!reflection_probe->update_list.in_list()) {
+                            if (!reflection_probe->update_list.is_in_list()) {
                                 reflection_probe->render_step = 0;
                                 reflection_probe_render_list.add_last(
                                     &reflection_probe->update_list
@@ -3690,7 +3690,7 @@ void VisualServerScene::_prepare_scene(
         } else if (ins->base_type == VS::INSTANCE_GI_PROBE && ins->visible) {
             InstanceGIProbeData* gi_probe =
                 static_cast<InstanceGIProbeData*>(ins->base_data);
-            if (!gi_probe->update_element.in_list()) {
+            if (!gi_probe->update_element.is_in_list()) {
                 gi_probe_update_list.add(&gi_probe->update_element);
             }
 
@@ -5331,13 +5331,13 @@ void VisualServerScene::render_probes() {
     /* REFLECTION PROBES */
 
     SelfList<InstanceReflectionProbeData>* ref_probe =
-        reflection_probe_render_list.first();
+        reflection_probe_render_list.get_first();
 
     bool busy = false;
 
     while (ref_probe) {
-        SelfList<InstanceReflectionProbeData>* next = ref_probe->next();
-        RID base = ref_probe->self()->owner->base;
+        SelfList<InstanceReflectionProbeData>* next = ref_probe->get_next();
+        RID base = ref_probe->get_self()->owner->base;
 
         switch (VSG::storage->reflection_probe_get_update_mode(base)) {
             case VS::REFLECTION_PROBE_UPDATE_ONCE: {
@@ -5346,13 +5346,13 @@ void VisualServerScene::render_probes() {
                 }
 
                 bool done = _render_reflection_probe_step(
-                    ref_probe->self()->owner,
-                    ref_probe->self()->render_step
+                    ref_probe->get_self()->owner,
+                    ref_probe->get_self()->render_step
                 );
                 if (done) {
                     reflection_probe_render_list.remove(ref_probe);
                 } else {
-                    ref_probe->self()->render_step++;
+                    ref_probe->get_self()->render_step++;
                 }
 
                 busy = true; // do not render another one of this kind
@@ -5362,7 +5362,7 @@ void VisualServerScene::render_probes() {
                 bool done = false;
                 while (!done) {
                     done = _render_reflection_probe_step(
-                        ref_probe->self()->owner,
+                        ref_probe->get_self()->owner,
                         step
                     );
                     step++;
@@ -5377,12 +5377,12 @@ void VisualServerScene::render_probes() {
 
     /* GI PROBES */
 
-    SelfList<InstanceGIProbeData>* gi_probe = gi_probe_update_list.first();
+    SelfList<InstanceGIProbeData>* gi_probe = gi_probe_update_list.get_first();
 
     while (gi_probe) {
-        SelfList<InstanceGIProbeData>* next = gi_probe->next();
+        SelfList<InstanceGIProbeData>* next = gi_probe->get_next();
 
-        InstanceGIProbeData* probe = gi_probe->self();
+        InstanceGIProbeData* probe = gi_probe->get_self();
         Instance* instance_probe   = probe->owner;
 
         // check if probe must be setup, but don't do if on the lighting thread
@@ -5658,12 +5658,12 @@ void VisualServerScene::update_dirty_instances() {
     // this is just to get access to scenario so we can update the spatial
     // partitioning scheme
     Scenario* scenario = nullptr;
-    if (_instance_update_list.first()) {
-        scenario = _instance_update_list.first()->self()->scenario;
+    if (_instance_update_list.get_first()) {
+        scenario = _instance_update_list.get_first()->get_self()->scenario;
     }
 
-    while (_instance_update_list.first()) {
-        _update_dirty_instance(_instance_update_list.first()->self());
+    while (_instance_update_list.get_first()) {
+        _update_dirty_instance(_instance_update_list.get_first()->get_self());
     }
 
     if (scenario) {
@@ -5681,9 +5681,9 @@ bool VisualServerScene::free(RID p_rid) {
     } else if (scenario_owner.owns(p_rid)) {
         Scenario* scenario = scenario_owner.get(p_rid);
 
-        while (scenario->instances.first()) {
+        while (scenario->instances.get_first()) {
             instance_set_scenario(
-                scenario->instances.first()->self()->self,
+                scenario->instances.get_first()->get_self()->self,
                 RID()
             );
         }


### PR DESCRIPTION
Makes the `SelfList` interface simpler and easier to understand. Includes the separation of the method definitions from the declarations.